### PR TITLE
Povolit mazání aktivity s nedorazivšími

### DIFF
--- a/migrace/2022-06-14-upravit-cizi-klic-aby-slo-smazat-aktivitu.php
+++ b/migrace/2022-06-14-upravit-cizi-klic-aby-slo-smazat-aktivitu.php
@@ -1,0 +1,14 @@
+<?php
+/** @var \Godric\DbMigrations\Migration $this */
+
+$this->q(<<<SQL
+ALTER TABLE akce_prihlaseni_spec
+  DROP FOREIGN KEY `akce_prihlaseni_spec_ibfk_1`
+SQL
+);
+
+$this->q(<<<SQL
+ALTER TABLE akce_prihlaseni_spec
+   ADD FOREIGN KEY (`id_akce`) REFERENCES `akce_seznam` (`id_akce`) ON UPDATE CASCADE ON DELETE CASCADE
+SQL
+);


### PR DESCRIPTION
Aby šlo smazat aktivitu, u které máme záznam, že byl někdo přihlášen, ale nedorazil,

```
Cannot delete or update a parent row: a foreign key constraint fails (`akce_prihlaseni_spec`, CONSTRAINT `akce_prihlaseni_spec_ibfk_1` FOREIGN KEY (`id_akce`) REFERENCES `akce_seznam` (`id_akce`)) caused by DELETE FROM akce_seznam WHERE id_akce = 4410
```