### PR TITLE
Upozorneni na chybejici potvrzeni u rodicu se uz chybne neukazuje u starsich uzivatelu prihlasenych na Gamecon

### DIFF
--- a/admin/scripts/modules/uvod.php
+++ b/admin/scripts/modules/uvod.php
@@ -144,7 +144,7 @@ if($uPracovni && $uPracovni->gcPrihlasen())
   $potvrzeniOd = $r['potvrzeni_zakonneho_zastupce'] ? new DateTimeImmutable($r['potvrzeni_zakonneho_zastupce']) : null;
   $potrebujePotvrzeni = potrebujePotvrzeni($datumNarozeni);
   $mameLetosniPotvrzeni = $potvrzeniOd && $potvrzeniOd->format('y') === date('y');
-  if (!$mameLetosniPotvrzeni) $x->parse('uvod.uzivatel.chybiPotvrzeni');
+  if ($potrebujePotvrzeni && !$mameLetosniPotvrzeni) $x->parse('uvod.uzivatel.chybiPotvrzeni');
   if(GC_BEZI && (!$up->gcPritomen() || $up->finance()->stav() < 0)) $x->parse('uvod.potvrditZruseniPrace');
   $x->parse('uvod.uzivatel');
   $x->parse('uvod.slevy');


### PR DESCRIPTION
Pokud je uživatel už přihlášený na Gamecon a je dost starý, takže nepotřebuje potvrzení od rodičů, tak se v adminu v Úvodu už nezobrazuje upozornění, že ho potřebuje.
https://trello.com/c/eoIPgAf4/795-admin-chybn%C4%9B-hl%C3%A1s%C3%AD-chyb%C4%9Bj%C3%ADc%C3%AD-potvrzen%C3%AD-u-rodi%C4%8D%C5%AF