### PR TITLE
926: Oprava vypočteného bonusu za hodinovou aktivitu

### DIFF
--- a/model/SystemoveNastaveni/SystemoveNastaveni.php
+++ b/model/SystemoveNastaveni/SystemoveNastaveni.php
@@ -161,7 +161,7 @@ SQL;
     ): int {
         switch ($klic) {
             case 'BONUS_ZA_1H_AKTIVITU' :
-                return (int)($bonusZaStandardni3hAz5hAktivitu / 3);
+                return (int)($bonusZaStandardni3hAz5hAktivitu / 4);
             case 'BONUS_ZA_2H_AKTIVITU' :
                 return (int)($bonusZaStandardni3hAz5hAktivitu / 2);
             case 'BONUS_ZA_6H_AZ_7H_AKTIVITU' :


### PR DESCRIPTION
https://trello.com/c/jtDu0OoQ/926-zm%C4%9Bny-bonus%C5%AF#comment-

Jelikož 280 / 3 není chtěných 70, ale nechtěných 93...

Oprava bonusu vypravěče za hodinovou aktivitu.