### PR TITLE
Fix tooltip blokující formulář po zmizení

### DIFF
--- a/web/soubory/blackarrow/_spolecne/_zaklad.less
+++ b/web/soubory/blackarrow/_spolecne/_zaklad.less
@@ -100,7 +100,8 @@ hr {
   visibility: hidden;
   opacity: 0;
   margin-top: 5px;
-  transition: opacity 0.3s, margin-top 0.3s, visibility 1s;
+  pointer-events: none;
+  transition: opacity 0.3s, margin-top 0.3s, visibility 0s linear 0.3s;
 
   right: 0;
   max-width: 90vw;
@@ -141,6 +142,8 @@ hr {
   visibility: visible;
   opacity: 1;
   margin-top: 0;
+  pointer-events: auto;
+  transition: opacity 0.3s, margin-top 0.3s, visibility 0s;
 }
 
 .corner-ribbon {


### PR DESCRIPTION
V přihlášce, jak jsou tyhle tooltipy, tak když na ně člověk poprvé najede, tak se spawne to tooltip okno. A potom když člověk chce najet na cokoli, co je pod tím tooltip oknem, i když se to tooltip okno zrovna nezobrazuje, tak se objeví to tooltip okno a nejde jednoduše vyplnit cokoli, co je pod tím. Dá se najít si volný pixel nebo refreshnout stránku a na tooltip nenajíždět, tím pádem to nezačne blokovat, takže to není úplně tragédie. Jen je to weird.

Vidím, že ten tooltip má teda nějaký time limit, kdy zmizí a neblokuje to už. 

---

Mě to příjde, že i když tooltip zmizí tak tam ještě třeba 2 sekudny jakoby zůstává no... je to dost nepříjemný