### PR TITLE
Prave zobrazena klavesnice neni zase skryta kvuli prekresleni sloupcu v admin Uvodu

### DIFF
--- a/admin/scripts/modules/uvod.xtpl
+++ b/admin/scripts/modules/uvod.xtpl
@@ -291,10 +291,16 @@
 <div style="clear:both"></div>
 <script>
 var $boxy = $('.aBox');
+var previousColCount = 0;
 function sloupce() {
   var $sloupce = $('.sloupce');
   var fullw = $sloupce.width();
   var colw = $('.sloupce > .sloup').width();
+  var currentColCount = Math.floor(fullw / colw);
+  if (currentColCount == previousColCount) {
+    return; // sloupce se preskladaji jen pokud to ma smysl (pokud se jich nove vejde vic nebo min)
+  }
+  previousColCount = currentColCount;
   // vysypat boxy mimo, pokud tam jsou
   $boxy.insertAfter($sloupce);
   // vytvořit adekvátní počet sloupců


### PR DESCRIPTION
Kdykoliv se změnila velikost okna s obsahem v adminu - Úvodu, tak se javascriptem přeskládaly sloupce s obsahem. Na mobilu se to pak stalo pokaždé, když někdo kliknul do vstupního pole, protože se otevřela virtuální klávesnice, to změnilo velikost okna, to přeskládalo obsah a to na mobilu znamená ztrátu focusu, takže se klávesnice zase zavřela.
Teď se sloupce přeskládají pouze pokud to má smysl, tedy pokud se změnila velikost okna natolik, že je tam o místo na celý sloupec víc nebo míň (a ne při každém pixelu).
https://trello.com/c/HbOrowU4/793-editace-v-adminu-na-mobilu