### PR TITLE
Uzivatel je na webu vzdy prenacten, aby data v session nezastarala

### DIFF
--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -921,6 +921,7 @@ class Uzivatel {
     {
       $u=new Uzivatel($_SESSION[$klic]);
       $u->klic=$klic;
+      $u->otoc(); // nacti cerstva data do session
       return $u;
     }
     elseif(isset($_COOKIE['gcTrvalePrihlaseni']) && $klic == 'uzivatel')

--- a/web/moduly/registrace.php
+++ b/web/moduly/registrace.php
@@ -10,6 +10,7 @@ if(isset($_GET['testMailu']))
   exit;
 }
 
+/** @var Uzivatel|null $u */
 //zpracování úpravy dat
 if($u && isset($_POST['upravit']))
 {


### PR DESCRIPTION
Uživatelská data ukládáme do session prohlížeče, což je nepříjemné, protože když se data bez vědomí prohlížeče změní (v jiném prohlížeči, přes admin...) tak každý prohlížeč pak ukazuje jiná, ta "svoje" data.

Oprava je v tom, že přenačtu uživatelská data z databáze vždy, když je někdo chce.

Přišel jsem na to při práci na https://trello.com/c/LMovvQif/785-chyba-v-p%C5%99ihla%C5%A1ov%C3%A1n%C3%AD-%C5%BEensk%C3%A1-mu%C5%BEsk%C3%A1-m%C3%ADsta