### PR TITLE
881 řazení log sponzorů a partnerů na webu

### DIFF
--- a/model/Web/Loga.php
+++ b/model/Web/Loga.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Web;
+
+use Gamecon\XTemplate\XTemplate;
+use Nahled;
+
+class Loga
+{
+    public static function logaSponzoru(): static
+    {
+        return new static(ADRESAR_WEBU_S_OBRAZKY . '/soubory/systemove/sponzori');
+    }
+
+    public static function logaPartneru(): static
+    {
+        return new static(ADRESAR_WEBU_S_OBRAZKY . '/soubory/systemove/partneri');
+    }
+
+    public function __construct(
+        private readonly string $adresarLog,
+    )
+    {
+        if (!is_dir($this->adresarLog)) {
+            throw new \RuntimeException("Adresář '{$this->adresarLog}' neexistuje nebo nelez přečíst.");
+        }
+    }
+
+    public function vypisDoSablony(
+        XTemplate $template,
+        string    $templateBlock,
+    )
+    {
+        foreach ($this->serazenaLoga() as ['src' => $src, 'url' => $url]) {
+            $template->assign(['src' => $src, 'url' => $url]);
+            $template->parse($templateBlock);
+        }
+    }
+
+    public function serazenaLoga()
+    {
+        $soubory = glob($this->adresarLog . '/*', GLOB_NOSORT);
+        ['obrazky' => $obrazky, 'radici_soubor' => $radiciSoubor] = $this->rozdel($soubory);
+        $obrazky  = $this->vyhodVyrazene($obrazky);
+        $serazene = $this->serad($obrazky, $radiciSoubor);
+
+        foreach ($serazene as $obrazek) {
+            if (substr($obrazek, 0) === '_') {
+                continue;
+            }
+            $info = pathinfo($obrazek);
+            // odstraníme prefix pro řazení 'číslo_'
+            $urlPartnera = preg_replace('~^\d+_~', '', $info['filename']);
+            yield [
+                'src' => Nahled::zSouboru($obrazek)->pasuj(120, 60),
+                'url' => 'http://' . $urlPartnera,
+            ];
+        }
+    }
+
+    private function serad(array $obrazky, ?string $radiciSoubor)
+    {
+        $klicovaneObrazky = [];
+        foreach ($obrazky as $obrazek) {
+            $klicovaneObrazky[$this->baseNazev($obrazek)] = $obrazek;
+        }
+        ksort($klicovaneObrazky);
+
+        $razeniZeSouboru = $radiciSoubor
+            ? str_getcsv(file_get_contents($radiciSoubor), "\n")
+            : false;
+
+        if (!$razeniZeSouboru) {
+            return $klicovaneObrazky; // seřazené abecedně
+        }
+
+        $razeniZeSouboru = array_filter(
+            $razeniZeSouboru,
+            // odtranění prázdných řádků a #komentářů
+            fn(string $radek) => trim($radek) !== '' && !str_starts_with(trim($radek), '#'),
+        );
+
+        if (count($razeniZeSouboru) === 0) {
+            return $klicovaneObrazky; // seřazené abecedně
+        }
+
+        $baseRazeniZeSouboru = array_map(fn(string $nazev) => $this->baseNazev($nazev), $razeniZeSouboru);
+        $serazeneObrazky     = [];
+        foreach ($baseRazeniZeSouboru as $baseNazevZeSouboru) {
+            if (array_key_exists($baseNazevZeSouboru, $klicovaneObrazky)) {
+                $serazeneObrazky[$baseNazevZeSouboru] = $klicovaneObrazky[$baseNazevZeSouboru];
+            }
+        }
+
+        if (!$serazeneObrazky) {
+            return $klicovaneObrazky; // seřazené abecedně
+        }
+
+        foreach ($klicovaneObrazky as $nazev => $obrazek) {
+            if (!array_key_exists($nazev, $serazeneObrazky)) {
+                $serazeneObrazky[$nazev] = $obrazek; // doplníme obrázky seřazené podle seznamu v souboru ještě obrázky s pořadím abecedním, pokud nějaké v souboru nebyly
+            }
+        }
+        // seřazené nejdříve podle seznamu v souboru a pokud v něm nebyly, tak přidané ke konci v abecedním pořadí
+        return $serazeneObrazky;
+    }
+
+    /**
+     * Například /foo/bar/www.Albi.cz => albi
+     */
+    private function baseNazev(string $soubor): string
+    {
+        $basename = basename($soubor);
+        $base     = preg_replace('~(^www[.]|[.][^.]+$)~', '', $basename);
+        return mb_strtolower($base);
+    }
+
+    private function rozdel(array $soubory): array
+    {
+        $obrazky = [];
+        foreach ($soubory as $index => $soubor) {
+            if (str_starts_with(mime_content_type($soubor), 'image/')) {
+                $obrazky[] = $soubor;
+                unset($soubory[$index]);
+            }
+        }
+        $radiciSoubory = array_filter(
+            $soubory,
+            fn(string $soubor) => str_ends_with($soubor, 'RAZENI.csv'),
+        );
+        $radiciSoubor  = reset($radiciSoubory) ?: null;
+        return [
+            'obrazky'       => $obrazky,
+            'radici_soubor' => $radiciSoubor,
+        ];
+    }
+
+    private function vyhodVyrazene(array $obrazky): array
+    {
+        return array_filter(
+            $obrazky,
+            // vyřazený obrázek, jeho název začíná podtržítkem '_'
+            fn(string $obrazek) => substr($obrazek, 0) !== '_',
+        );
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -112,9 +112,10 @@ if ($m->bezStranky()) {
     }
     $t->parse('index');
     $t->out('index');
-    echo profilInfo();
+    profilInfo();
 } else {
-    $t = new XTemplate('sablony/index.xtpl');
+    // TODO tohle podle mě nemůže fungovat, to je nějaký mrtvý kód
+    $t = new XTemplate('sablony/blackarrow/index.xtpl');
     // templata a nastavení proměnných do glob templaty
     $t->assign([
         'u'            => $u,
@@ -163,5 +164,5 @@ if ($m->bezStranky()) {
     $t->parse($u ? 'index.prihlasen' : 'index.neprihlasen');
     $t->parse('index');
     $t->out('index');
-    echo profilInfo();
+    profilInfo();
 }

--- a/web/moduly/sponzori.php
+++ b/web/moduly/sponzori.php
@@ -1,15 +1,22 @@
 <?php
 
-$this->bezDekorace(true);
+/** @var Modul $this */
+/** @var \Gamecon\XTemplate\XTemplate $t */
 
-foreach(['sponzor', 'partner'] as $kategorie) {
-  foreach(glob("soubory/obsah/{$kategorie}i/*") as $f) {
-    $fn = preg_replace('@.*/(.*)\.(jpg|png|gif)@', '$1', $f, -1, $n);
-    if($fn[0] == '_' || $n == 0) continue; // skrývání odebraných sponzorů
-    $t->assign([
-      'url' => $fn,
-      'img' => $f,
-    ]);
-    $t->parse("sponzori.$kategorie");
-  }
+$this->bezStranky(true);
+
+{ // local variables scope
+    foreach (['sponzor' => 'sponzori', 'partner' => 'partneri'] as $kategorie => $adresar) {
+        foreach (glob(ADRESAR_WEBU_S_OBRAZKY . "/soubory/obsah/{$adresar}/*") as $soubor) {
+            $fn = preg_replace('@.*/([^_].*)\.(?:jpg|png|gif)@', '$1', $soubor, -1, $pocetZmen);
+            if ($pocetZmen === 0) {
+                continue; // skrývání odebraných sponzorů ([^_] znamená "jen pokud nezačíná podtržítkem" a podtržítko znamená "vyřazený obrázek")
+            }
+            $t->assign([
+                'url' => $fn,
+                'src' => URL_WEBU . '/soubory/obsah/' . $adresar . '/' . basename($soubor),
+            ]);
+            $t->parse("sponzori.$kategorie");
+        }
+    }
 }

--- a/web/moduly/titulka.php
+++ b/web/moduly/titulka.php
@@ -3,6 +3,7 @@
 use Gamecon\Cas\DateTimeCz;
 use Gamecon\Aktivita\TypAktivity;
 use Gamecon\Cas\DateTimeGamecon;
+use Gamecon\Web\Loga;
 
 /** @var \Gamecon\XTemplate\XTemplate $t */
 /** @var Modul $this */
@@ -15,64 +16,45 @@ $this->info()
 
 // linie
 $offsety = [120, 320, 280];
-$typy = serazenePodle(TypAktivity::zViditelnych(), 'poradi');
+$typy    = serazenePodle(TypAktivity::zViditelnych(), 'poradi');
 foreach ($typy as $i => $typ) {
     $t->assign([
-        'cislo' => sprintf('%02d', $i + 1),
-        'nazev' => mb_ucfirst($typ->nazev()),
-        'url' => $typ->url(),
-        'obrazek' => 'soubory/systemove/linie/' . $typ->id() . '.jpg',
-        'ikona' => 'soubory/systemove/linie-ikony/' . $typ->id() . '.png',
+        'cislo'     => sprintf('%02d', $i + 1),
+        'nazev'     => mb_ucfirst($typ->nazev()),
+        'url'       => $typ->url(),
+        'obrazek'   => 'soubory/systemove/linie/' . $typ->id() . '.jpg',
+        'ikona'     => 'soubory/systemove/linie-ikony/' . $typ->id() . '.png',
         'aosOffset' => $offsety[$i % 3],
-        'popis' => $typ->popisKratky(),
+        'popis'     => $typ->popisKratky(),
     ]);
     $t->parse('titulka.linie');
 }
 
 // sponzoři a partneři
-$sponzoriLoga = glob(ADRESAR_WEBU_S_OBRAZKY . '/soubory/systemove/sponzori/*');
-
-foreach ($sponzoriLoga as $obrazek) {
-    $info = pathinfo($obrazek);
-    $t->assign([
-        'src' => Nahled::zSouboru($obrazek)->pasuj(160, 96),
-        'url' => 'http://' . $info['filename'],
-    ]);
-    $t->parse('titulka.sponzor');
-}
-
-$partneriLoga = glob(ADRESAR_WEBU_S_OBRAZKY . '/soubory/systemove/partneri/*');
-
-foreach ($partneriLoga as $obrazek) {
-    $info = pathinfo($obrazek);
-    $t->assign([
-        'src' => Nahled::zSouboru($obrazek)->pasuj(120, 60),
-        'url' => 'http://' . $info['filename'],
-    ]);
-    $t->parse('titulka.partner');
-}
+Loga::logaSponzoru()->vypisDoSablony($t, 'titulka.sponzor');
+Loga::logaPartneru()->vypisDoSablony($t, 'titulka.partner');
 
 // odpočet
 if (pred(REG_GC_OD)) {
     $zacatek = (new DateTimeCz(REG_GC_OD))->format('j. n. \v\e H:i');
     $t->assign([
         'odpocetTimestamp' => strtotime(REG_GC_OD),
-        'odpocetNadpis' => "Přihlašování začne $zacatek",
+        'odpocetNadpis'    => "Přihlašování začne $zacatek",
     ]);
 } else {
     $t->assign([
         'odpocetTimestamp' => strtotime(GC_BEZI_OD),
-        'odpocetNadpis' => 'Do GameConu zbývá',
+        'odpocetNadpis'    => 'Do GameConu zbývá',
     ]);
     $t->parse('titulka.odpocetPrihlasit');
 }
 
 $zacatekGameconu = DateTimeGamecon::zacatekGameconu();
-$konecGameconu = DateTimeGamecon::konecGameconu();
+$konecGameconu   = DateTimeGamecon::konecGameconu();
 
 // ostatní
 $t->assign([
-    'gcOd' => $zacatekGameconu->format('j.'),
-    'gcDo' => $konecGameconu->format('j. n.'),
+    'gcOd'  => $zacatekGameconu->format('j.'),
+    'gcDo'  => $konecGameconu->format('j. n.'),
     'gcRok' => $konecGameconu->format('Y'),
 ]);

--- a/web/sablony/blackarrow/sponzori.xtpl
+++ b/web/sablony/blackarrow/sponzori.xtpl
@@ -1,0 +1,19 @@
+<!-- begin: sponzori -->
+<div class="sponzori">
+  <h2 id="sponzori"><a href="#sponzori">Děkujeme našim sponzorům a partnerům!</a></h2>
+  <div class="sponzori_loga">
+    <!-- begin: sponzor -->
+    <div class="sponzori_logo">
+      <a href="{url}" target="_blank"><img src="{src}" alt="{url}"></a>
+    </div>
+    <!-- end:sponzor -->
+  </div>
+  <div class="partneri_loga">
+    <!-- begin: partner -->
+    <div class="partneri_logo">
+      <a href="{url}" target="_blank"><img src="{src}" alt="{url}"></a>
+    </div>
+    <!-- end:partner -->
+  </div>
+</div>
+<!-- end: sponzori -->

--- a/web/tridy/modul.php
+++ b/web/tridy/modul.php
@@ -41,24 +41,24 @@ class Modul
     }
 
     /** Jestli se modul má renderovat bez zobrazeného menu */
-    function bezMenu($val = null) {
+    public function bezMenu($val = null) {
         if (isset($val)) $this->bezMenu = (bool)$val;
         return $this->bezMenu;
     }
 
     /** Jestli se má modul renderovat přes celou šířku monitoru */
-    function bezOkraju($val = null) {
+    public function bezOkraju($val = null) {
         if (isset($val)) $this->bezOkraju = (bool)$val;
         return $this->bezOkraju;
     }
 
     /** Jestli se má modul renderovat čistě jako plaintext */
-    function bezStranky($val = null) {
+    public function bezStranky($val = null) {
         if (isset($val)) $this->bezStranky = $val;
         return $this->bezStranky;
     }
 
-    function bezPaticky($val = null) {
+    public function bezPaticky($val = null) {
         if (isset($val)) $this->bezPaticky = $val;
         return $this->bezPaticky;
     }
@@ -67,21 +67,21 @@ class Modul
      * Jestli je modul v novém vizuálním stylu (codename blackarrow).
      * TODO po zmigrování všech modulů je možné toto postupně odstranit.
      */
-    function blackarrowStyl($val = null) {
+    public function blackarrowStyl($val = null) {
         if (isset($val)) $this->blackarrowStyl = $val;
         return $this->blackarrowStyl;
     }
 
-    function cssUrls() {
+    public function cssUrls() {
         return $this->cssUrls;
     }
 
-    function info(Info $val = null): ?Info {
+    public function info(Info $val = null): ?Info {
         if (isset($val)) $this->info = $val;
         return $this->info;
     }
 
-    function jsUrls() {
+    public function jsUrls() {
         return $this->jsUrls;
     }
 
@@ -91,18 +91,18 @@ class Modul
     }
 
     /** Setter/getter pro parametr (proměnnou) předanou dovnitř modulu */
-    function param($nazev) {
+    public function param($nazev) {
         if (func_num_args() == 2) {
             $this->params[$nazev] = func_get_arg(1);
         }
         return $this->params[$nazev] ?? null;
     }
 
-    function pridejCssUrl($url) {
+    public function pridejCssUrl($url) {
         $this->cssUrls[] = $url;
     }
 
-    function pridejJsSoubor($cesta) {
+    public function pridejJsSoubor($cesta) {
         $cestaKSouboru  = strpos(realpath($cesta), realpath(WWW)) === 0
             ? $cesta
             : WWW . '/' . $cesta;
@@ -114,13 +114,10 @@ class Modul
 
     /** Vrátí výchozí šablonu pro tento modul (pokud existuje) */
     protected function sablona() {
-        $soubor           = 'sablony/' . $this->nazev() . '.xtpl';
         $blackarrowSoubor = 'sablony/blackarrow/' . $this->nazev() . '.xtpl';
 
         if (is_file($blackarrowSoubor)) {
             return new XTemplate($blackarrowSoubor);
-        } else if (is_file($soubor)) {
-            return new XTemplate($soubor);
         } else {
             return null;
         }
@@ -131,7 +128,7 @@ class Modul
      * Viz, že modul dostává některé parametry pomocí proměnných resp. šablona se
      * načítá automaticky.
      */
-    function spust() {
+    public function spust() {
         extract($this->params); // TODO možná omezit explicitně parametry, které se smí extractnout, ať to není black magic
         $t = $this->sablona();
 
@@ -149,7 +146,7 @@ class Modul
     }
 
     /** Vrátí výstup, který modul vygeneroval */
-    function vystup() {
+    public function vystup() {
         if ($this->bezDekorace || $this->bezStranky)
             return $this->vystup;
         elseif ($this->bezOkraju)
@@ -161,7 +158,7 @@ class Modul
     }
 
     /** Načte modul odpovídající dané Url (pokud není zadaná, použije aktuální) */
-    static function zUrl(Url $urlObjekt = null, SystemoveNastaveni $systemoveNastaveni) {
+    public static function zUrl(Url $urlObjekt = null, SystemoveNastaveni $systemoveNastaveni) {
         $url        = null;
         $podstranka = null;
         if (!$urlObjekt) {
@@ -176,7 +173,7 @@ class Modul
     }
 
     /** Načte modul podle daného názvu */
-    static function zNazvu(
+    public static function zNazvu(
         ?string            $nazev,
         string             $podstranka = null,
         SystemoveNastaveni $systemoveNastaveni


### PR DESCRIPTION
https://trello.com/c/cmAKkTlf/881-%C5%99azen%C3%AD-log-sponzor%C5%AF-a-partner%C5%AF-na-webu

Abychom mohli loga sponzorů a partnerů seřadit jak potřebujeme.

Nově to lze seznamem v souboru RAZENI.csv v adresáři s obrázky a předponou `číslo_`.  Řazení v souboru má přednost.