### PR TITLE
Fixed anonymization of user data according to GDPR

### DIFF
--- a/migrace/055.php
+++ b/migrace/055.php
@@ -1,0 +1,27 @@
+<?php
+/** @var \Godric\DbMigrations\Migration $this */
+$this->q(<<<SQL
+DROP PROCEDURE IF EXISTS GDPR_PROCISTENI_UDAJU;
+
+CREATE PROCEDURE `GDPR_PROCISTENI_UDAJU`(IN cilove_id_uzivatele INT)
+    MODIFIES SQL DATA
+UPDATE uzivatele_hodnoty
+SET jmeno_uzivatele      = '',
+    prijmeni_uzivatele   = '',
+    datum_narozeni       = DATE_FORMAT(datum_narozeni, '%y-01-01'),
+    telefon_uzivatele    = '',
+    email1_uzivatele     = UUID(),
+    email2_uzivatele     = '',
+    ulice_a_cp_uzivatele = '',
+    ubytovan_s           = '',
+    op                   = '',
+    login_uzivatele      = UUID(),
+    heslo_md5            = '',
+    jine_uzivatele       = '',
+    poznamka             = '',
+    skola                = '',
+    pomoc_typ            = '',
+    pomoc_vice           = ''
+WHERE id_uzivatele = cilove_id_uzivatele
+SQL
+);

--- a/migrace/055.php
+++ b/migrace/055.php
@@ -6,22 +6,21 @@ DROP PROCEDURE IF EXISTS GDPR_PROCISTENI_UDAJU;
 CREATE PROCEDURE `GDPR_PROCISTENI_UDAJU`(IN cilove_id_uzivatele INT)
     MODIFIES SQL DATA
 UPDATE uzivatele_hodnoty
-SET jmeno_uzivatele      = '',
-    prijmeni_uzivatele   = '',
+SET jmeno_uzivatele      = 'ANON',
+    prijmeni_uzivatele   = 'ANON',
     datum_narozeni       = DATE_FORMAT(datum_narozeni, '%y-01-01'),
-    telefon_uzivatele    = '',
+    telefon_uzivatele    = 'ANON',
     email1_uzivatele     = UUID(),
-    email2_uzivatele     = '',
-    ulice_a_cp_uzivatele = '',
-    ubytovan_s           = '',
-    op                   = '',
+    email2_uzivatele     = UUID(),
+    ulice_a_cp_uzivatele = 'ANON',
+    ubytovan_s           = 'ANON',
+    op                   = 'ANON',
     login_uzivatele      = UUID(),
-    heslo_md5            = '',
-    jine_uzivatele       = '',
-    poznamka             = '',
-    skola                = '',
-    pomoc_typ            = '',
-    pomoc_vice           = ''
+    heslo_md5            = 'ANON',
+    jine_uzivatele       = 'ANON',
+    skola                = 'ANON',
+    pomoc_typ            = 'ANON',
+    pomoc_vice           = 'ANON'
 WHERE id_uzivatele = cilove_id_uzivatele
 SQL
 );


### PR DESCRIPTION
https://trello.com/c/PydmpjQ9/710-vymazanie-osobn%C3%BDch-%C3%BAdajov

Oprava následujícího:

- vstupní parametr se jmenoval stejně jako sloupec ve `WHERE`, takže to MySQL nepochopilo (MySQL ignoruje velikost písmen téměř pro vše https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html, takže `id_uzivatele` je pro něj to samé jaké jako `ID_UZIVATELE`, což ve výsledku anonymizovalo všechny uživatele, protože `id_uzivatele` se vždycky rovná samo sobě)
- většina položek nemůže být null, nýbrž pouze prázdný string
  - takže se anonymizovalo jen `ubytovan_s` a `skola`
- `DATE_FORMAT(datum_narozeni, '%y-00-00')` zblbne MySQL natolik (kvůli nulovému měsíci a dnu), že z toho vznikne `2066-01-01`

PS: raději bych viděl tuhle logiku v PHP a měl v adminu červené tlačítko *Anonymizovat*

- v PHP protože se to snáze nachází a opravuje lidem, co nejsou kamarádi s SQL procedurami (nejde o mě, já si jich užil dost)
- s červeným tlačítkem, aby to mohl udělat "kdokoli" s příslušnými právy a nepotřeboval na to ajťáka