### PR TITLE
Upraveny migrace aby bylo vzdy pouzito InnoDB

### DIFF
--- a/migrace/058.php
+++ b/migrace/058.php
@@ -258,7 +258,7 @@ CREATE TABLE IF NOT EXISTS kategorie_sjednocenych_tagu(
     id_hlavni_kategorie INT UNSIGNED,
     poradi INT UNSIGNED NOT NULL,
     FOREIGN KEY (id_hlavni_kategorie) REFERENCES kategorie_sjednocenych_tagu(id) ON UPDATE CASCADE ON DELETE RESTRICT
-) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 INSERT INTO kategorie_sjednocenych_tagu(nazev, id_hlavni_kategorie, poradi)
 VALUES {$mainCategoriesSql};
 INSERT INTO kategorie_sjednocenych_tagu(nazev, id_hlavni_kategorie, poradi)
@@ -269,7 +269,7 @@ CREATE TABLE IF NOT EXISTS sjednocene_tagy (
     nazev VARCHAR(128) PRIMARY KEY,
     poznamka TEXT NOT NULL DEFAULT '',
     FOREIGN KEY FK_kategorie_tagu(id_kategorie_tagu) REFERENCES kategorie_sjednocenych_tagu(id)
-) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 ALTER TABLE sjednocene_tagy AUTO_INCREMENT={$tagsAutoIncrementStart};
 INSERT /* intentionally not IGNORE to detect invalid input data, see bellow */ INTO sjednocene_tagy(id, id_kategorie_tagu, nazev, poznamka)
 SELECT sjednocene_tagy_temp.id, kategorie_sjednocenych_tagu.id, sjednocene_tagy_temp.opraveny_nazev, GROUP_CONCAT(DISTINCT sjednocene_tagy_temp.poznamka SEPARATOR '; ')
@@ -278,7 +278,7 @@ JOIN kategorie_sjednocenych_tagu ON kategorie_sjednocenych_tagu.nazev = sjednoce
 WHERE sjednocene_tagy_temp.opraveny_nazev != '-' -- strange records convinced for deletion
 GROUP BY sjednocene_tagy_temp.opraveny_nazev, kategorie_sjednocenych_tagu.id; -- intentionally grouped also by kategorie_sjednocenych_tagu.id to get fatal in case of duplicated opraveny_nazev but different kategorie_sjednocenych_tagu.id => logic error in source data
 CREATE TABLE IF NOT EXISTS akce_sjednocene_tagy LIKE akce_tagy;
-INSERT IGNORE INTO akce_sjednocene_tagy(id_akce, id_tagu) 
+INSERT IGNORE INTO akce_sjednocene_tagy(id_akce, id_tagu)
 SELECT akce_tagy.id_akce, sjednocene_tagy.id
 FROM akce_tagy
 INNER JOIN sjednocene_tagy_temp ON sjednocene_tagy_temp.id = akce_tagy.id_tagu

--- a/migrace/060.php
+++ b/migrace/060.php
@@ -9,20 +9,20 @@ CREATE TABLE IF NOT EXISTS reporty(
     format_csv TINYINT(1) DEFAULT 1,
     format_html TINYINT(1) DEFAULT 1,
     viditelny TINYINT(1) DEFAULT 1
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 
 INSERT INTO reporty(skript, nazev, format_csv, format_html)
 VALUES
-('aktivity',                                                      'Historie přihlášení na aktivity', 1, 1),                               
-('pocty-her',                                                     'Účastníci a počty jejich aktivit', 1, 0),                             
-('pocty-her-graf',                                                'Graf rozložení rozmanitosti her', 0, 1),                               
-('rozesilani-ankety',                                             'Rozesílání ankety s tokenem', 0, 1),                                   
-('parovani-ankety',                                               'Párování ankety a údajů uživatelů', 0, 1),                             
-('grafy-ankety',                                                  'Grafy k anketě', 0, 1),                                                
-('update-zustatku',                                               'UPDATE příkaz zůstatků pro letošní GC', 0, 1),                         
-('neprihlaseni-vypraveci',                                        'Nepřihlášení a neubytovaní vypravěči', 0, 1),                          
-('duplicity',                                                     'Duplicitní uživatelé', 0, 1),                                          
-('stravenky',                                                     'Stravenky uživatelů', 0, 1),                                           
+('aktivity',                                                      'Historie přihlášení na aktivity', 1, 1),
+('pocty-her',                                                     'Účastníci a počty jejich aktivit', 1, 0),
+('pocty-her-graf',                                                'Graf rozložení rozmanitosti her', 0, 1),
+('rozesilani-ankety',                                             'Rozesílání ankety s tokenem', 0, 1),
+('parovani-ankety',                                               'Párování ankety a údajů uživatelů', 0, 1),
+('grafy-ankety',                                                  'Grafy k anketě', 0, 1),
+('update-zustatku',                                               'UPDATE příkaz zůstatků pro letošní GC', 0, 1),
+('neprihlaseni-vypraveci',                                        'Nepřihlášení a neubytovaní vypravěči', 0, 1),
+('duplicity',                                                     'Duplicitní uživatelé', 0, 1),
+('stravenky',                                                     'Stravenky uživatelů', 0, 1),
 ('stravenky?ciste',                                               'Stravenky (bianco)', 1, 1),
 /*
   Dva nouzové reporty z roku 2015 už nejsou potřeba, nebudeme je převádět a necháme je zmizet
@@ -32,8 +32,8 @@ VALUES
 ('maily-prihlaseni',                                              'Maily – přihlášení na GC (vč. unsubscribed)', 1, 1),
 ('maily-neprihlaseni',                                            'Maily – nepřihlášení na GC', 1, 1),
 ('maily-vypraveci',                                               'Maily – vypravěči (vč. unsubscribed)', 1, 1),
-('maily-dle-data-ucasti?start=0',                                 'Maily - nedávní účastníci (prvních 2000)', 1, 0),                     
-('maily-dle-data-ucasti?start=2000',                              'Maily - dávní účastníci (dalších 2000)', 1, 0),                       
+('maily-dle-data-ucasti?start=0',                                 'Maily - nedávní účastníci (prvních 2000)', 1, 0),
+('maily-dle-data-ucasti?start=2000',                              'Maily - dávní účastníci (dalších 2000)', 1, 0),
 ('finance-lide-v-databazi-a-zustatky',                            'Finance: Lidé v databázi + zůstatky', 1, 1),
 ('finance-aktivity-negenerujici-slevu',                           'Finance: Aktivity negenerující slevu', 1, 1),
 ('finance-prijmy-a-vydaje-infopultaka',                           'Finance: Příjmy a výdaje infopulťáka', 1, 1),
@@ -62,6 +62,6 @@ CREATE TABLE IF NOT EXISTS reporty_log_pouziti
     KEY report_uzivatel (id_reportu, id_uzivatele),
     FOREIGN KEY id_reportu (id_reportu) REFERENCES reporty(id) ON UPDATE CASCADE ON DELETE NO ACTION,
     FOREIGN KEY id_uzivatele (id_uzivatele) REFERENCES uzivatele_hodnoty(id_uzivatele) ON UPDATE CASCADE ON DELETE NO ACTION
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 SQL
 );

--- a/migrace/062.php
+++ b/migrace/062.php
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS kategorie_sjednocenych_tagu_62(
     id_hlavni_kategorie INT UNSIGNED,
     poradi INT UNSIGNED NOT NULL,
     FOREIGN KEY (id_hlavni_kategorie) REFERENCES kategorie_sjednocenych_tagu_62(id) /* itself (parent row) */ ON UPDATE CASCADE ON DELETE RESTRICT
-) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 INSERT INTO kategorie_sjednocenych_tagu_62(nazev, id_hlavni_kategorie, poradi)
 VALUES {$mainCategoriesSql};
 INSERT INTO kategorie_sjednocenych_tagu_62(nazev, id_hlavni_kategorie, poradi)
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS sjednocene_tagy_62 (
     nazev VARCHAR(128) PRIMARY KEY,
     poznamka TEXT NOT NULL DEFAULT '',
     FOREIGN KEY FK_kategorie_sjednocenych_tagu_62(id_kategorie_tagu) REFERENCES kategorie_sjednocenych_tagu_62(id) ON UPDATE CASCADE ON DELETE RESTRICT
-) DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 ALTER TABLE sjednocene_tagy_62 AUTO_INCREMENT={$tagsAutoIncrementStart};
 INSERT /* intentionally not IGNORE to detect invalid input data, see bellow */ INTO sjednocene_tagy_62(id, id_kategorie_tagu, nazev, poznamka)
 SELECT sjednocene_tagy_temp.id, kategorie_sjednocenych_tagu_62.id, sjednocene_tagy_temp.opraveny_nazev, GROUP_CONCAT(DISTINCT sjednocene_tagy_temp.poznamka SEPARATOR '; ')

--- a/migrace/064.php
+++ b/migrace/064.php
@@ -7,7 +7,7 @@ CREATE TABLE akce_instance(
     id_hlavni_akce INTEGER NOT NULL,
     CONSTRAINT FOREIGN KEY FK_akce_instance_to_akce_seznam(id_hlavni_akce) REFERENCES akce_seznam(id_akce)
         ON UPDATE CASCADE ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 
 INSERT INTO akce_instance(id_instance, id_hlavni_akce)
 SELECT patri_pod, MIN(id_akce)
@@ -35,7 +35,8 @@ MODIFY COLUMN stav INTEGER NOT NULL;
 CREATE TABLE akce_stav(
     id_stav INTEGER UNIQUE KEY AUTO_INCREMENT,
     nazev VARCHAR(128) PRIMARY KEY
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+
 SET SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO'; -- jinak to místo nuly vloží novou autoincrement hodnotu
 INSERT INTO akce_stav(id_stav, nazev)
 VALUES
@@ -60,7 +61,7 @@ CREATE TABLE mutex(
     do DATETIME NULL,
     FOREIGN KEY FK_mutex_to_uzivatele_hodnoty(zamknul) REFERENCES uzivatele_hodnoty(id_uzivatele)
         ON UPDATE CASCADE ON DELETE SET NULL
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 
 ALTER TABLE akce_seznam
 MODIFY COLUMN lokace INT NULL DEFAULT NULL;

--- a/migrace/065.php
+++ b/migrace/065.php
@@ -9,6 +9,6 @@ CREATE TABLE akce_import(
     cas DATETIME NOT NULL,
     KEY google_sheet_id(google_sheet_id),
     FOREIGN KEY FK_akce_import_to_uzivatele_hodnoty(id_uzivatele) REFERENCES uzivatele_hodnoty(id_uzivatele) ON UPDATE CASCADE ON DELETE NO ACTION
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 SQL
 );

--- a/migrace/071.php
+++ b/migrace/071.php
@@ -13,7 +13,8 @@ sort($migrationCodes);
 $currentMigrationCode = basename(__FILE__, '.php');
 
 $this->q(<<<SQL
-CREATE TABLE migrations(migration_id SERIAL, migration_code VARCHAR(128) PRIMARY KEY, applied_at DATETIME NULL);
+CREATE TABLE migrations(migration_id SERIAL, migration_code VARCHAR(128) PRIMARY KEY, applied_at DATETIME NULL)
+ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 SQL
 );
 


### PR DESCRIPTION
Stalo se, že jsme se Kubou sekli na několik dní při nahazování jeho lokální kopie kvůli nefunkčním cizím klíčům.

Důvodem bylo, že jeho databáze neměla jako výchozí engine InnoDB a protože některé migrace engine výslovně neuváděly, tak se pak tabulky vytvořili s MyISAM a MySQL zahlásilo svůj oblíbený neurčitý error, který může znamenat půlku vesmíru.

Tímto ve všech migracích výslovně uvádíme engine InnoDB, aby se to dalšími nováčkovi nestalo.