### PR TITLE
Fix: $referrerHost neobsahuje číslo portu HTTP_HOST ano

### DIFF
--- a/model/funkce/funkce.php
+++ b/model/funkce/funkce.php
@@ -187,7 +187,7 @@ function omezCsrf() {
     }
     $referrerHost = parse_url($_SERVER['HTTP_REFERER'] ?? null, PHP_URL_HOST);
 
-    if ($referrerHost !== $_SERVER['HTTP_HOST'] && $referrerHost !== parse_url(URL_ADMIN, PHP_URL_HOST)) {
+    if ($referrerHost !== $_SERVER['SERVER_NAME'] && $referrerHost !== parse_url(URL_ADMIN, PHP_URL_HOST)) {
         // výjimka, aby došlo k zalogování
         throw new Exception(
             "Referrer POST '$referrerHost' požadavku neodpovídá doméně '{$_SERVER['HTTP_HOST']}' ani '" . PHP_URL_HOST . "'"

--- a/model/funkce/funkce.php
+++ b/model/funkce/funkce.php
@@ -190,7 +190,7 @@ function omezCsrf() {
     if ($referrerHost !== $_SERVER['SERVER_NAME'] && $referrerHost !== parse_url(URL_ADMIN, PHP_URL_HOST)) {
         // výjimka, aby došlo k zalogování
         throw new Exception(
-            "Referrer POST '$referrerHost' požadavku neodpovídá doméně '{$_SERVER['HTTP_HOST']}' ani '" . PHP_URL_HOST . "'"
+            "Referrer POST '$referrerHost' požadavku neodpovídá doméně '{$_SERVER['SERVER_NAME']}' ani '" . PHP_URL_HOST . "'"
         );
     }
 }


### PR DESCRIPTION
Vyměnit HTTP_HOST za SERVER_NAME, který je vždy bez portu, jinak
nefunguje validní POST požadavek s portem v adrese.