### PR TITLE
submenu pomoci CSS zobrazi custom-text Prehled aktivit namisto Aktivity

### DIFF
--- a/admin/files/design/styl.css
+++ b/admin/files/design/styl.css
@@ -123,39 +123,6 @@ body {
   position: relative;
 }
 
-#submenu .adm_submenu_item a[href='aktivity']::after {
-  content: 'Přehled aktivit';
-  display: block;
-  cursor: pointer;
-  color: #333;
-  left: 0;
-  top: 0px;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  padding-top: inherit;
-  padding-bottom: inherit;
-  padding-left: inherit;
-  padding-right: inherit;
-  text-align: center;
-}
-
-#submenu .adm_submenu_item a[href='aktivity']::before {
-  content: 'Přehled';
-  display: inline-block;
-  color: transparent;
-}
-
-
-#submenu .adm_submenu_item a[href='aktivity'], #submenu .adm_submenu_item a[href='aktivity']:hover {
-  color: transparent;
-}
-
-#submenu .adm_submenu_item a[href='aktivity']:hover::after {
-  color: #000;
-  text-decoration: underline;
-}
-
 #submenu .adm_submenu_item a.activeSubmenuLink {
   background: #FFF;
   border-color: hsl(98, 23%, 75%);

--- a/admin/files/design/styl.css
+++ b/admin/files/design/styl.css
@@ -330,7 +330,7 @@ li.list-header { list-style-type: none; position: relative; left: -1em }
 
 /* pro automaticky generované chybové hlášky */
 .chybaBlok { position: fixed; box-sizing: border-box;
-  width: 80%; left: 10%; top: 55px;
+  width: 80%; left: 10%; top: 25px;
   text-align: center; z-index: 99;
 }
 .chybaBlok .hlaska { padding: 28px; margin: 5px 0; box-shadow: 0 0 10px ; font-size: 20px; }

--- a/admin/files/design/styl.css
+++ b/admin/files/design/styl.css
@@ -120,12 +120,46 @@ body {
   border: 1px solid #7B936D;
   font-size: 100%;
   line-height: 100%;
+  position: relative;
 }
+
+#submenu .adm_submenu_item a[href='aktivity']::after {
+  content: 'Přehled aktivit';
+  display: block;
+  cursor: pointer;
+  color: #333;
+  left: 0;
+  top: 0px;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  padding-top: inherit;
+  padding-bottom: inherit;
+  padding-left: inherit;
+  padding-right: inherit;
+  text-align: center;
+}
+
+#submenu .adm_submenu_item a[href='aktivity']::before {
+  content: 'Přehled';
+  display: inline-block;
+  color: transparent;
+}
+
+
+#submenu .adm_submenu_item a[href='aktivity'], #submenu .adm_submenu_item a[href='aktivity']:hover {
+  color: transparent;
+}
+
+#submenu .adm_submenu_item a[href='aktivity']:hover::after {
+  color: #000;
+  text-decoration: underline;
+}
+
 #submenu .adm_submenu_item a.activeSubmenuLink {
   background: #FFF;
   border-color: hsl(98, 23%, 75%);
   text-decoration: underline;
-  font-size: 100%;
 }
 
 #submenu .adm_submenu_item a:hover {
@@ -182,6 +216,7 @@ body {
   font-size: 110%;
   text-decoration: none;
   width: 100%;
+  white-space: normal;
   padding: 6px 5px 6px;
   text-align: center;
   color: #fff;

--- a/admin/index.php
+++ b/admin/index.php
@@ -17,10 +17,11 @@ require __DIR__ . '/scripts/prihlaseni.php';
  * @var Uzivatel|void|null $uPracovni
  */
 
+$pageTitle = 'GameCon – Administrace';
 // xtemplate inicializace
 $xtpl = new XTemplate(__DIR__ . '/templates/main.xtpl');
 $xtpl->assign([
-    'pageTitle' => 'GameCon – Administrace',
+    'pageTitle' => $pageTitle,
     'base' => URL_ADMIN . '/',
     'cssVersions' => new \Gamecon\Web\VerzeSouboru(__DIR__ . '/files/design', 'css'),
 ]);
@@ -155,6 +156,7 @@ if (!$u && !in_array($stranka, ['last-minute-tabule', 'program-obecny'])) {
             }
             if (($podstranka != '' && $podstranka == $url) || ($podstranka == '' && $stranka == $url)) {
                 $addAttributes[] = 'class="activeSubmenuLink"';
+                $pageTitle = $pageTitle . ' | ' . $polozka['nazev'];
             }
             $xtpl->assign('add_attributes', implode(' ', $addAttributes));
 
@@ -177,6 +179,7 @@ if (!$u && !in_array($stranka, ['last-minute-tabule', 'program-obecny'])) {
     $xtpl->parse('all.paticka');
     $xtpl->assign('chyba', chyba::vyzvedniHtml());
     $xtpl->assign('jsVyjimkovac', \Gamecon\Vyjimkovac\Vyjimkovac::js(URL_WEBU . '/ajax-vyjimkovac'));
+    $xtpl->assign('pageTitle', $pageTitle);
     $xtpl->parse('all');
     $xtpl->out('all');
     profilInfo();

--- a/admin/index.php
+++ b/admin/index.php
@@ -77,6 +77,7 @@ if (!$u && !in_array($stranka, ['last-minute-tabule', 'program-obecny'])) {
         } else {
             chdir('./scripts/modules/');
             $soubor = $cwd . '/' . $menu[$stranka]['soubor'];
+            $pageTitle .= ' | ' . $menu[$stranka]['nazev'];
         }
         ob_start(); // výstup uložíme do bufferu
         require $soubor;

--- a/admin/scripts/admin-menu.php
+++ b/admin/scripts/admin-menu.php
@@ -71,6 +71,8 @@ class AdminMenu
         $this->menu[$url]['group'] = (int)($m[1] ?? 0);
         preg_match('@\* submenu_order: (.*)@', $fc, $m);
         $this->menu[$url]['order'] = (int)($m[1] ?? 0);
+        preg_match('@\* submenu_nazev: (.*)@', $fc, $m);
+        $this->menu[$url]['nazev'] = ($m[1] ?? $this->menu[$url]['nazev']);
         preg_match('@\* submenu_link_open_in_blank: (.*)@', $fc, $m);
         $this->menu[$url]['link_in_blank'] = (bool)($m[1] ?? false);
     }

--- a/admin/scripts/modules/aktivity/aktivity.php
+++ b/admin/scripts/modules/aktivity/aktivity.php
@@ -7,6 +7,7 @@
  * pravo: 102
  * submenu_group: 1
  * submenu_order: 3
+ * submenu_nazev: Přehled Aktivit
  */
 
 if (post('smazat')) {

--- a/admin/scripts/modules/aktivity/aktivity.php
+++ b/admin/scripts/modules/aktivity/aktivity.php
@@ -3,7 +3,7 @@
 /**
  * Stránka pro tvorbu a správu aktivit.
  *
- * nazev: Přehled aktivit
+ * nazev: Aktivity
  * pravo: 102
  * submenu_group: 1
  * submenu_order: 3

--- a/admin/templates/prihlaseni.xtpl
+++ b/admin/templates/prihlaseni.xtpl
@@ -3,7 +3,7 @@ Přihlášení<br><br>
 <table>
 <tr>
   <td>Jméno:</td>
-  <td><input type="text" name="loginNAdm"></td>
+  <td><input type="text" name="loginNAdm" autofocus></td>
 </tr>
 <tr>
   <td>Heslo:</td>


### PR DESCRIPTION
Aby měla Cemi radost, že v levém hlavním menu Adminu je Aktivity, ale v submenu je pak položka nazvaná jako Přehled aktivit... trochu kouzlení s CSS

<img width="511" alt="neni-title-jako-title" src="https://user-images.githubusercontent.com/136198/162303658-02895710-7082-4678-872b-4a2030887da3.png">

