### PR TITLE
Opraveno udržení scrollu po akci na stránce admin aktivit

### DIFF
--- a/admin/files/keep-scroll-on-reload-1.2.js
+++ b/admin/files/keep-scroll-on-reload-1.2.js
@@ -1,5 +1,4 @@
 { // local scope
-
   if (document.referrer === window.location.href) { // still the same URL
     function scrollToPreviousPosition() {
 

--- a/admin/scripts/modules/aktivity/aktivity.xtpl
+++ b/admin/scripts/modules/aktivity/aktivity.xtpl
@@ -294,6 +294,7 @@
   </table>
 </div>
 <script>
-  scrollToPreviousPosition()
+  const contentReadyToScrollToPreviousPosition = new CustomEvent('contentReadyToScrollToPreviousPosition')
+  document.dispatchEvent(contentReadyToScrollToPreviousPosition)
 </script>
 <!-- end:aktivity -->


### PR DESCRIPTION
Nedávno jsme JS funkci na udržení scrollu mezi přenačtením stránky přesunuli, ale zapomněli jsme změnit její volání.