### PR TITLE
846: Oprava štítků, aby každý patřil do nějaké kategorie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "ext-intl": "*",
     "ext-mysqli": "*",
     "ext-mbstring": "*",
-    "ext-intl": "*",
     "michelf/php-markdown": "~1.4",
     "oyejorge/less.php": "~1.7",
     "dg/mysql-dump": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1812a71f4f38dfb4b7145d575ce71568",
+    "content-hash": "ec252dae654082ec900667b7dc5c0bd6",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -472,34 +472,39 @@
         },
         {
             "name": "tracy/tracy",
-            "version": "v2.5.1",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/tracy.git",
-                "reference": "bea9df15a1cdbf3ec50ef3a75f5ada1ab536d679"
+                "reference": "37c238d08db44f2cd6f21f7d97e5cea11d631fae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/tracy/zipball/bea9df15a1cdbf3ec50ef3a75f5ada1ab536d679",
-                "reference": "bea9df15a1cdbf3ec50ef3a75f5ada1ab536d679",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/37c238d08db44f2cd6f21f7d97e5cea11d631fae",
+                "reference": "37c238d08db44f2cd6f21f7d97e5cea11d631fae",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-session": "*",
-                "php": ">=5.4.4"
+                "php": ">=7.2 <8.1"
+            },
+            "conflict": {
+                "nette/di": "<3.0"
             },
             "require-dev": {
-                "nette/di": "~2.3",
-                "nette/tester": "~1.7"
-            },
-            "suggest": {
-                "https://nette.org/donate": "Please support Tracy via a donation"
+                "latte/latte": "^2.5",
+                "nette/di": "^3.0",
+                "nette/mail": "^3.0",
+                "nette/tester": "^2.2",
+                "nette/utils": "^3.0",
+                "phpstan/phpstan": "^0.12",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -507,7 +512,7 @@
                     "src"
                 ],
                 "files": [
-                    "src/shortcuts.php"
+                    "src/Tracy/functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -524,7 +529,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "😎 Tracy: the addictive tool to ease debugging PHP code for cool developers. Friendly design, logging, profiler, advanced features like debugging AJAX calls or CLI support. You will love it.",
+            "description": "😎  Tracy: the addictive tool to ease debugging PHP code for cool developers. Friendly design, logging, profiler, advanced features like debugging AJAX calls or CLI support. You will love it.",
             "homepage": "https://tracy.nette.org",
             "keywords": [
                 "Xdebug",
@@ -533,7 +538,11 @@
                 "nette",
                 "profiler"
             ],
-            "time": "2018-07-03T11:34:33+00:00"
+            "support": {
+                "issues": "https://github.com/nette/tracy/issues",
+                "source": "https://github.com/nette/tracy/tree/v2.8.1"
+            },
+            "time": "2021-01-01T22:21:23+00:00"
         }
     ],
     "packages-dev": [
@@ -606,7 +615,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*"
+        "php": ">=7.1",
+        "ext-json": "*",
+        "ext-intl": "*",
+        "ext-mysqli": "*",
+        "ext-mbstring": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/migrace/062.php
+++ b/migrace/062.php
@@ -1,0 +1,172 @@
+<?php
+// This is a fix of a 058.php where renamed category (styl Desk => styl Deskovky) in tags, but not in categories itself causes invalid pairing
+
+/** @var \Godric\DbMigrations\Migration $this */
+
+// CATEGORIES
+$categories = require __DIR__ . '/pomocne/062/fetchCategories.php';
+
+// SUB-CATEGORIES
+$mainCategories = [];
+$parentCategoryName = null;
+$subCategories = [];
+foreach ($categories as $category) {
+  if ($category[0]) { // "Kategorie"
+    $mainCategories[] = $category;
+    $parentCategoryName = $category[0];
+  } else {
+    if (!$parentCategoryName) {
+      throw new \LogicException(sprintf('Chybi hlavni kategorie pro %s', var_export($category, true)));
+    }
+    $subCategories[$parentCategoryName][] = $category;
+  }
+}
+
+// TAGS
+
+$tags = require __DIR__ . '/pomocne/062/fetchTags.php';
+
+$checkNameUniqueness = require __DIR__ . '/pomocne/062/checkNameUniquenessFunction.php';
+
+$checkNameUniqueness($tags);
+
+// TAGS FOR SQL
+$tagsForSql = array_map(
+  function(array $row): array {
+    if (!$row[1]) {
+      $row[1] = null; // turn empty ID (empty string) into null to activate MySQL auto-increment
+    }
+    return $row;
+  },
+  $tags
+);
+// has to move tags without ID to end to avoid conflict of auto-generated ID with an existing ID, if auto-generated were inserted first
+usort($tagsForSql, function(array $someRow, array $anotherRow) {
+  $someId = $someRow[1];
+  $anotherId = $anotherRow[1];
+  if ($someId && $anotherId) {
+    return $someId <=> $anotherId; // lower first
+  }
+  if ($someId) {
+    return -1; // someId exists and goes first, anotherId is empty and goes last
+  }
+  if ($anotherId) {
+    return 1; // someId is empty and goes last, anotherId exist and goes first
+  }
+  return strcmp($someRow[5], $anotherRow[5]); // both IDs are empty, just sort them alphabetically by name
+});
+
+$intoSqlValues = require __DIR__ . '/pomocne/062/intToSqlValuesFunction.php';
+$fixedTagsSql = $intoSqlValues($tagsForSql, $this->db);
+$tagsAutoIncrementStart = 0;
+foreach ($tags as $tag) {
+  $tagsAutoIncrementStart = max($tagsAutoIncrementStart, (int)$tag[1] /* id */);
+}
+$tagsAutoIncrementStart++; // start after previous last ID to avoid (almost impossible) accidental usage of new record instead of old one
+// CATEGORIES FOR SQL
+$mainCategoriesForSql = array_map(
+  static function(array $mainCategory): array {
+    $mainCategory[1] = null; // no parent category
+    return $mainCategory;
+  },
+  $mainCategories
+);
+$mainCategoriesSql = $intoSqlValues($mainCategoriesForSql, $this->db);
+$subCategoriesForSql = [];
+foreach ($subCategories as $parentCategoryName => $subCategoriesWithSameParent) {
+  $subCategoriesWithSameParentForSql = array_map(
+    function(array $subCategory) use ($parentCategoryName): array {
+      $subCategory[0] = $subCategory[1]; // sub-category name moved to first position
+      $subCategory[1] = sprintf(<<<'SQL'
+(SELECT id FROM kategorie_sjednocenych_tagu_62 AS parent_category WHERE nazev = '%s')
+SQL
+        ,
+        mysqli_real_escape_string($this->db, $parentCategoryName)
+      ); // parent category ID
+      return $subCategory;
+    },
+    $subCategoriesWithSameParent
+  );
+  foreach ($subCategoriesWithSameParentForSql as $subCategoryWithSameParentForSql) {
+    $subCategoriesForSql[] = $subCategoryWithSameParentForSql;
+  }
+}
+$subCategoriesSql = $intoSqlValues($subCategoriesForSql, $this->db);
+$queries = [];
+//TODO REMOVE THIS development CLEANUP
+$queries[] = <<<SQL
+DROP TABLE IF EXISTS sjednocene_tagy_62;
+DROP TABLE IF EXISTS kategorie_sjednocenych_tagu_62;
+SQL;
+
+$queries[] = <<<SQL
+CREATE TEMPORARY TABLE sjednocene_tagy_temp LIKE tagy;
+ALTER TABLE sjednocene_tagy_temp ADD COLUMN nazev_kategorie VARCHAR(128), ADD COLUMN opraveny_nazev VARCHAR(128), ADD COLUMN poznamka TEXT;
+INSERT INTO sjednocene_tagy_temp(id, nazev, nazev_kategorie, opraveny_nazev, poznamka) VALUES {$fixedTagsSql};
+ALTER TABLE sjednocene_tagy_temp ADD INDEX (nazev_kategorie), ADD INDEX (opraveny_nazev);
+SQL;
+$queries[] = <<<SQL
+CREATE TABLE IF NOT EXISTS kategorie_sjednocenych_tagu_62(
+    id INT UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+    nazev VARCHAR(128) PRIMARY KEY,
+    id_hlavni_kategorie INT UNSIGNED,
+    poradi INT UNSIGNED NOT NULL,
+    FOREIGN KEY (id_hlavni_kategorie) REFERENCES kategorie_sjednocenych_tagu_62(id) /* itself (parent row) */ ON UPDATE CASCADE ON DELETE RESTRICT
+) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+INSERT INTO kategorie_sjednocenych_tagu_62(nazev, id_hlavni_kategorie, poradi)
+VALUES {$mainCategoriesSql};
+INSERT INTO kategorie_sjednocenych_tagu_62(nazev, id_hlavni_kategorie, poradi)
+VALUES {$subCategoriesSql};
+SQL;
+
+$queries[] = <<<SQL
+CREATE TABLE IF NOT EXISTS sjednocene_tagy_62 (
+    id INT UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+    id_kategorie_tagu INT UNSIGNED NOT NULL,
+    nazev VARCHAR(128) PRIMARY KEY,
+    poznamka TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY FK_kategorie_tagu(id_kategorie_tagu) REFERENCES kategorie_sjednocenych_tagu_62(id) ON UPDATE CASCADE ON DELETE RESTRICT
+) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+ALTER TABLE sjednocene_tagy_62 AUTO_INCREMENT={$tagsAutoIncrementStart};
+INSERT /* intentionally not IGNORE to detect invalid input data, see bellow */ INTO sjednocene_tagy_62(id, id_kategorie_tagu, nazev, poznamka)
+SELECT sjednocene_tagy_temp.id, kategorie_sjednocenych_tagu_62.id, sjednocene_tagy_temp.opraveny_nazev, GROUP_CONCAT(DISTINCT sjednocene_tagy_temp.poznamka SEPARATOR '; ')
+FROM sjednocene_tagy_temp
+JOIN kategorie_sjednocenych_tagu_62 ON kategorie_sjednocenych_tagu_62.nazev = sjednocene_tagy_temp.nazev_kategorie
+WHERE sjednocene_tagy_temp.opraveny_nazev != '-' -- strange records marked for deletion
+GROUP BY sjednocene_tagy_temp.opraveny_nazev, kategorie_sjednocenych_tagu_62.id; -- intentionally grouped also by kategorie_sjednocenych_tagu.id to get fatal in case of duplicated opraveny_nazev but different kategorie_sjednocenych_tagu.id => logic error in source data
+SQL;
+$queries[] = <<<SQL
+CREATE TABLE IF NOT EXISTS akce_sjednocene_tagy_62 LIKE akce_tagy;
+INSERT IGNORE INTO akce_sjednocene_tagy_62(id_akce, id_tagu)
+SELECT akce_tagy.id_akce, sjednocene_tagy_62.id
+FROM akce_tagy
+INNER JOIN sjednocene_tagy_temp ON sjednocene_tagy_temp.id = akce_tagy.id_tagu
+INNER JOIN sjednocene_tagy_62 ON sjednocene_tagy_62.nazev = sjednocene_tagy_temp.opraveny_nazev;
+SQL;
+
+$queries[] = <<<SQL
+RENAME TABLE sjednocene_tagy TO sjednocene_tagy_bug_058_zaloha;
+RENAME TABLE kategorie_sjednocenych_tagu TO kategorie_sjednocenych_tagu_bug_058_zaloha;
+RENAME TABLE akce_sjednocene_tagy TO akce_sjednocene_tagy_bug_058_zaloha;
+SQL;
+
+$queries[] = <<<SQL
+RENAME TABLE sjednocene_tagy_62 TO sjednocene_tagy;
+RENAME TABLE kategorie_sjednocenych_tagu_62 TO kategorie_sjednocenych_tagu;
+RENAME TABLE akce_sjednocene_tagy_62 TO akce_sjednocene_tagy;
+SQL;
+
+$queries[] = <<<SQL
+DROP TEMPORARY TABLE sjednocene_tagy_temp;
+SQL;
+try {
+  foreach ($queries as $query) {
+    $this->q($query);
+  }
+} catch (\Exception $exception) {
+  throw new RuntimeException(
+    sprintf("Migration %s failed: '%s'. Check it: \n%s", basename(__FILE__, '.php'), $exception->getMessage(), $query),
+    $exception->getCode(),
+    $exception
+  );
+}

--- a/migrace/pomocne/062/062_opravene_kategorie_sjednocenych_tagu.csv
+++ b/migrace/pomocne/062/062_opravene_kategorie_sjednocenych_tagu.csv
@@ -1,0 +1,51 @@
+Kategorie,Subkategorie,Řadící kód
+Primary,,1
+typ,,10
+,typ RPG,11
+,typ LKD,12
+,typ mDrD,13
+,typ Larp,14
+,typ Akční,15
+,typ Deskovky,16
+,typ WG,17
+,typ Přednášky,18
+žánr,,20
+,žánr RPG,21
+,žánr LKD,22
+,žánr mDrD,23
+,žánr Larp,24
+,žánr Akční,25
+,žánr Deskovky,26
+,žánr WG,27
+,žánr Přednášky,28
+prostředí,,30
+,prostředí RPG,31
+,prostředí LKD,32
+,prostředí mDrD,33
+,prostředí Larp,34
+,prostředí Akční,35
+,prostředí Deskovky,36
+,prostředí WG,37
+,prostředí Přednášky,38
+styl,,40
+,styl RPG,41
+,styl LKD,42
+,styl mDrD,43
+,styl Larp,44
+,styl Akční,45
+,styl Deskovky,46
+,styl WG,47
+,styl Přednášky,48
+systém,,50
+,systém RPG,51
+,systém LKD,52
+,systém mDrD,53
+,systém Larp,54
+,systém Akční,55
+,systém Deskovky,56
+,systém WG,57
+,systém Přednášky,58
+různé,,80
+,různé Partner,81
+omezení,,90
+,omezení Věk,95

--- a/migrace/pomocne/062/checkNameUniquenessFunction.php
+++ b/migrace/pomocne/062/checkNameUniquenessFunction.php
@@ -1,0 +1,81 @@
+<?php
+return static function(array $tags) {
+  $removeDiacriticsAndToLower = require __DIR__ . '/removeDiacriticsAndToLowerFunction.php';
+
+  $opraveneNazvy = [];
+  $puvodniNazvy = [];
+  $duplicitniPuvodniNazvy = [];
+  $duplicitniNazvy = [];
+  $opraveneNazvyBezDiakritiky = [];
+  $duplicitniNazvyBezDiakritiky = [];
+  $opraveneNazvyBezDiakritikyAMezer = [];
+  $duplicitniNazvyBezDiakritikyAMezer = [];
+  foreach ($tags as $tag) {
+    $opravenyNazev = $tag[5];
+    if ($opravenyNazev === '-') {
+      continue; // convinced for deletion
+    }
+    $puvodniNazev = $tag[2];
+    $predchoziPuvodniNazev = $puvodniNazvy[$puvodniNazev][2] ?? false;
+    if ($predchoziPuvodniNazev) {
+      $duplicitniPuvodniNazvy[] = $puvodniNazev;
+      continue;
+    }
+    $puvodniNazvy[$puvodniNazev] = $tag;
+    $predchoziKategorie = $opraveneNazvy[$opravenyNazev][3] ?? false;
+    $kategorie = $tag[3];
+    if ($predchoziKategorie !== false && $kategorie !== $predchoziKategorie) {
+      $duplicitniNazvy[] = "{$opravenyNazev} (s kategorii '{$kategorie}' proti predchozi '{$predchoziKategorie}')";
+      continue;
+    }
+    $opraveneNazvy[$opravenyNazev] = $tag;
+    $opravenyNazevBezDiakritiky = $removeDiacriticsAndToLower($opravenyNazev);
+    $predchoziNazevStejnyBezDiakritiky = $opraveneNazvyBezDiakritiky[$opravenyNazevBezDiakritiky][5] ?? false;
+    if ($predchoziNazevStejnyBezDiakritiky && $predchoziNazevStejnyBezDiakritiky !== $opravenyNazev) {
+      $duplicitniNazvyBezDiakritiky[] = "'{$opravenyNazevBezDiakritiky}' ('{$opravenyNazev}' proti predchozimu nazvu '{$predchoziNazevStejnyBezDiakritiky}')";
+      continue;
+    }
+    $kategorieBezDiakritiky = $removeDiacriticsAndToLower($kategorie);
+    $predchoziKategorieBezDiakritiky = $opraveneNazvyBezDiakritiky[$opravenyNazevBezDiakritiky]['kategorie_bez_diakritiky'] ?? false;
+    if ($predchoziKategorieBezDiakritiky !== false && $kategorieBezDiakritiky !== $predchoziKategorieBezDiakritiky) {
+      $duplicitniNazvyBezDiakritiky[] = "'{$opravenyNazevBezDiakritiky}' ('{$opravenyNazev}' s kategorii '{$kategorie}' proti predchozi '{$predchoziKategorie}')";
+      continue;
+    }
+    $opraveneNazvyBezDiakritiky[$opravenyNazevBezDiakritiky] = $tag;
+    $opraveneNazvyBezDiakritiky[$opravenyNazevBezDiakritiky]['kategorie_bez_diakritiky'] = $kategorieBezDiakritiky;
+    $opravenyNazevBezDiakritikyAMezer = preg_replace('~\s~', '', $opravenyNazevBezDiakritiky);
+    $predchoziNazevStejnyBezDiakritikyAMezer = $opraveneNazvyBezDiakritikyAMezer[$opravenyNazevBezDiakritikyAMezer][5] ?? false;
+    if ($predchoziNazevStejnyBezDiakritikyAMezer && $predchoziNazevStejnyBezDiakritikyAMezer !== $opravenyNazev) {
+      $duplicitniNazvyBezDiakritikyAMezer[] = "'{$opravenyNazevBezDiakritikyAMezer}' ('{$opravenyNazev}' proti predchozimu nazvu '{$predchoziNazevStejnyBezDiakritikyAMezer}')";
+      continue;
+    }
+    $kategorieBezDiakritikyAMezer = preg_replace('~\s~', '', $kategorieBezDiakritiky);
+    $predchoziKategorieBezDiakritikyAMezer = $opraveneNazvyBezDiakritikyAMezer[$opravenyNazevBezDiakritikyAMezer]['kategorie_bez_diakritiky_a_mezer'] ?? false;
+    if ($predchoziKategorieBezDiakritikyAMezer !== false && $kategorieBezDiakritikyAMezer !== $predchoziKategorieBezDiakritikyAMezer) {
+      $duplicitniNazvyBezDiakritikyAMezer[] = "'{$opravenyNazevBezDiakritikyAMezer}' ('{$opravenyNazev}' s kategorii '{$kategorie}' proti predchozi '{$predchoziKategorie}')";
+      continue;
+    }
+    $opraveneNazvyBezDiakritikyAMezer[$opravenyNazevBezDiakritikyAMezer] = $tag;
+    $opraveneNazvyBezDiakritikyAMezer[$opravenyNazevBezDiakritikyAMezer]['kategorie_bez_diakritiky_a_mezer'] = $kategorieBezDiakritikyAMezer;
+  }
+  $errorMessages = [];
+  if ($duplicitniNazvy) {
+    sort($duplicitniNazvy);
+    $errorMessages[] = sprintf('Nektere opravene nazvy jsou vicekrat: %s', implode(', ', $duplicitniNazvy));
+  }
+  if ($duplicitniPuvodniNazvy) {
+    sort($duplicitniPuvodniNazvy);
+    $errorMessages[] = sprintf('Nektere puvodni nazvy jsou vicekrat: %s', implode(', ', $duplicitniPuvodniNazvy));
+  }
+  if ($duplicitniNazvyBezDiakritiky) {
+    sort($duplicitniNazvyBezDiakritiky);
+    $errorMessages[] = sprintf('Nektere opravene nazvy jsou bez hacku a carek a malymi pismeny stejne: %s', implode(', ', $duplicitniNazvyBezDiakritiky));
+  }
+  if ($duplicitniNazvyBezDiakritikyAMezer) {
+    sort($duplicitniNazvyBezDiakritikyAMezer);
+    $errorMessages[] = sprintf('Nektere opravene nazvy jsou bez hacku, carek, bilych znaku a malymi pismeny stejne: %s', implode(', ', $duplicitniNazvyBezDiakritikyAMezer));
+  }
+  if ($errorMessages) {
+    throw new RuntimeException(implode("\n", $errorMessages));
+  }
+};

--- a/migrace/pomocne/062/fetchCategories.php
+++ b/migrace/pomocne/062/fetchCategories.php
@@ -1,0 +1,27 @@
+<?php
+$categoriesSourceFile = __DIR__ . '/062_opravene_kategorie_sjednocenych_tagu.csv';
+$categoriesHandle = fopen($categoriesSourceFile, 'rb');
+if (!$categoriesHandle) {
+  throw new RuntimeException('Can not open ' . $categoriesSourceFile);
+}
+
+$expectedCategoryHeaders = ['Kategorie', 'Subkategorie', 'Řadící kód'];
+$fetchedCategoryHeaders = fgetcsv($categoriesHandle, 0, ',');
+if (!$fetchedCategoryHeaders || $fetchedCategoryHeaders !== $expectedCategoryHeaders) {
+  fclose($categoriesHandle);
+  throw new RuntimeException(
+    sprintf(
+      'Chybny vstupni soubor %s, v zahlavi chybi sloupce %s a prebyvaji %s',
+      $categoriesSourceFile,
+      var_export(array_diff($expectedCategoryHeaders, $fetchedCategoryHeaders ?? []), true),
+      var_export(array_diff($fetchedCategoryHeaders ?? [], $expectedCategoryHeaders), true)
+    )
+  );
+}
+$categories = [];
+while ($row = fgetcsv($categoriesHandle, 0, ',')) {
+  $categories[] = array_map('trim', $row);
+}
+fclose($categoriesHandle);
+
+return $categories;

--- a/migrace/pomocne/062/fetchTags.php
+++ b/migrace/pomocne/062/fetchTags.php
@@ -1,0 +1,28 @@
+<?php
+$fixedTagsSourceFile = __DIR__ . '/../055_sjednocene_tagy.csv';
+$fixedTagsHandle = fopen($fixedTagsSourceFile, 'rb');
+if (!$fixedTagsHandle) {
+  throw new RuntimeException('Can not open ' . $fixedTagsSourceFile);
+}
+
+$expectedTagHeaders = ['orig. pořadí', 'id', 'puvodni nazev', 'Kategorie', 'Kategorie - hypotetické', 'opraveny nazev', 'poznamka'];
+$fetchedTagHeaders = fgetcsv($fixedTagsHandle, 0, ',');
+if (!$fetchedTagHeaders || $fetchedTagHeaders !== $expectedTagHeaders) {
+  fclose($fixedTagsHandle);
+  throw new RuntimeException(
+    sprintf(
+      'Chybny vstupni soubor %s, v zahlavi chybi sloupce %s a prebyvaji %s',
+      $fixedTagsSourceFile,
+      var_export(array_diff($expectedTagHeaders, $fetchedTagHeaders ?? []), true),
+      var_export(array_diff($fetchedTagHeaders ?? [], $expectedTagHeaders), true)
+    )
+  );
+}
+$fixedTags = [];
+while ($row = fgetcsv($fixedTagsHandle, 0, ',')) {
+  unset($row[0] /* orig. pořadí */, $row[4] /* Kategorie - hypotetické */);
+  $fixedTags[] = array_map('trim', $row);
+}
+fclose($fixedTagsHandle);
+
+return $fixedTags;

--- a/migrace/pomocne/062/intToSqlValuesFunction.php
+++ b/migrace/pomocne/062/intToSqlValuesFunction.php
@@ -1,0 +1,29 @@
+<?php
+return static function(array $values, \mysqli $db): string {
+  return implode(
+    ",\n", // ('foo','bar'),('baz','quz')
+    array_map(
+      function(array $row) use($db): string {
+        return sprintf(
+          '(%s)', // ('foo','bar')
+          implode(
+            ',', // 'foo','bar'
+            array_map(
+              function(?string $value) use($db): string {
+                if ($value === null) {
+                  return 'NULL';
+                }
+                if (preg_match('~^[(].+[)]$~', $value)) {
+                  return $value; // some sub-select
+                }
+                return sprintf("'%s'", mysqli_real_escape_string($db, $value));
+              },
+              $row
+            )
+          )
+        );
+      },
+      $values
+    )
+  );
+};

--- a/migrace/pomocne/062/removeDiacriticsAndToLowerFunction.php
+++ b/migrace/pomocne/062/removeDiacriticsAndToLowerFunction.php
@@ -1,0 +1,15 @@
+<?php
+return static function(string $value): string {
+  $withoutDiacritics = '';
+  $specialsReplaced = \str_replace(
+    ['̱', '̤', '̩', 'Ə', 'ə', 'ʿ', 'ʾ', 'ʼ',],
+    ['', '', '', 'E', 'e', "'", "'", "'",],
+    $value
+  );
+  \preg_match_all('~(?<words>\w*)(?<nonWords>\W*)~u', $specialsReplaced, $matches);
+  foreach ($matches['words'] as $index => $word) {
+    $wordWithoutDiacritics = \transliterator_transliterate('Any-Latin; Latin-ASCII', $word);
+    $withoutDiacritics .= $wordWithoutDiacritics . $matches['nonWords'][$index];
+  }
+  return strtolower($withoutDiacritics);
+};

--- a/model/vyjimkovac-chyba.php
+++ b/model/vyjimkovac-chyba.php
@@ -25,8 +25,12 @@ class VyjimkovacChyba {
       'url'     => 'http://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'],
       'zdroj'   => @$_SERVER['HTTP_REFERER'] ?: null,
     ];
-    if($u = Uzivatel::zSession()) {
-      $r['uzivatel'] = $u->id();
+    try {
+      if ($u = Uzivatel::zSession()) {
+        $r['uzivatel'] = $u->id();
+      }
+    } catch (\Throwable $throwable) {
+      // nothing to do with that here...
     }
     return $r;
   }

--- a/nastaveni/.gitignore
+++ b/nastaveni/.gitignore
@@ -1,0 +1,1 @@
+/google_api_client_secret.json


### PR DESCRIPTION
https://trello.com/c/dFzCulIR/846-n%C4%9Bkter%C3%A9-%C5%A1t%C3%ADtky-chyb%C3%AD

Loni jsem pokazil sjednocování štítků, když jsem změnil název některých kategorií jen ve zdrojovém souboru se štítky, ale už ne v souboru s kategoriemi samotnými, takže se najednou rozcházely názvy "deskovky" a "desk" a tím se některé štítky nahrály bez kategorie. A tím se také přestaly zobrazovat.

Zkopíroval jsem původní SQL migraci, opravil názvy kategorií, přidal NOT NULL kontrolu ke kategorii každého štítku, aby mi zase nějaký neutekl bez kategorie a ve finále jsem nahradil loňská data za opravená.

Riziko je, že tím přepíšu změny ve štítcích, které za ten rok někdo udělal. Poslal jsem dotaz na Smauga, zda je to OK.