### PR TITLE
Lze zadat port pro připojení k DB

### DIFF
--- a/admin/migrace.php
+++ b/admin/migrace.php
@@ -18,7 +18,7 @@ ini_set('html_errors',      false); // chyby zobrazovat jako plaintext
 // spustit migrace
 pripravCache(SPEC . '/db-backup');
 (new Godric\DbMigrations\DbMigrations([
-  'connection'          =>  new mysqli(DBM_SERV, DBM_USER, DBM_PASS, DBM_NAME),
+  'connection'          =>  new mysqli(DBM_SERV, DBM_USER, DBM_PASS, DBM_NAME, defined('DBM_PORT') ? DBM_PORT : null),
   'migrationsDirectory' =>  __DIR__ . '/../migrace',
   'backupsDirectory'    =>  SPEC . '/db-backup',
   'checkInitialMigrationChanges' => false,

--- a/model/funkce/fw-database.php
+++ b/model/funkce/fw-database.php
@@ -57,6 +57,7 @@ function dbConnect($selectDb = true) {
     $dbname     = DB_NAME;
     $dbuser     = DB_USER;
     $dbpass     = DB_PASS;
+    $dbPort     = defined('DB_PORT') ? DB_PORT : null;
     $spojeni    = null;
     $dbLastQ    = '';   //vztahuje se pouze na dotaz v aktualnim skriptu
     $dbNumQ     = 0;    //počet dotazů do databáze
@@ -64,7 +65,7 @@ function dbConnect($selectDb = true) {
 
     // připojení
     $start = microtime(true);
-    $spojeni = @mysqli_connect('p:' . $dbhost, $dbuser, $dbpass, $selectDb ? $dbname : ''); // persistent connection
+    $spojeni = @mysqli_connect('p:' . $dbhost, $dbuser, $dbpass, $selectDb ? $dbname : '', $dbPort); // persistent connection
     if(!$spojeni)
       throw new Exception('Failed to connect to the database, error: "' . mysqli_connect_error() . '".');
     if(!$spojeni->set_charset('utf8'))

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -6,12 +6,14 @@ ini_set('display_errors', true); // zobrazovat chyby při lokálním vývoji (po
 @define('DB_PASS', '');
 @define('DB_NAME', 'gamecon');
 @define('DB_SERV', '127.0.0.1');
+//@define('DB_PORT', '3306');
 
 // uživatel s přístupem k změnám struktury
-@define('DBM_USER', 'root');
-@define('DBM_PASS', '');
-@define('DBM_NAME', 'gamecon');
-@define('DBM_SERV', 'localhost');
+@define('DBM_USER', DB_USER);
+@define('DBM_PASS', DB_PASS);
+@define('DBM_NAME', DB_NAME);
+@define('DBM_SERV', DB_SERV);
+//@define('DBM_PORT', DB_PORT);
 
 @define('URL_WEBU',  '/gamecon/web'); // absolutní url uživatelského webu
 @define('URL_ADMIN', '/gamecon/admin'); // absolutní url adminu


### PR DESCRIPTION
Jelikož nováčci mají často potíže s nahozením MySQL a připojením se k databázi, tak jsem nahodil veřejně dostupnou anonymizovanou databázi. Ale raději na nestandardním portu, aby mi to nebombardovaly roboti.

Tohle přidává podporu nestandardnímu MySQL portu do Gameconu.