### PR TITLE
Cache šablon se při změně knihoven zahodí

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,11 @@
       "Gamecon\\Tests\\": "tests"
     }
   },
+  "scripts": {
+    "post-update-cmd": "@clear-templates-cache",
+    "post-install-cmd": "@clear-templates-cache",
+    "clear-templates-cache": "php -r 'array_map(\"unlink\", glob(\"cache/private/xtpl/*.php\"));'"
+  },
   "config": {
     "sort-packages": true
   }


### PR DESCRIPTION
XTemplate závislost máme nešťastně určenou v composer.json přes `"godric/xtemplate": "dev-master"`, tak nám jeho změny lítají dovnitř kompatibilita nekompatibilita.

A Godrik nedávno XTemplate změnil a najednou to očekávalo stejný název souboru, ale s jiným obsahem a cache tak najednou byla neplatná, XTemplate to nepoznal a crashlo to.

Tímhle cache promažeme vždy, když se zavolá composer install nebo update.

Pozor! Není to finální a zakládám na to [task](https://trello.com/c/C8SqPoi0/793-zm%C4%9Bna-v-xtemplate-n%C3%A1m-m%C5%AF%C5%BEe-hodit-fatal) - tohle se nám klíďo píďo může stát v podukci.