### PR TITLE
arm procesory

### DIFF
--- a/.docker/docker-build.sh
+++ b/.docker/docker-build.sh
@@ -10,6 +10,5 @@ if [ -z "${PHP_VERSION}" ]; then
 fi
 TAG=gameconcz/gamecon:"${PHP_VERSION}"
 
-docker buildx create --use
-
-docker buildx build --platform linux/amd64,linux/arm64/v8 --pull --tag "${TAG}" "${PROJECT_ROOT}/.docker" && docker push "${TAG}"
+# docker buildx create --use
+docker buildx build --platform linux/amd64,linux/arm --pull --tag "${TAG}" --push "${PROJECT_ROOT}/.docker"


### PR DESCRIPTION
v rámci rozšíření inkluzivity specifického HW využívaného zejména ovcemi (Apple) potřebujeme buildovat image i pro arm v8 procesory (i další procesory kdyžuž - třeba mini lokální GC na RPi by se mohl někdy v budoucnu hodit jako záloha pro infopult) 

nutno zkontrolovat že při buildu se zobrazí pak pushnuté arm i amd verze na docker hubu [gameconcz/gamecon](https://hub.docker.com/r/gameconcz/gamecon/tags)