### PR TITLE
578: Zálohuj databázi do definované složky a s rozumným jménem

### DIFF
--- a/admin/cron.php
+++ b/admin/cron.php
@@ -65,21 +65,15 @@ logs("Odemčeno $i aktivit.");
 
 
 if(date('G') == 5) { // 5 hodin ráno
-  logs('Zálohuji databázi na FTP.');
+  logs('Zálohuji databázi.');
 
-  if(!defined('FTP_ZALOHA_DB'))
-    throw new Exception('Není definována konstanta s adresou serveru pro zálohování.');
+  if(!defined('ZALOHA_DB_SLOZKA'))
+    throw new Exception('Není definována konstanta s adresářem pro zálohování.');
 
-  $backup = new Godric\DbBackup\DbBackup([
-    'sourceDb'  =>  [
-      'server'    =>  DB_SERV,
-      'user'      =>  DB_USER,
-      'password'  =>  DB_PASS,
-      'database'  =>  DB_NAME,
-    ],
-    'targetFtp' =>  FTP_ZALOHA_DB,
-  ]);
-  $backup->run();
+  $db = dbConnect();
+  $dump = new MySQLDump($db);
+  $time = date('Y-m-d_His');
+  $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
 
   logs('Záloha dokončena.');
 }

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -72,6 +72,16 @@ if (date('G') == 5) { // 5 hodin ráno
         && !is_dir(ZALOHA_DB_SLOZKA)
     ) {
         $chybaZalohovaniDb = "Nelze vytvořit adresář pro zálohování '" . ZALOHA_DB_SLOZKA . "': " . implode("\n", (array)error_get_last());
+    } else {
+        try {
+            $dump = new MySQLDump(dbConnect());
+            $time = date('Y-m-d_His');
+            $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
+            logs('záloha databáze dokončena.');
+        } catch (\Throwable $throwable) {
+            $chybaZalohovaniDb = 'Uložení zálohy na disk selhalo';
+            logs('Error při ukládání zálohy DB: ' . $throwable->getMessage() . '; ' . $throwable->getTraceAsString());
+        }
     }
     if ($chybaZalohovaniDb) {
         logs($chybaZalohovaniDb);
@@ -81,10 +91,6 @@ if (date('G') == 5) { // 5 hodin ráno
             ->text($chybaZalohovaniDb)
             ->odeslat();
     }
-    $dump = new MySQLDump(dbConnect());
-    $time = date('Y-m-d_His');
-    $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
-    logs('záloha databáze dokončena.');
 }
 
 logs('Cron dokončen.');

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -17,66 +17,74 @@ $vyjimkovac->zobrazeni(\Gamecon\Vyjimkovac\Vyjimkovac::PLAIN);
  * Výstup do logu
  */
 function logs($s) {
-  echo date('Y-m-d H:i:s ') . $s . "\n";
+    echo date('Y-m-d H:i:s ') . $s . "\n";
 }
 
 /////////////////////////////////// příprava ///////////////////////////////////
 
 // otestovat, že je skript volán s heslem a sprvánou url
-if(HTTPS_ONLY) httpsOnly();
-if(!defined('CRON_KEY') || get('key') !== CRON_KEY)
-  die('špatný klíč');
+if (HTTPS_ONLY) httpsOnly();
+if (!defined('CRON_KEY') || get('key') !== CRON_KEY)
+    die('špatný klíč');
 
 // otevřít log soubor pro zápis a přesměrovat do něj výstup
-$logdir  = SPEC . '/logs';
+$logdir = SPEC . '/logs';
 $logfile = 'cron-' . date('Y-m') . '.log';
-if(!is_dir($logdir))
-  mkdir($logdir);
+if (!is_dir($logdir))
+    mkdir($logdir);
 $logdescriptor = fopen($logdir . '/' . $logfile, 'ab');
-ob_start(function($string)use($logdescriptor) {
-  fwrite($logdescriptor, $string . "\n");
-  fclose($logdescriptor);
+ob_start(function ($string) use ($logdescriptor) {
+    fwrite($logdescriptor, $string . "\n");
+    fclose($logdescriptor);
 });
 
 // zapnout zobrazení chyb
-ini_set('display_errors',   true); // zobrazovat chyby obecně
-ini_set('error_reporting',  E_ALL ^ E_STRICT); // vybrat typy chyb k zobrazení
-ini_set('html_errors',      false); // chyby zobrazovat jako plaintext
+ini_set('display_errors', true); // zobrazovat chyby obecně
+ini_set('error_reporting', E_ALL ^ E_STRICT); // vybrat typy chyb k zobrazení
+ini_set('html_errors', false); // chyby zobrazovat jako plaintext
 
 /////////////////////////////////// cron kód ///////////////////////////////////
 
 logs('Začínám provádět cron script.');
 
 if (defined('FIO_TOKEN') && FIO_TOKEN !== '') {
-  logs('Zpracovávám nové platby přes Fio API.');
-  $platby = Platby::nactiNove();
-  foreach($platby as $p) {
-    logs('platba ' . $p->id() . ' (' . $p->castka() . 'Kč, VS: ' . $p->vs() . ($p->zprava() ? ', zpráva: ' . $p->zprava() : '') . ')');
-  }
-  if(!$platby) logs('Žádné zaúčtovatelné platby.');
-}
-else {
-  logs('FIO_TOKEN není definován, přeskakuji nové platby.');
+    logs('Zpracovávám nové platby přes Fio API.');
+    $platby = Platby::nactiNove();
+    foreach ($platby as $p) {
+        logs('platba ' . $p->id() . ' (' . $p->castka() . 'Kč, VS: ' . $p->vs() . ($p->zprava() ? ', zpráva: ' . $p->zprava() : '') . ')');
+    }
+    if (!$platby) logs('Žádné zaúčtovatelné platby.');
+} else {
+    logs('FIO_TOKEN není definován, přeskakuji nové platby.');
 }
 
 logs('Odemykám zamčené aktivity.');
 $i = Aktivita::odemciHromadne();
 logs("Odemčeno $i aktivit.");
 
-
-if(date('G') == 5) { // 5 hodin ráno
-  logs('Zálohuji databázi.');
-
-  if(!defined('ZALOHA_DB_SLOZKA') || !ZALOHA_DB_SLOZKA) {
-      logs('Není definována konstanta s adresářem pro zálohování.');
-  } else {
-      $db = dbConnect();
-      $dump = new MySQLDump($db);
-      $time = date('Y-m-d_His');
-      $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
-      logs('Záloha databáze dokončena.');
-  }
+if (date('G') == 5) { // 5 hodin ráno
+    logs('Zálohuji databázi...');
+    $chybaZalohovaniDb = null;
+    if (!defined('ZALOHA_DB_SLOZKA') || !ZALOHA_DB_SLOZKA) {
+        $chybaZalohovaniDb = 'Není definována konstanta s adresářem pro zálohování ZALOHA_DB_SLOZKA.';
+    } elseif (!is_dir(ZALOHA_DB_SLOZKA)
+        && !@mkdir(ZALOHA_DB_SLOZKA, 0750, true)
+        && !is_dir(ZALOHA_DB_SLOZKA)
+    ) {
+        $chybaZalohovaniDb = "Nelze vytvořit adresář pro zálohování '" . ZALOHA_DB_SLOZKA . "': " . implode("\n", (array)error_get_last());
+    }
+    if ($chybaZalohovaniDb) {
+        logs($chybaZalohovaniDb);
+        (new GcMail)
+            ->adresat('info@gamecon.cz')
+            ->predmet('Neproběhla záloha databáze ' . date(\Gamecon\Cas\DateTimeCz::FORMAT_DB))
+            ->text($chybaZalohovaniDb)
+            ->odeslat();
+    }
+    $dump = new MySQLDump(dbConnect());
+    $time = date('Y-m-d_His');
+    $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
+    logs('záloha databáze dokončena.');
 }
-
 
 logs('Cron dokončen.');

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -67,15 +67,15 @@ logs("Odemčeno $i aktivit.");
 if(date('G') == 5) { // 5 hodin ráno
   logs('Zálohuji databázi.');
 
-  if(!defined('ZALOHA_DB_SLOZKA'))
-    throw new Exception('Není definována konstanta s adresářem pro zálohování.');
-
-  $db = dbConnect();
-  $dump = new MySQLDump($db);
-  $time = date('Y-m-d_His');
-  $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
-
-  logs('Záloha dokončena.');
+  if(!defined('ZALOHA_DB_SLOZKA') || !ZALOHA_DB_SLOZKA) {
+      logs('Není definována konstanta s adresářem pro zálohování.');
+  } else {
+      $db = dbConnect();
+      $dump = new MySQLDump($db);
+      $time = date('Y-m-d_His');
+      $dump->save(ZALOHA_DB_SLOZKA . "/export_$time.sql.gz");
+      logs('Záloha databáze dokončena.');
+  }
 }
 
 

--- a/backup/db/.gitignore
+++ b/backup/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -33,7 +33,6 @@ $baseUrl = (($_SERVER['HTTPS'] ?? 'off') === 'on' ? 'https' : 'http') . '://' . 
 @define('CRON_KEY', '123');
 @define('UNIVERZALNI_HESLO', ''); // obejití zadávání hesla pro vývojové prostředí
 @define('FIO_TOKEN', '123456'); // přístup k api fio banky pro načítání plateb
-@define('ZALOHA_DB_SLOZKA', __DIR__ . '/../cache/private'); // cesta pro zálohy databáze
 @define('MAILY_DO_SOUBORU', __DIR__ . '/../cache/private/maily.log');
 @define('AUTOMATICKE_MIGRACE', true);
 @define('AUTOMATICKA_TVORBA_DB', true);

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -33,7 +33,7 @@ $baseUrl = (($_SERVER['HTTPS'] ?? 'off') === 'on' ? 'https' : 'http') . '://' . 
 @define('CRON_KEY', '123');
 @define('UNIVERZALNI_HESLO', ''); // obejití zadávání hesla pro vývojové prostředí
 @define('FIO_TOKEN', '123456'); // přístup k api fio banky pro načítání plateb
-@define('FTP_ZALOHA_DB', 'ftp://user:password@server/directory'); // FTP pro zálohy databáze
+@define('ZALOHA_DB_SLOZKA', __DIR__ . '/../cache/private'); // cesta pro zálohy databáze
 @define('MAILY_DO_SOUBORU', __DIR__ . '/../cache/private/maily.log');
 @define('AUTOMATICKE_MIGRACE', true);
 @define('AUTOMATICKA_TVORBA_DB', true);

--- a/nastaveni/nastaveni-local-docker_default.php
+++ b/nastaveni/nastaveni-local-docker_default.php
@@ -31,7 +31,6 @@ define('SECRET_CRYPTO_KEY', 'def0000066cba9ae32fdda839a143276cc0646b3880920c9387
 define('CRON_KEY', '123');
 define('UNIVERZALNI_HESLO', 'heslo123'); // obejití zadávání hesla pro vývojové prostředí
 define('FIO_TOKEN', '123456'); // přístup k api fio banky pro načítání plateb
-define('ZALOHA_DB_SLOZKA', __DIR__ . '/../cache/private'); // cesta pro zálohy databáze
 define('MAILY_DO_SOUBORU', __DIR__ . '/../cache/private/maily.log');
 define('AUTOMATICKE_MIGRACE', true);
 define('PROFILOVACI_LISTA', true);

--- a/nastaveni/nastaveni-local-docker_default.php
+++ b/nastaveni/nastaveni-local-docker_default.php
@@ -31,7 +31,7 @@ define('SECRET_CRYPTO_KEY', 'def0000066cba9ae32fdda839a143276cc0646b3880920c9387
 define('CRON_KEY', '123');
 define('UNIVERZALNI_HESLO', 'heslo123'); // obejití zadávání hesla pro vývojové prostředí
 define('FIO_TOKEN', '123456'); // přístup k api fio banky pro načítání plateb
-define('FTP_ZALOHA_DB', 'ftp://user:password@server/directory'); // FTP pro zálohy databáze
+define('ZALOHA_DB_SLOZKA', __DIR__ . '/../cache/private'); // cesta pro zálohy databáze
 define('MAILY_DO_SOUBORU', __DIR__ . '/../cache/private/maily.log');
 define('AUTOMATICKE_MIGRACE', true);
 define('PROFILOVACI_LISTA', true);

--- a/nastaveni/nastaveni.php
+++ b/nastaveni/nastaveni.php
@@ -243,6 +243,6 @@ Organizační tým GameConu',
 define('SUPERADMINI', [1682, 4032]);
 
 @define('ADRESAR_WEBU_S_OBRAZKY', __DIR__ . '/../web');
-@define('ZALOHA_DB_SLOZKA', __DIR__ . '../backup/db'); // cesta pro zálohy databáze
+@define('ZALOHA_DB_SLOZKA', __DIR__ . '/../backup/db'); // cesta pro zálohy databáze
 
 @define('PRODEJ_JIDLA_POZASTAVEN', false);

--- a/nastaveni/nastaveni.php
+++ b/nastaveni/nastaveni.php
@@ -243,5 +243,6 @@ Organizační tým GameConu',
 define('SUPERADMINI', [1682, 4032]);
 
 @define('ADRESAR_WEBU_S_OBRAZKY', __DIR__ . '/../web');
+@define('ZALOHA_DB_SLOZKA', __DIR__ . '../backup/db'); // cesta pro zálohy databáze
 
 @define('PRODEJ_JIDLA_POZASTAVEN', false);


### PR DESCRIPTION
Kopírování na FTP stejně nefunguje, takže lze vypustit FTP modul. Zálohy
nejsou pojmenované náhodným jménem, ale dle času, aby se daly později
rozumně použít. Složku pro ukládání záloh je nutné nastavit konstantou.

Pro správnou funkci cronu je potřeba nastavit `ZALOHA_DB_SLOZKA`,
konstanta `FTP_ZALOHA_DB` se stala zbytečnou.