### PR TITLE
Změnit spojování arrays ze spread na rychlejší array_merge

### DIFF
--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -757,7 +757,7 @@ SQL
         $sKladnymPoradim = dbFetchAll('SELECT id_typu, typ_1p FROM akce_typy WHERE aktivni = 1 AND (poradi > 0 OR id_typu = 0) ORDER BY poradi');
         // typy se záporným pořadím jsou technické, brigádnické a tak
         $seZapornymPoradim = dbFetchAll('SELECT id_typu, typ_1p FROM akce_typy WHERE aktivni = 1 AND poradi < 0 AND id_typu != 0 ORDER BY poradi DESC');
-        foreach ([...$sKladnymPoradim, ...$seZapornymPoradim] as $akceTypData) {
+        foreach (array_merge($sKladnymPoradim, $seZapornymPoradim) as $akceTypData) {
             $xtpl->assign('selected', $aktivita && $akceTypData['id_typu'] == $aktivitaData[Sql::TYP]
                 ? 'selected'
                 : '');
@@ -3265,7 +3265,9 @@ SQL,
                 $dalsi = [];
                 foreach (end($urovne) as $a) {
                     if ($a->a[Sql::DITE]) {
-                        $dalsi = [...$dalsi, ...$this->parseIds($a->a[Sql::DITE] ?? '')];
+                        foreach ($this->parseIds($a->a[Sql::DITE] ?? '') as $id) {
+                            $dalsi[] = $id;
+                        }
                     }
                 }
                 if ($dalsi) {

--- a/model/PrednacitaniTrait.php
+++ b/model/PrednacitaniTrait.php
@@ -79,7 +79,9 @@ trait PrednacitaniTrait
             $zdrojObjekt           = $kolekce[$r[0]];
             $zdrojObjektCilIds = array_map('intval', explode(',', $r[1]));
             $zdrojObjekt->$atribut = $zdrojObjektCilIds;
-            $cilIds = [...$cilIds, ...$zdrojObjektCilIds];
+            foreach ($zdrojObjektCilIds as $id) {
+                    $cilIds[] = $id;
+            }
         }
 
         // vytvoření indexu cílů k vyhledávání podle id

--- a/model/Statistiky/Statistiky.php
+++ b/model/Statistiky/Statistiky.php
@@ -37,8 +37,11 @@ class Statistiky
         return $data;
     }
 
-    private function dataProGrafUcastiZaRok(int $rok, \DateTimeImmutable $doChvile): array
-    {
+    private function dataProGrafUcastiZaRok
+    (
+        int                $rok,
+        \DateTimeImmutable $doChvile,
+    ): array {
         /** @var \DateTimeImmutable|DateTimeGamecon $zacatekRegistraci */
         $zacatekRegistraci = min(DateTimeGamecon::spocitejPrihlasovaniUcastnikuOd($rok), $doChvile);
         /** @var \DateTimeImmutable|DateTimeGamecon $konecGc */
@@ -311,8 +314,11 @@ SQL,
         );
     }
 
-    public function pripravDataProGraf(array $prihlaseniData, array $vybraneRoky, string $zarovnaniGrafu): array
-    {
+    public function pripravDataProGraf(
+        array  $prihlaseniData,
+        array  $vybraneRoky,
+        string $zarovnaniGrafu,
+    ): array {
         $nazvyDnu         = [];
         $zacatkyRegistaci = [];
         $zacatkyGc        = [];
@@ -384,7 +390,7 @@ SQL,
             }
             array_pop($nazvyDnuJednohoRoku);
             $nazvyDnuJednohoRoku[] = 'po GC'; // všechny dny po GC smrsknute do jediného, posledního sloupce v grafu
-            $nazvyDnu              = array_unique([...$nazvyDnu, ...$nazvyDnuJednohoRoku]);
+            $nazvyDnu              = array_unique(array_merge($nazvyDnu, $nazvyDnuJednohoRoku));
             $indexZpracovavanehoRoku++;
         }
 
@@ -681,7 +687,7 @@ FROM (
     ) AS ucast_podle_roku
     GROUP BY rocnik_role
 ) AS pocty
-SQL
+SQL,
             ),
             'Registrovaní vs Dorazili',
         );
@@ -790,7 +796,7 @@ JOIN shop_predmety USING (id_predmetu)
 WHERE shop_predmety.typ = {$ubytovani}
 GROUP BY shop_nakupy.rok
 ORDER BY shop_nakupy.rok
-SQL
+SQL,
             ),
             'Ubytování',
         );

--- a/model/db-object.php
+++ b/model/db-object.php
@@ -154,7 +154,7 @@ abstract class DbObject
             self::doCache($freshObject);
         }
 
-        return [...$cachedObjects, ...$freshObjects];
+        return array_merge($cachedObjects, $freshObjects);
     }
 
     /** Načte a vrátí všechny objekty z databáze */

--- a/tests/Model/Uzivatel/KategorieNeplaticeTest.php
+++ b/tests/Model/Uzivatel/KategorieNeplaticeTest.php
@@ -34,14 +34,14 @@ class KategorieNeplaticeTest extends TestCase
         Finance $finance,
         ?string $kdySeRegistrovalNaLetosniGc,
         bool    $maPravoNerusitObjednavky,
-        string  $zacatekVlnyOdhlasovani, // prvni nebo druha vlna
+        // prvni nebo druha vlna
+        string  $zacatekVlnyOdhlasovani,
         int     $rocnik,
         float   $castkaVelkyDluh,
         float   $castkaPoslalDost,
         int     $pocetDnuPredVlnouKdyJeJesteChrane,
         ?int    $ocekavanaKategorieNeplatice,
-    )
-    {
+    ) {
         $kategorieNeplatice         = new KategorieNeplatice(
             $finance,
             $kdySeRegistrovalNaLetosniGc
@@ -52,7 +52,7 @@ class KategorieNeplaticeTest extends TestCase
             $rocnik,
             $castkaVelkyDluh,
             $castkaPoslalDost,
-            $pocetDnuPredVlnouKdyJeJesteChrane
+            $pocetDnuPredVlnouKdyJeJesteChrane,
         );
         $zjistenaKategorieNeplatice = $kategorieNeplatice->ciselnaKategoriiNeplatice();
         self::assertSame(
@@ -191,11 +191,14 @@ class KategorieNeplaticeTest extends TestCase
      */
     private static function pravoNerusitObjednavkyPrebijeTemerVsechno(): array
     {
-        $ocekavanaKategorieNeplatice = static function (?string $kdySeRegistrovalNaLetosniGc, float $stav) {
+        $ocekavanaKategorieNeplatice = static function (
+            ?string $kdySeRegistrovalNaLetosniGc,
+            float   $stav,
+        ) {
             return match ($kdySeRegistrovalNaLetosniGc) {
-                null => null,
+                null    => null,
                 default => match ($stav >= 0) {
-                    true => KategorieNeplatice::NEDLUZNIK,
+                    true  => KategorieNeplatice::NEDLUZNIK,
                     false => KategorieNeplatice::MA_PRAVO_NEODHLASOVAT,
                 }
             };
@@ -280,8 +283,7 @@ class KategorieNeplaticeTest extends TestCase
                 $pocetDnuPredVlnouKdyJeJesteChranen,
         ?int    $ocekavanaKategorieNeplatice,
         int     $rocnik = ROCNIK,
-    ): array
-    {
+    ): array {
         return [
             $finance,
             $kdySeRegistrovalNaLetosniGc,
@@ -367,7 +369,7 @@ class KategorieNeplaticeTest extends TestCase
      */
     private static function vsechnyKombinaceFinanci(): array
     {
-        $platby   = [...self::letosZaplatilDost(), ...self::letosZaplatilMalo()];
+        $platby   = array_merge(self::letosZaplatilDost(), self::letosZaplatilMalo());
         $zustatky = self::kombinaceZustatku();
 
         $kombinace = [];
@@ -379,6 +381,7 @@ class KategorieNeplaticeTest extends TestCase
                 ];
             }
         }
+
         return $kombinace;
     }
 
@@ -400,6 +403,7 @@ class KategorieNeplaticeTest extends TestCase
                 ];
             }
         }
+
         return $kombinaceZustatku;
     }
 
@@ -431,16 +435,15 @@ class KategorieNeplaticeTest extends TestCase
         float $sumaPlateb = 0.0,
         float $zustatekZPredchozichRocniku = 0.0,
         float $stav = 0.0,
-    ): Finance
-    {
-        return new class($sumaPlateb, $zustatekZPredchozichRocniku, $stav) extends Finance {
+    ): Finance {
+        return new class($sumaPlateb, $zustatekZPredchozichRocniku, $stav) extends Finance
+        {
 
             public function __construct(
                 protected float $sumaPlateb,
                 protected float $zustatekZPredchozichRocniku,
                 protected float $stav,
-            )
-            {
+            ) {
             }
 
             public function obnovUdaje(): void
@@ -452,8 +455,10 @@ class KategorieNeplaticeTest extends TestCase
                 $this->sumaPlateb = $sumaPlateb;
             }
 
-            public function sumaPlateb(?int $rocnik = ROCNIK, bool $prepocti = false): float
-            {
+            public function sumaPlateb(
+                ?int $rocnik = ROCNIK,
+                bool $prepocti = false,
+            ): float {
                 return $this->sumaPlateb;
             }
 
@@ -491,7 +496,7 @@ class KategorieNeplaticeTest extends TestCase
             $rocnik,
             $castkaVelkyDluh,
             $castkaPoslalDost,
-            $pocetDnuPredVlnouKdyJeJesteChrane
+            $pocetDnuPredVlnouKdyJeJesteChrane,
         );
 
         $puvodniCiselnaKategorieNeplatice = $kategorieNeplatice->ciselnaKategoriiNeplatice();


### PR DESCRIPTION
Když poprvé přišel do PHP spread operátor pro array `...[1,2,3]`, dělal jsem si benchmark a vyšlo mi, že je mnohem rychlejší udělat `$foo = [...$foo, ...$bar]` než `$foo = array_merge($foo, $bar)`.

Jenže doba pokročila a dnes je to obráceně
```
 php test.php
Iterations: 30000

Manual push:     0.011 s
array_merge:     5.61 s
Spread operator: 9.714 s
```

```php
<?php
/**
 * Quick benchmark of different array-merging approaches.
 * Run: php merge-benchmark.php
 */

const ITERATIONS = 3 * 10 ** 4; // adjust for your machine

function smallArray(
    int $i,
): array {
    // trivial small array to merge
    return [$i, $i + 1, $i + 2];
}

echo "Iterations: " . ITERATIONS . PHP_EOL . PHP_EOL;

// Manual push
$start  = microtime(true);
$result = [];
for ($i = 0; $i < ITERATIONS; $i++) {
    foreach (smallArray($i) as $v) {
        $result[] = $v;
    }
}
echo "Manual push:     " . round(microtime(true) - $start, 3) . " s" . PHP_EOL;

// array_merge
$start  = microtime(true);
$result = [];
for ($i = 0; $i < ITERATIONS; $i++) {
    $result = array_merge($result, smallArray($i));
}
echo "array_merge:     " . round(microtime(true) - $start, 3) . " s" . PHP_EOL;

// Spread operator
$start  = microtime(true);
$result = [];
for ($i = 0; $i < ITERATIONS; $i++) {
    $result = [...$result, ...smallArray($i)];
}
echo "Spread operator: " . round(microtime(true) - $start, 3) . " s" . PHP_EOL;
```

