### PR TITLE
876: Statistiky právě probíhajícího ročníku jsou protaženy až do konce GC

### DIFF
--- a/admin/scripts/modules/nastaveni/nastaveni.php
+++ b/admin/scripts/modules/nastaveni/nastaveni.php
@@ -11,11 +11,11 @@ use Gamecon\SystemoveNastaveni\SystemoveNastaveniHtml;
 
 /**
  * @var Uzivatel $u
+ * @var SystemoveNastaveni $systemoveNastaveni
  */
 
-$nastaveni = SystemoveNastaveni::vytvorZGlobalnich();
-$nastaveniHtml = new SystemoveNastaveniHtml($nastaveni);
-$nastaveniAjax = new SystemoveNastaveniAjax($nastaveni, $nastaveniHtml, $u);
+$nastaveniHtml = new SystemoveNastaveniHtml($systemoveNastaveni);
+$nastaveniAjax = new SystemoveNastaveniAjax($systemoveNastaveni, $nastaveniHtml, $u);
 
 if ($nastaveniAjax->zpracujPost()) {
     exit;

--- a/admin/scripts/modules/statistiky.php
+++ b/admin/scripts/modules/statistiky.php
@@ -7,7 +7,13 @@
  * pravo: 107
  */
 
+/**
+ * @var $u Uzivatel
+ * @var $systemoveNastaveni SystemoveNastaveni
+ */
+
 use Gamecon\Statistiky\Statistiky;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 
 $zbyva = new DateTime(DEN_PRVNI_DATE);
 $zbyva = $zbyva->diff(new DateTime());
@@ -30,7 +36,7 @@ $ubytovaniKratce = $statistiky->tabulkaUbytovaniKratce();
 $jidlo = $statistiky->tabulkaJidlaHtml();
 $pohlavi = $statistiky->tabulkaZastoupeniPohlaviHtml();
 
-$prihlaseniData = $statistiky->dataProGrafUcasti(new DateTimeImmutable());
+$prihlaseniData = $statistiky->dataProGrafUcasti($systemoveNastaveni->ted());
 
 $zarovnaniGrafu = get('zarovnaniGrafu') ?? Statistiky::ZAROVNANI_KE_KONCI_GC;
 [

--- a/nastaveni/nastaveni.php
+++ b/nastaveni/nastaveni.php
@@ -22,8 +22,9 @@ if (!defined('ROK')) define('ROK', 2022); // aktuální rok -- při změně roku
 // Nastavení ovládatelné z adminu //
 ////////////////////////
 
-$nastaveni = SystemoveNastaveni::vytvorZGlobalnich();
-$nastaveni->zaznamyDoKonstant();
+global $systemoveNastaveni;
+$systemoveNastaveni = SystemoveNastaveni::vytvorZGlobalnich();
+$systemoveNastaveni->zaznamyDoKonstant();
 
 if (defined('BONUS_ZA_STANDARDNI_3H_AZ_5H_AKTIVITU')) { // nemusí být ještě načtena před SQL migracemi
     // OSTATNÍ FINANČNÍ NASTAVENÍ
@@ -57,9 +58,9 @@ if (defined('BONUS_ZA_STANDARDNI_3H_AZ_5H_AKTIVITU')) { // nemusí být ještě 
 // SAMOTNÝ GAMECON //
 /////////////////////
 // 2022-07-21 07:00:00 čtvrtek ve třetím týdnu v červenci
-if (!defined('GC_BEZI_OD')) define('GC_BEZI_OD', $nastaveni->dejVychoziHodnotu('GC_BEZI_OD')); // začátek GameConu (přepnutí stránek do režimu "úpravy na jen na infopultu")
+if (!defined('GC_BEZI_OD')) define('GC_BEZI_OD', $systemoveNastaveni->dejVychoziHodnotu('GC_BEZI_OD')); // začátek GameConu (přepnutí stránek do režimu "úpravy na jen na infopultu")
 // 2022-07-24 21:00:00
-if (!defined('GC_BEZI_DO')) define('GC_BEZI_DO', $nastaveni->dejVychoziHodnotu('GC_BEZI_DO')); // konec GameCou (přepnutí stránek do režimu "gc skončil, úpravy nemožné")
+if (!defined('GC_BEZI_DO')) define('GC_BEZI_DO', $systemoveNastaveni->dejVychoziHodnotu('GC_BEZI_DO')); // konec GameCou (přepnutí stránek do režimu "gc skončil, úpravy nemožné")
 
 ///////////////////////////
 // REGISTRACE NA GAMECON //


### PR DESCRIPTION
> Bylo by možný nastavit jako default, že se to zarovnává na začátek registrací? Takhle to musím furt překlikávat, protože zarovnání na konec GC mi je k ničemu, když ta letošní křivka ještě nedoběhla. Případně aby se to zarovnávalo pro předpokládaný konec GC a ne pro konec grafu, teď když si to zarovnáš pro konec GC, tak letošní křivka nesedí, protože bere jako konec GC dnešek.

Bylo