### PR TITLE
874: Potvrzení proti Covidu může být nahráno i po začátku Gameconu

### DIFF
--- a/admin/scripts/modules/ubytovani.php
+++ b/admin/scripts/modules/ubytovani.php
@@ -7,86 +7,83 @@
  * pravo: 101
  */
 
+/**
+ * @var Uzivatel|null|void $uPracovni
+ */
 
 $nastaveni = ['ubytovaniBezZamku' => true, 'jidloBezZamku' => true];
 $shop = $uPracovni ? new Shop($uPracovni, $nastaveni) : null;
 
+if (post('pokojeImport')) {
+    $f = fopen($_FILES['pokojeSoubor']['tmp_name'], 'rb');
+    if (!$f) throw new Exception('Soubor se nepodařilo načíst');
 
-if(post('pokojeImport')) {
-  $f = fopen($_FILES['pokojeSoubor']['tmp_name'], 'rb');
-  if(!$f) throw new Exception('Soubor se nepodařilo načíst');
+    $hlavicka = array_flip(fgetcsv($f, 512, ";"));
+    if (!array_key_exists('id_uzivatele', $hlavicka)) throw new Exception('Nepodařilo se zpracovat soubor');
+    $uid = $hlavicka['id_uzivatele'];
+    $od = $hlavicka['prvni_noc'];
+    $do = $hlavicka['posledni_noc'];
+    $pokoj = $hlavicka['pokoj'];
 
-  $hlavicka = array_flip(fgetcsv($f, 512, ";"));
-  if(!array_key_exists('id_uzivatele', $hlavicka)) throw new Exception('Nepodařilo se zpracovat soubor');
-  $uid = $hlavicka['id_uzivatele'];
-  $od = $hlavicka['prvni_noc'];
-  $do = $hlavicka['posledni_noc'];
-  $pokoj = $hlavicka['pokoj'];
+    dbDelete('ubytovani', ['rok' => ROK]);
 
-  dbDelete('ubytovani', ['rok' => ROK]);
-
-  while($r = fgetcsv($f, 512, ";")) {
-    if($r[$pokoj]) {
-      for($den = $r[$od]; $den <= $r[$do]; $den++) {
-        dbInsert('ubytovani', [
-          'id_uzivatele'  =>  $r[$uid],
-          'den'           =>  $den,
-          'pokoj'         =>  $r[$pokoj],
-          'rok'           =>  ROK,
-        ]);
-      }
+    while ($r = fgetcsv($f, 512, ";")) {
+        if ($r[$pokoj]) {
+            for ($den = $r[$od]; $den <= $r[$do]; $den++) {
+                dbInsert('ubytovani', [
+                    'id_uzivatele' => $r[$uid],
+                    'den' => $den,
+                    'pokoj' => $r[$pokoj],
+                    'rok' => ROK,
+                ]);
+            }
+        }
     }
-  }
 
-  oznameni('Import dokončen');
+    oznameni('Import dokončen');
 }
 
-
-if(post('pridelitPokoj')) {
-  Pokoj::ubytujNaCislo(Uzivatel::zId(post('uid')), post('pokoj'));
-  oznameni('Pokoj přidělen');
+if (post('pridelitPokoj')) {
+    Pokoj::ubytujNaCislo(Uzivatel::zId(post('uid')), post('pokoj'));
+    oznameni('Pokoj přidělen');
 }
 
-
-if(post('zpracujUbytovani')) {
-  $shop->zpracujUbytovani();
-  oznameni('Ubytování uloženo');
+if (post('zpracujUbytovani')) {
+    $shop->zpracujUbytovani();
+    oznameni('Ubytování uloženo');
 }
 
-
-if(post('zpracujJidlo')) {
-  $shop->zpracujJidlo();
-  oznameni('Jídlo uloženo');
+if (post('zpracujJidlo')) {
+    $shop->zpracujJidlo();
+    oznameni('Jídlo uloženo');
 }
-
 
 $t = new XTemplate('ubytovani.xtpl');
 
-
 $pokoj = Pokoj::zCisla(get('pokoj'));
 $ubytovani = $pokoj ? $pokoj->ubytovani() : [];
-if(get('pokoj') && !$pokoj) throw new Chyba('pokoj ' . get('pokoj') . ' neexistuje nebo je prázdný');
+if (get('pokoj') && !$pokoj) throw new Chyba('pokoj ' . get('pokoj') . ' neexistuje nebo je prázdný');
 $t->assign([
-  'uid'       =>  $uPracovni ? $uPracovni->id() : '',
-  'pokoj'     =>  get('pokoj'),
-  'ubytovani' =>  array_uprint($ubytovani, function($e){
-    $ne = $e->gcPritomen() ? '' : 'ne';
-    $color = $ne ? '#f00' : '#0a0';
-    $a = $e->koncA();
-    return $e->jmenoNick() . " (<span style=\"color:$color\">{$ne}dorazil$a</span>)";
-  }, '<br>'),
+    'uid' => $uPracovni ? $uPracovni->id() : '',
+    'pokoj' => get('pokoj'),
+    'ubytovani' => array_uprint($ubytovani, function ($e) {
+        $ne = $e->gcPritomen() ? '' : 'ne';
+        $color = $ne ? '#f00' : '#0a0';
+        $a = $e->koncA();
+        return $e->jmenoNick() . " (<span style=\"color:$color\">{$ne}dorazil$a</span>)";
+    }, '<br>'),
 ]);
 
-if($uPracovni && $uPracovni->gcPrihlasen()) {
-  $t->assign('shop', $shop);
-  $t->parse('ubytovani.ubytovani');
-  $t->parse('ubytovani.jidlo');
+if ($uPracovni && $uPracovni->gcPrihlasen()) {
+    $t->assign('shop', $shop);
+    $t->parse('ubytovani.ubytovani');
+    $t->parse('ubytovani.jidlo');
 }
 
-if(!$uPracovni) {
-  $t->assign('status', '<div class="warning">Uživatel nevybrán</div>');
-} elseif(!$uPracovni->gcPrihlasen()) {
-  $t->assign('status', '<div class="error">Uživatel není přihlášen na GC</div>');
+if (!$uPracovni) {
+    $t->assign('status', '<div class="warning">Uživatel nevybrán</div>');
+} elseif (!$uPracovni->gcPrihlasen()) {
+    $t->assign('status', '<div class="error">Uživatel není přihlášen na GC</div>');
 }
 
 $t->parse('ubytovani');

--- a/admin/scripts/modules/uvod.php
+++ b/admin/scripts/modules/uvod.php
@@ -11,6 +11,8 @@
 use \Gamecon\Cas\DateTimeCz;
 use \Gamecon\Cas\DateTimeGamecon;
 
+/** @var Uzivatel|null|void $uPracovni */
+
 if (!empty($_POST['datMaterialy']) && $uPracovni && $uPracovni->gcPrihlasen()) {
     $uPracovni->dejZidli(Z_PRITOMEN);
     back();
@@ -85,7 +87,7 @@ if (post('poznamkaNastav')) {
     back();
 }
 
-if (post('zmenitUdaj')) {
+if (post('zmenitUdaj') && $uPracovni) {
     $udaje = post('udaj');
     if ($udaje['op'] ?? null) {
         $uPracovni->cisloOp($udaje['op']);

--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -1361,9 +1361,9 @@ SQL
         return $x->text('covid');
     }
 
-    public function zpracujPotvrzeniProtiCovidu() {
+    public function zpracujPotvrzeniProtiCovidu(): bool {
         if (!isset($_FILES['potvrzeniProtiCovidu']) || empty($_FILES['potvrzeniProtiCovidu']['tmp_name'])) {
-            return;
+            return false;
         }
         $f = @fopen($_FILES['potvrzeniProtiCovidu']['tmp_name'], 'rb');
         if (!$f) {
@@ -1392,6 +1392,8 @@ SQL
 
         $ted = new DateTimeImmutable();
         $this->ulozPotvrzeniProtiCoviduPridanyKdy($ted);
+
+        return true;
     }
 
     private function ulozPotvrzeniProtiCoviduPridanyKdy(?\DateTimeInterface $kdy) {

--- a/nastaveni/nastaveni.php
+++ b/nastaveni/nastaveni.php
@@ -16,7 +16,7 @@ error_reporting($puvodni ^ E_NOTICE);
 // Základní nastavení //
 ////////////////////////
 
-@define('ROK', 2021);                    // aktuální rok -- při změně roku viz http://bit.ly/2l5olnb
+@define('ROK', 2021);                    // aktuální rok -- při změně roku viz Překlápění ročníku na Gamecon Gdrive https://docs.google.com/document/d/1H_PM70WjNpQ1Xz65OYfr1BeSTdLrNQSkScMIZEtxWEc/edit
 @define('GC_BEZI_OD', ROK . '-07-15 07:00:00');   // začátek GameConu (přepnutí stránek do režimu "úpravy na jen na infopultu")
 @define('GC_BEZI_DO', ROK . '-07-18 21:00:00');   // konec GameCou (přepnutí stránek do režimu "gc skončil, úpravy nemožné")
 @define('REG_GC_OD', ROK . '-05-13 20:21:00');   // spuštění možnosti registrace na GameCon

--- a/web/moduly/prihlaska/covid-sekce.xtpl
+++ b/web/moduly/prihlaska/covid-sekce.xtpl
@@ -1,0 +1,19 @@
+<!-- begin:covid -->
+
+<div class="prihlaska_sekce">
+  <h2>Covid-19</h2>
+
+  <div class="prihlaska_infoPruh">
+    <div class="prihlaska_info">
+      <h3>Nutné potvrzení</h3>
+      <div class="prihlaska_info prihlaska_info-ikona">
+        Nejpozději na Infopultu, před vstupem na samotný GameCon, nám musíš prokázat splnění podmínek účasti, a to
+        jedním ze tří možných typů potvrzení.
+      </div>
+    </div>
+  </div>
+
+  {covidFreePotvrzeni}
+</div>
+
+<!-- end:covid -->

--- a/web/sablony/blackarrow/prihlaska.xtpl
+++ b/web/sablony/blackarrow/prihlaska.xtpl
@@ -1,201 +1,211 @@
 <!-- begin:prihlaska -->
 
 <div class="prihlaska_hlavickaObal">
-<div class="prihlaska_hlavicka">
-  <h1>Přihláška na GameCon</h1>
+  <div class="prihlaska_hlavicka">
+    <h1>Přihláška na GameCon</h1>
 
-  <!-- begin:prihlasen -->
-  <p>Jsi přihlášen{a} na GameCon {rok}. Níž si můžeš upravit svou přihlášku, tj. objednané ubytování a předměty až téměř do začátku GameConu.</p>
-  <!-- end:prihlasen -->
+    <!-- begin:prihlasen -->
+    <p>Jsi přihlášen{a} na GameCon {rok}. Níž si můžeš upravit svou přihlášku, tj. objednané ubytování a předměty až
+      téměř do začátku GameConu.</p>
+    <!-- end:prihlasen -->
 
-  <!-- begin:neprihlasen -->
-  <p>Vyplněním údajů se přihlásíš na GameCon {rok}. Můžeš si vybrat předměty a ubytování s GameCon tématikou, které budeš chtít. Výber jde i později změnit.</p>
-  <!-- end:neprihlasen -->
-</div>
+    <!-- begin:neprihlasen -->
+    <p>Vyplněním údajů se přihlásíš na GameCon {rok}. Můžeš si vybrat předměty a ubytování s GameCon tématikou, které
+      budeš chtít. Výber jde i později změnit.</p>
+    <!-- end:neprihlasen -->
+  </div>
 </div>
 
 <form method="post" class="prihlaska" enctype="multipart/form-data">
 
-<!----------------------------------------------------------------------------->
+  <!----------------------------------------------------------------------------->
 
-<div class="prihlaska_sekce">
-  <h2>Předměty</h2>
+  <div class="prihlaska_sekce">
+    <h2>Předměty</h2>
 
-  <div class="prihlaska_infoPruh">
-    <div class="prihlaska_info">
-      <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/hra.png" style="top: -40px; right: -19px">
-      <h3>GameCon merch</h3>
-      <p>Placek, kostek i triček s logem GameConu si můžeš objednat více. Stačí kliknout na tlačítko + nebo u triček vyplnit jedno a po potvrzení formuláře se ti nabídne položka pro výběr dalšího.<br>
-      <b>Výběr jde změnit do 30.6.</b></p>
-    </div>
-    <!-- begin: slevy -->
-    <div class="prihlaska_info prihlaska_info-ikona">
-      <p>Jako {titul} máš nárok na následující bonusy (pokud si je objednáš): {slevy}.</p>
-    </div>
-    <!-- end: slevy -->
-  </div>
-
-  {predmety}
-
-  <div class="prihlaska_nahledy">
-    <!-- begin: nahled -->
-    <a href="{obrazek}" class="prihlaska_nahled" title="{nazev}">
-      <img src="{miniatura}">
-    </a>
-    <!-- end: nahled -->
-  </div>
-</div>
-
-<!----------------------------------------------------------------------------->
-
-<div class="prihlaska_sekce">
-  <h2>Jídlo</h2>
-
-  <div class="prihlaska_infoPruh">
-    <div class="prihlaska_info">
-      <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/rum.png" style="top: -48px; right: -8px">
-      <h3>Informace ke stravování</h3>
-      <ul>
-        <li>Jídlo je možné objednat nebo zrušit do 11.7.</li>
-        <li>Na výběr je z 3–5 jídel, která jsou vždy stejná na oběd i večeři a jedno vegetariánské jídlo.</li>
-      </ul>
-    </div>
-  </div>
-
-  {jidlo}
-</div>
-
-<!----------------------------------------------------------------------------->
-
-<div class="prihlaska_sekce">
-  <h2>Ubytování</h2>
-
-  <div class="prihlaska_infoPruh">
-    <div class="prihlaska_info">
-      <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/mapa.png" style="top: -33px; right: -15px">
-      <h3>Informace k ubytování</h3>
-      <ul>
-        <li>Ubytování je možné objednat nebo zrušit do 11.7.</li>
-        <li>Čísla ukazují počet obsazených míst / celkem.</li>
-        <li>Ubytování je k dispozici od středy, program začíná ve <strong>čtvrtek</strong> v poledne.</li>
-        <li>Ubytování v neděli znamená noc z neděle na pondělí, kdy už neprobíhá program. V pondělí je potřeba pokoj vyklidit do 9:00.</li>
-      </ul>
-    </div>
-
-    <!-- begin: ubytovaniInfoVypravec -->
-    <div class="prihlaska_info prihlaska_info-ikona">
-      <p>Jako vypravěč{ka} máš na ubytování (i aktivity) slevu ve výši cca jeden nocleh+jídlo za dvě uspořádané aktivity. Její přesnou výšku najdeš po dokončení registrace ve svém finančním přehledu.</p>
-    </div>
-    <!-- end: ubytovaniInfoVypravec -->
-
-    <!-- begin: ubytovaniInfoOrg -->
-    <div class="prihlaska_info prihlaska_info-ikona">
-      <p>Jako organizátor{ka} máš veškeré ubytování také zdarma.</p>
-    </div>
-    <!-- end: ubytovaniInfoOrg -->
-  </div>
-
-  {ubytovani}
-</div>
-
-<!----------------------------------------------------------------------------->
-
-<!----------------------------------------------------------------------------->
-
-<div class="prihlaska_sekce">
-  <h2>Covid-19</h2>
-
-  <div class="prihlaska_infoPruh">
-    <div class="prihlaska_info">
-      <h3>Nutné potvrzení</h3>
+    <div class="prihlaska_infoPruh">
+      <div class="prihlaska_info">
+        <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/hra.png" style="top: -40px; right: -19px">
+        <h3>GameCon merch</h3>
+        <p>Placek, kostek i triček s logem GameConu si můžeš objednat více. Stačí kliknout na tlačítko + nebo u triček
+          vyplnit jedno a po potvrzení formuláře se ti nabídne položka pro výběr dalšího.<br>
+          <b>Výběr jde změnit do 30.6.</b></p>
+      </div>
+      <!-- begin: slevy -->
       <div class="prihlaska_info prihlaska_info-ikona">
-        Nejpozději na Infopultu, před vstupem na samotný GameCon, nám musíš prokázat splnění podmínek účasti, a to jedním ze tří možných typů potvrzení.
+        <p>Jako {titul} máš nárok na následující bonusy (pokud si je objednáš): {slevy}.</p>
+      </div>
+      <!-- end: slevy -->
+    </div>
+
+    {predmety}
+
+    <div class="prihlaska_nahledy">
+      <!-- begin: nahled -->
+      <a href="{obrazek}" class="prihlaska_nahled" title="{nazev}">
+        <img src="{miniatura}">
+      </a>
+      <!-- end: nahled -->
+    </div>
+  </div>
+
+  <!----------------------------------------------------------------------------->
+
+  <div class="prihlaska_sekce">
+    <h2>Jídlo</h2>
+
+    <div class="prihlaska_infoPruh">
+      <div class="prihlaska_info">
+        <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/rum.png" style="top: -48px; right: -8px">
+        <h3>Informace ke stravování</h3>
+        <ul>
+          <li>Jídlo je možné objednat nebo zrušit do 11.7.</li>
+          <li>Na výběr je z 3–5 jídel, která jsou vždy stejná na oběd i večeři a jedno vegetariánské jídlo.</li>
+        </ul>
       </div>
     </div>
+
+    {jidlo}
   </div>
 
-  {covidFreePotvrzeni}
-</div>
+  <!----------------------------------------------------------------------------->
 
-<!----------------------------------------------------------------------------->
+  <div class="prihlaska_sekce">
+    <h2>Ubytování</h2>
 
-<div class="prihlaska_sekceObal prihlaska_sekceObal-vstupne">
-<div class="prihlaska_sekce">
-  <div class="prihlaska_infoPruh">
-    <div class="prihlaska_info">
-      <h3>K čemu slouží vstupné</h3>
-      <p><b>Je spousta příjemných maličkostí, které by nám zpříjemnily organizaci a vám udělaly lepší GameCon. Již z minulého dobrovolného vstupného jsme pro tento rok zajistili:</b></p>
-      <ul>
-        <li>prodlouženou otevírací dobu deskoherny</li>
-        <li>koncert a improshow</li>
-        <li>několik odměn do soutěží a miniher</li>
-        <li>rekvizity pro hry</li>
-        <li>ventilátory pro epické hraní a wargaming</li>
-      </ul>
-      <p>To stejné a možná i něco navíc chceme zajistit i příští rok. Vašich příspěvků si moc vážíme a děkujeme za ně.</p>
+    <div class="prihlaska_infoPruh">
+      <div class="prihlaska_info">
+        <img class="prihlaska_infoSymbol" src="soubory/blackarrow/prihlaska/mapa.png" style="top: -33px; right: -15px">
+        <h3>Informace k ubytování</h3>
+        <ul>
+          <li>Ubytování je možné objednat nebo zrušit do 11.7.</li>
+          <li>Čísla ukazují počet obsazených míst / celkem.</li>
+          <li>Ubytování je k dispozici od středy, program začíná ve <strong>čtvrtek</strong> v poledne.</li>
+          <li>Ubytování v neděli znamená noc z neděle na pondělí, kdy už neprobíhá program. V pondělí je potřeba pokoj
+            vyklidit do 9:00.
+          </li>
+        </ul>
+      </div>
+
+      <!-- begin: ubytovaniInfoVypravec -->
+      <div class="prihlaska_info prihlaska_info-ikona">
+        <p>Jako vypravěč{ka} máš na ubytování (i aktivity) slevu ve výši cca jeden nocleh+jídlo za dvě uspořádané
+          aktivity. Její přesnou výšku najdeš po dokončení registrace ve svém finančním přehledu.</p>
+      </div>
+      <!-- end: ubytovaniInfoVypravec -->
+
+      <!-- begin: ubytovaniInfoOrg -->
+      <div class="prihlaska_info prihlaska_info-ikona">
+        <p>Jako organizátor{ka} máš veškeré ubytování také zdarma.</p>
+      </div>
+      <!-- end: ubytovaniInfoOrg -->
+    </div>
+
+    {ubytovani}
+  </div>
+
+  <!----------------------------------------------------------------------------->
+
+  <!----------------------------------------------------------------------------->
+
+  {covidSekce}
+
+  <!----------------------------------------------------------------------------->
+
+  <div class="prihlaska_sekceObal prihlaska_sekceObal-vstupne">
+    <div class="prihlaska_sekce">
+      <div class="prihlaska_infoPruh">
+        <div class="prihlaska_info">
+          <h3>K čemu slouží vstupné</h3>
+          <p><b>Je spousta příjemných maličkostí, které by nám zpříjemnily organizaci a vám udělaly lepší GameCon. Již z
+            minulého dobrovolného vstupného jsme pro tento rok zajistili:</b></p>
+          <ul>
+            <li>prodlouženou otevírací dobu deskoherny</li>
+            <li>koncert a improshow</li>
+            <li>několik odměn do soutěží a miniher</li>
+            <li>rekvizity pro hry</li>
+            <li>ventilátory pro epické hraní a wargaming</li>
+          </ul>
+          <p>To stejné a možná i něco navíc chceme zajistit i příští rok. Vašich příspěvků si moc vážíme a děkujeme za
+            ně.</p>
+        </div>
+      </div>
+
+      <h2>Dobrovolné vstupné</h2>
+
+      {vstupne}
     </div>
   </div>
 
-  <h2>Dobrovolné vstupné</h2>
+  <!----------------------------------------------------------------------------->
 
-  {vstupne}
-</div>
-</div>
+  <div class="prihlaska_sekce prihlaska_sekce-zapojit">
+    {pomoc}
+  </div>
 
-<!----------------------------------------------------------------------------->
+  <!----------------------------------------------------------------------------->
 
-<div class="prihlaska_sekce prihlaska_sekce-zapojit">
-  {pomoc}
-</div>
+  <div class="prihlaska_sekce">
+    <input type="submit" class="formular_primarni" name="prihlasitNeboUpravit" value="{ulozitNeboPrihlasit}">
+    <!-- begin:odhlasit -->
+    <input type="submit" class="formular_negativni" name="odhlasit" value="Odhlásit se z GameConu"
+           onclick="return confirm('Odhlášení z GameConu zruší všechny tvé registrace na aktivity a nákupy předmětů. Kliknutím na OK se odhlásíš.')">
+    <!-- end:odhlasit -->
+  </div>
 
-<!----------------------------------------------------------------------------->
-
-<div class="prihlaska_sekce">
-  <input type="submit" class="formular_primarni" name="prihlasitNeboUpravit" value="{ulozitNeboPrihlasit}">
-  <!-- begin:odhlasit -->
-  <input type="submit" class="formular_negativni" name="odhlasit" value="Odhlásit se z GameConu"
-    onclick="return confirm('Odhlášení z GameConu zruší všechny tvé registrace na aktivity a nákupy předmětů. Kliknutím na OK se odhlásíš.')">
-  <!-- end:odhlasit -->
-</div>
-
-<!----------------------------------------------------------------------------->
+  <!----------------------------------------------------------------------------->
 
 </form>
 
 <link rel="stylesheet" href="soubory/blackarrow/_spolecne/baguetteBox.min.css">
 <script src="soubory/blackarrow/_spolecne/baguetteBox.min.js"></script>
 <script>
-  baguetteBox.run('.prihlaska_nahledy');
+  baguetteBox.run('.prihlaska_nahledy')
 </script>
 
 <!-- end:prihlaska -->
 
 <!-- begin: prihlaskaPred -->
 <div class="prihlaska_hlavickaObal">
-<div class="prihlaska_hlavicka">
-  <h1>Přihláška na GameCon</h1>
+  <div class="prihlaska_hlavicka">
+    <h1>Přihláška na GameCon</h1>
 
-  <p>Přihlašování na GameCon bude spuštěno {zacatek}.</p>
-</div>
+    <p>Přihlašování na GameCon bude spuštěno {zacatek}.</p>
+  </div>
 </div>
 <!-- end: prihlaskaPred -->
 
 <!-- begin: prihlaskaPo -->
 <div class="prihlaska_hlavickaObal">
-<div class="prihlaska_hlavicka">
-  <h1>Přihláška na GameCon</h1>
+  <div class="prihlaska_hlavicka">
+    <h1>Přihláška na GameCon</h1>
 
-  <p>GameCon už proběhl, těšíme se na viděnou v roce {rok}.</p>
-</div>
+    <p>GameCon už proběhl, těšíme se na viděnou v roce {rok}.</p>
+  </div>
 </div>
 <!-- end: prihlaskaPo -->
 
 <!-- begin: prihlaskaGcBezi -->
 <div class="prihlaska_hlavickaObal">
-<div class="prihlaska_hlavicka">
-  <h1>Přihláška na GameCon</h1>
+  <div class="prihlaska_hlavicka">
+    <h1>Přihláška na GameCon</h1>
 
-  <p>Registrace přes internet jsou ukončeny, <strong>registrovat se můžeš přímo na místě na infopultu</strong>. Upravit si program a vybrat aktivity můžeš tamtéž.</p>
+    <p>Registrace přes internet jsou ukončeny, <strong>registrovat se můžeš přímo na místě na infopultu</strong>.
+      Upravit si program a vybrat aktivity můžeš tamtéž.</p>
+  </div>
 </div>
-</div>
+
+<!-- begin: covidSekce -->
+<form method="post" class="prihlaska" enctype="multipart/form-data">
+  <!-- begin: doklad -->
+  {covidSekce}
+  <!-- end: doklad -->
+  <!-- begin: submit -->
+  <div class="prihlaska_sekce">
+    <input type="submit" class="formular_primarni" name="pridatPotvrzeniProtiCovidu" value="Nahrát potvrzení">
+  </div>
+  <!-- end: submit -->
+</form>
+<!-- end: covidSekce -->
+
 <!-- end: prihlaskaGcBezi -->


### PR DESCRIPTION
https://trello.com/c/fDNehQ71/874-mo%C5%BEnost-nahr%C3%A1t-potvrzen%C3%AD-o-testu-do-p%C5%99ihl%C3%A1%C5%A1ky

Přihláška se po začátku Gameconu zamkne, takže by pak nešlo ani nahrávat potvrzení proti Covidu. Od teď to potvrzení bude možné nahrávat a měnit i po začátku Gameconu (dokud ho Infopult nezkontroluje).