### PR TITLE
Removed unused bug report from admin

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -10,16 +10,6 @@ if(HTTPS_ONLY) httpsOnly();
 // nastaví uživatele $u a $uPracovni
 require('scripts/prihlaseni.php');
 
-// odesílání bugreportu
-if(post('bugreport')) {
-  (new GcMail)
-    ->adresat('info@gamecon.cz')
-    ->predmet('Bugreport z adminu: '.post('nazev'))
-    ->text(post('popis')."\n\n(reportoval".$u->koncA()." ".$u->jmenoNick()." - ".$u->mail().")")
-    ->odeslat();
-  oznameni('hlášení chyby odesláno');
-}
-
 // xtemplate inicializace
 $xtpl=new XTemplate('./templates/main.xtpl');
 $xtpl->assign([

--- a/admin/templates/paticka.xtpl
+++ b/admin/templates/paticka.xtpl
@@ -1,26 +1,6 @@
 <!-- begin:paticka -->
 <div class="paticka">
-  <div class="obsah" id="bugreport">
-    <form method="post">
-      <table>
-        <tr>
-          <td>Co nefunguje:</td>
-          <td><input type="text" name="nazev" placeholder="(např. 'špatně se počítá sleva PJům')" style="width:400px"></td>
-        </tr>
-        <tr>
-          <td>Popis chyby:</td>
-          <td><textarea rows="4" name="popis" placeholder="(detailnější popis jak se chyba projevuje a jak by to mělo fungovat správně, např. 'pjům se počítá sleva za blok poloviční než má a nepočítá se jim jídlo zdarma')" style="width:400px"></textarea></td>
-        </tr>
-        <tr>
-          <td colspan="2">
-            <input type="submit" name="bugreport" value="Odeslat">
-          </td>
-        </tr>
-      </table>
-    </form>
-  </div>
   <div class="nabidka">
-    <a href="#" onclick="$('#bugreport').slideToggle(); return false">Nahlásit chybu</a> –
     <a href="program-obecny" target="_blank">Program GameConu</a> –
     <a href="last-minute-tabule" target="_blank">Volná místa</a>
     <!--


### PR DESCRIPTION
Před časem jsme došli k tomu, že funkci na nahlašování bugů v adminu nikdo nepoužívá, protože to každý hlásí svému nadřízenému, až se to nakonec dostane na IT.

Takže hlášení bugů z adminu jakožto mrtvý kód odstraňujeme.

https://trello.com/c/sYqwgsHT/798-z-adminu-lze-z%C5%99ejm%C4%9B-odeslat-nahl%C3%A1%C5%A1en%C3%AD-bugu-bez-n%C3%A1zvu-a-bez-textu