### PR TITLE
Cislo obcanskeho prukazu skryto v adminu

### DIFF
--- a/admin/scripts/modules/uvod.php
+++ b/admin/scripts/modules/uvod.php
@@ -187,7 +187,7 @@ if($uPracovni) {
     'datum_narozeni'        =>  'Narozen'.$uPracovni->koncA(),
     'email1_uzivatele'      =>  'E-mail',
     'poznamka'              =>  'Poznámka',
-    'op'                    =>  'Číslo OP',
+    // 'op'                    =>  'Číslo OP',
   ];
   $r = dbOneLine('SELECT '.implode(',', array_keys($udaje)).' FROM uzivatele_hodnoty WHERE id_uzivatele = '.$uPracovni->id());
   foreach($udaje as $sloupec => $nazev) {


### PR DESCRIPTION
Občanský průkaz jsem skryl z adminu. Ověřoval jsem pak, že na tom nespadne editace uživatele (op nesmí být v DB null), což je samozřejmě OK, protože to se nemění.
Ale co nechápu je, že když se člověk registruje, tak se několik NOT NULL hodnot vůbec nepošle, například `op` a stejně se to uloží. Když tu samou query pustím přímo, tak to spadne. Zřejmě je v Gameconu zaplá nějaká MySQL direktiva, kterou neznám.