### PR TITLE
976: Přidána možnost změnit konec registrací přes web

### DIFF
--- a/migrace/2022-07-11_01-datum-pro-ukonceni-registrace-na-gamecon.php
+++ b/migrace/2022-07-11_01-datum-pro-ukonceni-registrace-na-gamecon.php
@@ -1,0 +1,10 @@
+<?php
+
+/** @var \Godric\DbMigrations\Migration $this */
+
+$this->q(<<<SQL
+INSERT IGNORE INTO systemove_nastaveni (klic, hodnota, aktivni, nazev, popis, datovy_typ, skupina, poradi)
+    VALUES
+        ('REG_GC_DO', '', 0, 'Ukončení registrací přes web', 'Do kdy se lze registrovat na Gamecon přes přihlášlu na webu', 'datetime', 'Časy',  (SELECT MAX(poradi) + 1 FROM systemove_nastaveni AS predchozi))
+SQL
+);

--- a/model/SystemoveNastaveni/SystemoveNastaveni.php
+++ b/model/SystemoveNastaveni/SystemoveNastaveni.php
@@ -314,6 +314,7 @@ SQL;
             case 'GC_BEZI_OD' :
                 return DateTimeGamecon::spocitejZacatekGameconu($this->rok)->formatDb();
             case 'GC_BEZI_DO' :
+            case 'REG_GC_DO' :
                 return DateTimeGamecon::spocitejKonecGameconu($this->rok)->formatDb();
             case 'REG_GC_OD' :
                 return DateTimeGamecon::spocitejZacatekRegistraciUcastniku($this->rok)->formatDb();


### PR DESCRIPTION
https://trello.com/c/AaHUnSdx/976-%C3%BApravy-v-e-shopu-2022-3#comment-62cf1865832dd571df983b0a

Nějak se nemůžeme rozhodnout, zda chceme povolit registraci přes web až do konce GC.

Tak na to udělám nastavení.