### PR TITLE
Dlouho neaktivni spojeni k DB neposle HTTP headers kvuli warningu

### DIFF
--- a/model/funkce/fw-database.php
+++ b/model/funkce/fw-database.php
@@ -64,7 +64,7 @@ function dbConnect($selectDb = true) {
 
     // připojení
     $start = microtime(true);
-    $spojeni = mysqli_connect('p:' . $dbhost, $dbuser, $dbpass, $selectDb ? $dbname : ''); // persistent connection
+    $spojeni = @mysqli_connect('p:' . $dbhost, $dbuser, $dbpass, $selectDb ? $dbname : ''); // persistent connection
     if(!$spojeni)
       throw new Exception('Failed to connect to the database, error: "' . mysqli_connect_error() . '".');
     if(!$spojeni->set_charset('utf8'))


### PR DESCRIPTION
Často se mi na lokále stává, že stránka padne na `Warning: Cannot modify header information - headers already sent by...`. Může za to persistentní připojení k databázi, které po chvíli nepoužívání databáze ukončí a nové spojení nejdříve zahlásí timeout a pak se bez problémů připojí.
Řešení je prosté, potlačil jsem warning při připojení k databázi. Případné jiné problémy jsou odchyceny vzápětí a reportovány včetně detailů jako Exception.