### PR TITLE
Oprava chyby v db-object.

### DIFF
--- a/model/db-object.php
+++ b/model/db-object.php
@@ -132,6 +132,9 @@ abstract class DbObject
             foreach ($objekty as $objekt) {
                 self::$objektyZVsech[static::class][$objekt->id()] = $objekt;
             }
+            if ((self::$objekty[static::class] ?? null) == null) {
+                self::$objekty[static::class] = [];
+            }
             self::$objekty[static::class] += (self::$objektyZVsech[static::class] ?? []);
         }
 


### PR DESCRIPTION
Volání zVsech() mohlo vést k chybě při zapnutém cachování kvůli bugu v commitu d77c54ec0ca "Fix míchání cache objektů více tříd". Chyba se projevuje například v infopultu - při zvolené osobě proklik na "Program"