### PR TITLE
250: Zaokrouhlovat zůstatek na účtu kvůli potížím s float ocintky

### DIFF
--- a/model/finance.php
+++ b/model/finance.php
@@ -95,10 +95,10 @@ class Finance
 
         $this->logb('Celková cena', $cena, self::CELKOVA);
 
-        $this->stav =
+        $this->stav = round(
             -$cena
             + $this->platby
-            + $this->zustatekZPredchozichRocniku;
+            + $this->zustatekZPredchozichRocniku, 2);
 
         $this->logb('Aktivity', $this->cenaAktivity, self::AKTIVITA);
         $this->logb('Ubytování', $this->cenaUbytovani, self::UBYTOVANI);
@@ -430,6 +430,7 @@ class Finance
             $this->platby += $r['cena'];
             $this->log($r['nazev'], $r['cena'], self::PLATBA);
         }
+        $this->platby = round($this->platby, 2);
     }
 
     /**


### PR DESCRIPTION
https://trello.com/c/23zOhWln/250-zm%C4%9Bny-v-adminu-2021

Jelikož nepotřebujeme vidět _Stav účtu: | 2.8421709430404E-14 Kč_ a navíc je to chyba při sčítání float v PHP, tak budeme zůstatek zaokrouhlovávat.


