### PR TITLE
1188 Oprava matoucího textu v přihlášce o tématickém ubytování

### DIFF
--- a/web/sablony/blackarrow/prihlaska.xtpl
+++ b/web/sablony/blackarrow/prihlaska.xtpl
@@ -18,9 +18,7 @@
         <!-- end:prihlasen -->
 
         <!-- begin:neprihlasen -->
-        <p>Vyplněním údajů se přihlásíš na GameCon {rok}. Můžeš si vybrat předměty a ubytování s GameCon tématikou,
-            které
-            budeš chtít. Výběr jde i později změnit.</p>
+        <p>Vyplněním údajů se přihlásíš na GameCon {rok}. Můžeš si vybrat předměty s GameCon tématikou a ubytování, které budeš chtít. Výběr jde i později změnit.</p>
         <!-- end:neprihlasen -->
     </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/l4JkQQWB/1188-chyba-ubytov%C3%A1n%C3%AD-s-tematikou-gameconu