### PR TITLE
286: Při překlápění ročníku převádíme zůstatky všem i když nedorazili na GC

### DIFF
--- a/admin/scripts/zvlastni/reporty/update-zustatku.php
+++ b/admin/scripts/zvlastni/reporty/update-zustatku.php
@@ -10,20 +10,14 @@
 
 require_once __DIR__ . '/sdilene-hlavicky.php';
 
-$uzivateleQuery = dbQuery('
-  SELECT u.*
-  FROM r_uzivatele_zidle z
-  JOIN uzivatele_hodnoty u USING(id_uzivatele)
-  WHERE z.id_zidle=' . ZIDLE_PRIHLASEN);
-$poradi = 0;
 $sqlNaPrepocetZustatku = [];
-while ($uzivatelData = mysqli_fetch_assoc($uzivateleQuery)) {
-    $uzivatel = new Uzivatel($uzivatelData);
-    $uzivatel->nactiPrava(); //sql subdotaz, zlo
-    $sqlNaPrepocetZustatku[] = <<<SQL
-UPDATE uzivatele_hodnoty SET zustatek={$uzivatel->finance()->stav()}, poznamka='' WHERE id_uzivatele={$uzivatel->id()}
+foreach (Uzivatel::vsichni() as $uzivatel) {
+    $finance = $uzivatel->finance();
+    if ($finance->zustatekZPredchozichRocniku() != $uzivatel->finance()->stav()) {
+        $sqlNaPrepocetZustatku[] = <<<SQL
+UPDATE uzivatele_hodnoty SET zustatek={$uzivatel->finance()->stav()} /* původní zůstatek z předchozích ročníků {$finance->zustatekZPredchozichRocniku()} */, poznamka='' WHERE id_uzivatele={$uzivatel->id()};
 SQL;
-    $poradi++;
+    }
 }
 
 ?>

--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -395,10 +395,7 @@ SQL
     }
 
     public function maPravo($pravo) {
-        if (!isset($this->u['prava'])) {
-            $this->nactiPrava();
-        }
-        return in_array($pravo, $this->u['prava']);
+        return in_array($pravo, $this->prava());
     }
 
     public function nemaPravoNaBonusZaVedeniAktivit(): bool {
@@ -512,6 +509,13 @@ SQL
                 $prava[] = (int)$r['id_prava'];
             $this->u['prava'] = $prava;
         }
+    }
+
+    public function prava(): array {
+        if (!isset($this->u['prava'])) {
+            $this->nactiPrava();
+        }
+        return $this->u['prava'];
     }
 
     /** Vrátí přezdívku (nickname) uživatele */


### PR DESCRIPTION
https://trello.com/c/d7D6GeD1/286-odhl%C3%A1%C5%A1en%C3%AD-z-gc-p%C5%99evod-pen%C4%9Bz-do-dal%C5%A1%C3%ADho-ro%C4%8Dn%C3%ADku

Stává se, že si někdo pošle peníze na GC, pak včas ohlásí, že nemůže a my ho z GC odhlásíme. Jenže to provedeme tak, že mu sebereme roli "Přihlášen na GC rok XY". A při překlápění ročníku jsme tyto přeskakovali, takže jim finance zmizely.