### PR TITLE
855: Spárujeme i platbu s VS v textu bez lomítka na začátku

### DIFF
--- a/model/fio-platba.php
+++ b/model/fio-platba.php
@@ -33,7 +33,7 @@ class FioPlatba
     }
 
     protected function nactiVsZTextu(string $text): string {
-        if (!preg_match('~/vs/(?<vs>\d+)~i', $text, $matches)) {
+        if (!preg_match('~(^|/)vs/(?<vs>\d+)~i', $text, $matches)) {
             return '';
         }
         return $matches['vs'];


### PR DESCRIPTION
https://trello.com/c/mF1tzIMP/855-sp%C3%A1rov%C3%A1n%C3%AD-sk-plateb

Ze Slovenska posílají platby s variabilním symbolem ve zprávě. Ten by měl být ve formátu `/VS/123456`, ale občas to pošlou bez úvodního lomítka.

Budeme parsovat i takový formát.