### PR TITLE
Oprava zobrazení názvu typu aktivity ve filtru

### DIFF
--- a/admin/scripts/modules/aktivity/aktivity.php
+++ b/admin/scripts/modules/aktivity/aktivity.php
@@ -64,7 +64,7 @@ while($r = mysqli_fetch_assoc($o)) {
 }
 foreach($varianty as $k => $v) {
   $tpl->assign('val',$k);
-  $tpl->assign('nazev',ucfirst($v['popis']));
+  $tpl->assign('nazev_akce',ucfirst($v['popis']));
   $tpl->assign('sel',$filtr==$k?'selected="selected"':'');
   $tpl->parse('aktivity.filtrMoznost');
 }


### PR DESCRIPTION
Ve filtru aktivit https://admin.gamecon.cz/aktivity  _Zobrazit jen_ chybí jejich názvy . Tohle to opravuje.