### PR TITLE
1213 při znovuuložení týmových aktivit se resetuje počet míst

### DIFF
--- a/migrace/2024-06-16-opravit-tymove-limity-kapacity.php
+++ b/migrace/2024-06-16-opravit-tymove-limity-kapacity.php
@@ -1,0 +1,33 @@
+<?php
+/** @var \Godric\DbMigrations\Migration $this */
+
+$this->q(<<<SQL
+alter table akce_seznam
+    add team_limit int default null null comment 'uživatelem (vedoucím týmu) nastavený limit kapacity menší roven team_max, ale větší roven team_min. Prostřednictvím on update triggeru kontrolována tato vlastnost a je-li non-null, tak je tato kapacita nastavena do sloupce `kapacita`';
+SQL
+);
+
+$this->q(<<<SQL
+update akce_seznam
+    set team_limit = kapacita
+    where teamova = 1 and kapacita <> team_max;
+SQL
+);
+
+$this->q(<<<SQL
+create trigger trigger_check_and_apply_team_limit
+    before update
+    on akce_seznam
+    for each row
+begin
+    if new.team_limit is not null then
+    if new.team_limit < new.team_min or new.team_limit > new.team_max then
+        set new.team_limit = null;
+    else
+        set new.kapacita = new.team_limit;
+    end if;
+end if;
+end;
+
+SQL
+);

--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -956,20 +956,7 @@ SQL
             : null;
 
         if ($teamova) {
-            ///// Kapacita může být u teamových aktivit upravena vedoucím týmu na libovolnou hodnotu v rozmezí
-            ///// team_min, team_max. Tato úprava se propíše přímo do kapacity, a při uložení aktivity v adminovi
-            ///// se tedy NESMÍ přepsat kapacita pokud ji už takto tým upravil.
-            if (!empty($data[Sql::ID_AKCE])) {
-                $aktivita = self::zId($data[Sql::ID_AKCE]);
-                if ($aktivita->tymova() && $aktivita->tymMaxKapacita() === (int)$data['team_max']) {
-                    $data['kapacita'] = $aktivita->getKapacitaUnisex();
-                } else {
-                    $data['kapacita'] = $data['team_max'] ?? 0;
-                }
-            } else {
-                $data['kapacita'] = $data['team_max'] ?? 0;
-            }
-            ////
+            $data['kapacita']   = $data['team_max'] ?? 0;
             $data['kapacita_f'] = 0;
             $data['kapacita_m'] = 0;
         } else {

--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -956,6 +956,9 @@ SQL
             : null;
 
         if ($teamova) {
+            // Vedoucí týmu může ručně nastavit kapacitu nižší, dokud je větší rovna team_min. V takovém
+            // případě se NESMÍ kapacita změnit při např. úpravě popisu aktivity z adminu. DB trigger
+            // trigger_check_and_apply_team_limit toto zajišťuje s pomocí sloupce team_limit
             $data['kapacita']   = $data['team_max'] ?? 0;
             $data['kapacita_f'] = 0;
             $data['kapacita_m'] = 0;

--- a/model/Aktivita/SqlStruktura/AktivitaSqlStruktura.php
+++ b/model/Aktivita/SqlStruktura/AktivitaSqlStruktura.php
@@ -30,6 +30,7 @@ class AktivitaSqlStruktura
     public const TEAM_MAX      = 'team_max';
     public const TEAM_KAPACITA = 'team_kapacita';
     public const TEAM_NAZEV    = 'team_nazev';
+    public const TEAM_LIMIT    = 'team_limit';
     public const ZAMCEL        = 'zamcel';
     public const ZAMCEL_CAS    = 'zamcel_cas';
     public const POPIS         = 'popis';

--- a/model/tym.php
+++ b/model/tym.php
@@ -105,13 +105,13 @@ class Tym
                 if ($tym->kapacita() <= $tym->minKapacita()) {
                     throw new Exception('Kapacita týmu nelze snížit, už je minimální');
                 }
-                dbQuery('UPDATE akce_seznam SET kapacita = kapacita - 1 WHERE id_akce = $1', [post($post, 'id')]);
+                dbQuery('UPDATE akce_seznam SET team_limit = $2 - 1 WHERE id_akce = $1', [post($post, 'id'), $tym->kapacita()]);
             }
             if (post($post, 'pridat')) {
                 if ($tym->kapacita() >= $tym->maxKapacita()) {
                     throw new Exception('Kapacita týmu nelze zvýšit, už je maximální');
                 }
-                dbQuery('UPDATE akce_seznam SET kapacita = kapacita + 1 WHERE id_akce = $1', [post($post, 'id')]);
+                dbQuery('UPDATE akce_seznam SET team_limit = $2 + 1 WHERE id_akce = $1', [post($post, 'id'), $tym->kapacita()]);
             }
             back();
         }


### PR DESCRIPTION
Oprava verze 2, teď už by měla fungovat spolehlivě i s instancovanými aktivitami. Je to nepěkné, ale funkční řešení.