### PR TITLE
Pres textovy soubor v adresari s obrazky lze zadat slozitejsi odkaz na sponzora

### DIFF
--- a/web/moduly/sponzori.php
+++ b/web/moduly/sponzori.php
@@ -3,11 +3,20 @@
 $this->bezDekorace(true);
 
 foreach(['sponzor', 'partner'] as $kategorie) {
-  foreach(glob("soubory/obsah/{$kategorie}i/*") as $f) {
-    $fn = preg_replace('@.*/(.*)\.(jpg|png|gif)@', '$1', $f, -1, $n);
+  $adresarSObrazky = "soubory/obsah/{$kategorie}i";
+  $souborSOdkazy = "{$adresarSObrazky}/odkazy.txt";
+  if (is_readable($souborSOdkazy)) {
+    $odkazy = parse_ini_file($souborSOdkazy);
+  }
+  foreach(glob("{$adresarSObrazky}/*") as $f) {
+    if (!preg_match('@\.(jpeg|jpg|png|gif)$@', $f)) {
+      continue;
+    }
+    $fn = preg_replace('@.*/(.*)\.(jpeg|jpg|png|gif)$@', '$1', $f, -1, $n);
     if($fn[0] == '_' || $n == 0) continue; // skrývání odebraných sponzorů
+    $fileBasename = basename($f); // /foo/bar/baz.jpg = baz.jpg
     $t->assign([
-      'url' => $fn,
+      'url' => $odkazy[$fileBasename] ?? "http://$fn",
       'img' => $f,
     ]);
     $t->parse("sponzori.$kategorie");

--- a/web/sablony/sponzori.xtpl
+++ b/web/sablony/sponzori.xtpl
@@ -3,7 +3,7 @@
 
 <p>
 <!-- begin:sponzor -->
-<a href="http://{url}"><img src="{img}"></a>
+<a href="{url}"><img src="{img}"></a>
 <!-- end:sponzor -->
 </p>
 
@@ -11,7 +11,7 @@
 
 <p>
 <!-- begin:partner -->
-<a href="http://{url}"><img src="{img}"></a>
+<a href="{url}"><img src="{img}"></a>
 <!-- end:partner -->
 </p>
 


### PR DESCRIPTION
Tohle prý nechceme, takže nemergovat. Udělal jsem to jako studii, jak moc by to bylo náročné (nebylo) a jak by to bylo uživatelsky příjemné na používání.
Já jsem si pro test přidal soubor `web/soubory/obsah/sponzori/odkazy.txt` a do něj jsem dal obsah

```
hopestudio.cz.jpg = https://seznam.cz
```
https://trello.com/c/pBZwYdhg/764-p%C5%99idat-loga-sponzor%C5%AF-na-web