### PR TITLE
Titulka zobrazuje datum Gameconu včetně roku

### DIFF
--- a/web/moduly/titulka.php
+++ b/web/moduly/titulka.php
@@ -55,8 +55,12 @@ if (pred(REG_GC_OD)) {
   $t->parse('titulka.odpocetPrihlasit');
 }
 
+$zacatekGameconu = \Gamecon\Cas\DateTimeGamecon::zacatekGameconu();
+$konecGameconu = \Gamecon\Cas\DateTimeGamecon::konecGameconu();
+
 // ostatní
 $t->assign([
-  'gcOd' => (new DateTimeCz(GC_BEZI_OD))->format('j. n.'),
-  'gcDo' => (new DateTimeCz(GC_BEZI_DO))->format('j. n.'),
+  'gcOd' => $zacatekGameconu->format('j.'),
+  'gcDo' => $konecGameconu->format('j. n.'),
+  'gcRok' => $konecGameconu->format('Y'),
 ]);

--- a/web/sablony/blackarrow/titulka.xtpl
+++ b/web/sablony/blackarrow/titulka.xtpl
@@ -28,7 +28,7 @@
     <div class="p p3" data-aos="zoom-out" data-aos-delay="550" data-aos-offset="0">C</div>
     <div class="p p4" data-aos="zoom-out" data-aos-delay="600" data-aos-offset="0">ON</div>
     <div class="gchlavicka_claim" data-aos="zoom-out">Největší festival nepočítačových her</div>
-    <div class="gchlavicka_datum">{gcOd} &ndash; {gcDo}</div>
+    <div class="gchlavicka_datum">{gcOd} &ndash; {gcDo} <span class="gchlavicka_rok">{gcRok}</span></div>
     <div class="gchlavicka_misto" data-aos="zoom-out">P A R D U B I C E</div>
     <a class="gchlavicka_video" href="https://www.youtube.com/watch?v=-SBu7WGPkO4" target="_blank" data-aos="zoom-out" data-aos-offset="-200">přehrát video</a>
 </div>

--- a/web/soubory/blackarrow/gchlavicka/gchlavicka.less
+++ b/web/soubory/blackarrow/gchlavicka/gchlavicka.less
@@ -71,8 +71,8 @@
     background: url('../blackarrow/gchlavicka/smouha.png');
     background-size: cover;
     position: absolute;
-    width: 330rel;
-    padding: 15rel 0 15rel 50rel;
+    width: 350rel;
+    padding: 20rel 0 15rel 30rel;
     box-sizing: border-box;
     bottom: 32%;
     left: 61.7%;
@@ -81,6 +81,8 @@
         bottom: unset;
         left: 118.3/3.2vw;
     }
+    letter-spacing: -1px;
+    word-spacing: -2px;
 }
 
 .gchlavicka_misto {


### PR DESCRIPTION
https://trello.com/c/WwMmnO6l/902-zm%C4%9Bnit-form%C3%A1t-data-na-webu

Uživatele ten náš bordel se začátkem Gameconu mate. Přidáme zatím aspoň na titulku rok, pro který to datum platí.