### PR TITLE
Uzivatel lze v adminu nacist

### DIFF
--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -910,7 +910,7 @@ class Uzivatel {
    * Pokusí se načíst uživatele podle aktivní session případně z perzistentního
    * přihlášení.
    * @param string $klic klíč do $_SESSION kde očekáváme hodnoty uživatele
-   * @return mixed objekt uživatele nebo null
+   * @return Uzivatel|null objekt uživatele nebo null
    * @todo nenačítat znovu jednou načteného, cacheovat
    */
   public static function zSession($klic='uzivatel')
@@ -921,7 +921,6 @@ class Uzivatel {
     {
       $u=new Uzivatel($_SESSION[$klic]);
       $u->klic=$klic;
-      $u->otoc(); // nacti cerstva data do session
       return $u;
     }
     elseif(isset($_COOKIE['gcTrvalePrihlaseni']) && $klic == 'uzivatel')

--- a/web/index.php
+++ b/web/index.php
@@ -7,6 +7,7 @@ require __DIR__ . '/tridy/menu.php';
 if(HTTPS_ONLY) httpsOnly();
 
 $u = Uzivatel::zSession();
+$u->otoc(); // nacti cerstva data do session
 try {
   $url = Url::zAktualni();
 } catch(UrlException $e) {


### PR DESCRIPTION
Opravena chyba z https://github.com/gamecon-cz/gamecon/pull/91, kdy jsem obnovoval uživatelská data v session vždy, což ale rozbilo výběr uživatele v adminu.

Teď se uživtelská data v session obnovují jen na webu.