### PR TITLE
Fix přenosu práv ze starého ročníku do nových ročníkových rolí

### DIFF
--- a/migrace/9999_01-letosni-role-krome-ucasti-endless.php
+++ b/migrace/9999_01-letosni-role-krome-ucasti-endless.php
@@ -28,20 +28,21 @@ if ($chybejiciRocnikoveRole) {
     $rocnik        = rocnik_z_promenne_mysql();
     $letosniPrefix = Role::prefixRocniku($rocnik);
     foreach ($chybejiciRocnikoveRole as $idChybejiciRocnikoveRole => $nazevChybejiciRocnikoveRole) {
-        $result = $this->q(<<<SQL
-SELECT rocnik_role FROM role_seznam
+        $result                   = $this->q(<<<SQL
+SELECT id_role, rocnik_role FROM role_seznam
 WHERE nazev_role = '$nazevChybejiciRocnikoveRole'
 SQL,
         );
+        $idRolePredchozihoRocniku = null;
         if ($result) {
-            $rocnikRolePredchozihoRocniku = $result->fetch_column();
+            [$idRolePredchozihoRocniku, $rocnikRolePredchozihoRocniku] = $result->fetch_row();
             $result->close();
-            if ($rocnikRolePredchozihoRocniku) {
+            if ($idRolePredchozihoRocniku) {
                 $prefixProRoliPredchozihoRocniku = Role::prefixRocniku($rocnikRolePredchozihoRocniku);
                 $this->q(<<<SQL
 UPDATE role_seznam
 SET nazev_role = CONCAT('$prefixProRoliPredchozihoRocniku', ' ', nazev_role)
-WHERE nazev_role = '$nazevChybejiciRocnikoveRole'
+WHERE id_role = $idRolePredchozihoRocniku
 SQL,
                 );
             }
@@ -57,16 +58,25 @@ SQL,
         $kategorie = Role::kategoriePodleVyznamu($vyznam);
         $this->q(<<<SQL
 INSERT INTO role_seznam
-    SET id_role = $idChybejiciRocnikoveRole,
-        kod_role = '$kodRole',
-        nazev_role = '$nazevChybejiciRocnikoveRole',
-        popis_role = COALESCE((SELECT popis_role FROM role_seznam AS predchozi_popis_role WHERE vyznam_role = '$vyznam' LIMIT 1), '$nazevChybejiciRocnikoveRole'),
-        rocnik_role = $rocnik,
-        typ_role = '$rocnikova',
-        skryta = '$skryta',
-        vyznam_role = '$vyznam',
-        kategorie_role = '$kategorie'
+SET id_role = $idChybejiciRocnikoveRole,
+    kod_role = '$kodRole',
+    nazev_role = '$nazevChybejiciRocnikoveRole',
+    popis_role = COALESCE((SELECT popis_role FROM role_seznam AS predchozi_popis_role WHERE vyznam_role = '$vyznam' LIMIT 1), '$nazevChybejiciRocnikoveRole'),
+    rocnik_role = $rocnik,
+    typ_role = '$rocnikova',
+    skryta = '$skryta',
+    vyznam_role = '$vyznam',
+    kategorie_role = '$kategorie'
 SQL,
         );
+        if ($idRolePredchozihoRocniku) {
+            $this->q(<<<SQL
+INSERT INTO prava_role (id_role, id_prava)
+SELECT $idChybejiciRocnikoveRole, id_prava
+FROM prava_role AS lonska_prava_role
+WHERE id_role = $idRolePredchozihoRocniku
+SQL,
+            );
+        }
     }
 }


### PR DESCRIPTION
Př překopení ročníku a spuštění migrace se sice přejmenovaly staré ročníkové role a vytvořily nové, ale k novým se ze starých nepřenesla práva.