### PR TITLE
884: Stahovat platby z Fio pro spárování podle VS až třicet dní zpět

### DIFF
--- a/model/platby.php
+++ b/model/platby.php
@@ -3,7 +3,7 @@
 class Platby
 {
 
-    public const DNI_ZPET = 7; // kolik dní zpět se mají načítat platby při kontrole nově došlých plateb
+    public const DNI_ZPET = 14; // kolik dní zpět se mají načítat platby při kontrole nově došlých plateb
 
     /**
      * Načte a uloží nové platby z FIO, vrátí zaúčtované platby


### PR DESCRIPTION
https://trello.com/c/zsb8bCet/884-nepropsan%C3%A1-platba-do-adminu

I letos se stalo, že jedna platba ani po týdnu nebyla propsána do Gameconu. Ruční spuštění synchronizace s rozšířeným záběrem synchronizovaných dní ale platbu stáhlo. Zřejmě tedy jeden týden zpětně nestačí.