### PR TITLE
802: Na webu se opět logují JS errory do SQLite

### DIFF
--- a/model/Vyjimkovac/Vyjimkovac.php
+++ b/model/Vyjimkovac/Vyjimkovac.php
@@ -80,12 +80,35 @@ class Vyjimkovac implements Logovac {
     ob_start();
     ?><script>
       window.onerror = function(msg, url, line) {
+          const newXHR = new XMLHttpRequest();
+
+          newXHR.open('POST', '<?=$url?>');
+
+          newXHR.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+          const data = {
+              msg: msg,
+              url: url,
+              line: line
+          };
+
+          let encoded = "";
+          for (const key in data) {
+              if (encoded !== "") {
+                  encoded += "&";
+              }
+              encoded += key + "=" + encodeURIComponent(data[key]);
+          }
+
+          newXHR.send(encoded);
+      }
+      /*window.onerror = function(msg, url, line) {
         $.post('<?=$url?>', {
           msg: msg,
           url: url,
           line: line
         });
-      };
+      };*/
     </script><?php
     return ob_get_clean();
   }

--- a/web/index.php
+++ b/web/index.php
@@ -88,6 +88,7 @@ if($m->bezStranky()) {
   $t = new XTemplate('sablony/blackarrow/index.xtpl');
   $t->assign([
     'css'   => perfectcache('soubory/blackarrow/*/*.less'),
+    'jsVyjimkovac'  => \Gamecon\Vyjimkovac\Vyjimkovac::js(URL_WEBU.'/ajax-vyjimkovac'),
     'chyba' => Chyba::vyzvedniHtml(),
     'menu'  => $menu,
     'obsah' => $m->vystup(),

--- a/web/sablony/blackarrow/index.xtpl
+++ b/web/sablony/blackarrow/index.xtpl
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{css}">
     <!-- begin: extraCss --><link rel="stylesheet" href="{url}"><!-- end: extraCss -->
     <!-- begin: extraJs --><script src="{url}"></script><!-- end: extraJs -->
+    {jsVyjimkovac}
     {info}
     <link rel="icon" href="soubory/blackarrow/_spolecne/favicon.png">
 </head>


### PR DESCRIPTION
Při práci na https://trello.com/c/Uxmm2f8V/802-p%C5%99edm%C4%9Bty-v-shopu-2021 jsem zjistil, že když mi to padne na JS chybu, tak v "Chybách" v adminu není ani čárka.

Je to tím, že na webu už nepoužíváme jQuery a logovač na něj spoléhá.

Tohle upravuje JS logovač, aby nevyžadoval jQuery a aby se opět logovali JS chyby z webu.