### PR TITLE
oprava den aktivity podle `PROGRAM_ZACATEK`

### DIFF
--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -318,7 +318,7 @@ SQL
     private static function denAktivity(?Aktivita $aktivita): DateTimeCz|null
     {
         if ($aktivita && $aktivita->zacatek()) {
-            return $aktivita->zacatek()->format('H') > PROGRAM_ZACATEK
+            return $aktivita->zacatek()->format('H') >= PROGRAM_ZACATEK
                 ? $aktivita->zacatek()
                 : (clone $aktivita->zacatek())->minusDen();
         }

--- a/model/Aktivita/Program.php
+++ b/model/Aktivita/Program.php
@@ -669,7 +669,7 @@ HTML;
             return null;
         }
 
-        return $a['zacatek'] > PROGRAM_ZACATEK
+        return $a['zacatek'] >= PROGRAM_ZACATEK
             ? new DateTimeCz($a['den'])
             : (new DateTimeCz($a['den']))->plusDen();
     }


### PR DESCRIPTION
Zároveň s tímhle PR je potřeba posunout na všech aktivitách na začátku programu den o 1 dopředu

řeší [Trello kartu](https://trello.com/c/MKAUG6BZ/1196-mdrd-semifin%C3%A1le-a-fin%C3%A1le-se-%C5%A1patn%C4%9B-zobrazuj%C3%AD-v-programu)


