### PR TITLE
Detect *.preview.gamecon.cz environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@
 /nasad.log
 /.htdeployment
 
+# Generated at runtime by vytvorSouborSkrytehoNastaveniPodleEnv from env vars.
+# Contains decrypted DB creds & app secrets — must never be committed.
+/nastaveni/nastaveni-produkce.php
+/nastaveni/nastaveni-beta.php
+/nastaveni/nastaveni-preview.php
+
 /docker-compose.override.yml
 /.env
 

--- a/model/funkce/funkce.php
+++ b/model/funkce/funkce.php
@@ -1091,6 +1091,7 @@ function jsmeNaOstre(): bool
     $definedHost = getDefinedHost();
 
     return $definedHost !== null
+        && !jsmeNaPreview()
         && (
             in_array(
                 $definedHost,
@@ -1099,6 +1100,24 @@ function jsmeNaOstre(): bool
             )
             || preg_match('~(?<rocnik>[0-9]{4})[.]gamecon[.]cz$~', $definedHost)
         );
+}
+
+function jsmeNaPreview(): bool
+{
+    $definedHost = getDefinedHost();
+
+    return $definedHost !== null && jeHostPreview($definedHost);
+}
+
+/**
+ * Per-branch preview deploys live at <slug>.preview.gamecon.cz, with
+ * path-based routing (/admin, /web, /cache/public) — see
+ * nastaveni/verejne-nastaveni-preview.php. The leading slug is optional,
+ * so preview.gamecon.cz itself also matches.
+ */
+function jeHostPreview(string $host): bool
+{
+    return preg_match('~(^|[.])preview[.]gamecon[.]cz$~', $host) === 1;
 }
 
 function quickReportPlaceholderReplace(

--- a/nastaveni/verejne-nastaveni-beta.php
+++ b/nastaveni/verejne-nastaveni-beta.php
@@ -4,9 +4,13 @@ use Gamecon\Role\Role;
 
 require_once __DIR__ . '/nastaveni-beta.php';
 
-define('URL_WEBU', 'https://beta.gamecon.cz'); // absolutní url uživatelského webu
-define('URL_ADMIN', 'https://admin.beta.gamecon.cz'); // absolutní url adminu
-define('URL_CACHE', 'https://cache.beta.gamecon.cz'); // url sdílených cachí
+// URL_WEBU / URL_ADMIN / URL_CACHE honour env-var overrides so a single
+// Docker image can serve different prod/beta/preview deployments by
+// .env file (see docs/docker-migration-plan.md §2.7). Default values
+// preserve the legacy FTP-deploy behavior unchanged.
+define('URL_WEBU', getenv('URL_WEBU') ?: 'https://beta.gamecon.cz');         // absolutní url uživatelského webu
+define('URL_ADMIN', getenv('URL_ADMIN') ?: 'https://admin.beta.gamecon.cz'); // absolutní url adminu
+define('URL_CACHE', getenv('URL_CACHE') ?: 'https://cache.beta.gamecon.cz'); // url sdílených cachí
 
 define('ANALYTICS', false);
 define('HTTPS_ONLY', true);

--- a/nastaveni/verejne-nastaveni-preview.php
+++ b/nastaveni/verejne-nastaveni-preview.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/nastaveni-preview.php';
+
+// Preview deploys live at <slug>.preview.gamecon.cz with PATH-based routing
+// (no admin./cache. subdomains — that's a production-only convention).
+// The URL constants therefore mirror the local-dev shape: same host,
+// distinct path prefixes.
+$previewHost = defined('SERVER_NAME')
+    ? constant('SERVER_NAME')
+    : ($_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? 'preview.gamecon.cz');
+
+define('URL_WEBU', 'https://' . $previewHost);
+define('URL_ADMIN', 'https://' . $previewHost . '/admin');
+define('URL_CACHE', 'https://' . $previewHost . '/cache/public');
+
+// Previews use production-style data via the auto-restore-from-ostra hook
+// (see docs/docker-migration-plan.md §2.5). We deliberately do NOT send
+// analytics from previews — they're noise in real metrics — and we DO
+// enforce HTTPS because HAProxy terminates TLS for *.preview.gamecon.cz.
+define('ANALYTICS', false);
+define('HTTPS_ONLY', true);
+
+define('REACT_V_PROHLIZECI', false);
+define('AUTOMATICKE_SESTAVENI', false);
+define('BABEL_BINARKA', null);
+
+/** aktuální ročník -- při změně roku viz Překlápění ročníku @link PREKLOPENI_ROCNIKU_NAVOD.md */
+define('ROCNIK', 2026);
+
+error_reporting(E_ALL); // reportuje se vše, o zobrazení se stará výjimkovač

--- a/nastaveni/verejne-nastaveni-produkce.php
+++ b/nastaveni/verejne-nastaveni-produkce.php
@@ -1,9 +1,13 @@
 <?php
 require_once __DIR__ . '/nastaveni-produkce.php';
 
-define('URL_WEBU', 'https://gamecon.cz');        // absolutní url uživatelského webu
-define('URL_ADMIN', 'https://admin.gamecon.cz'); // absolutní url adminu
-define('URL_CACHE', 'https://cache.gamecon.cz'); // url sdílených cachí
+// URL_WEBU / URL_ADMIN / URL_CACHE honour env-var overrides so a single
+// Docker image can serve different prod/beta/preview deployments by
+// .env file (see docs/docker-migration-plan.md §2.7). Default values
+// preserve the legacy FTP-deploy behavior unchanged.
+define('URL_WEBU', getenv('URL_WEBU') ?: 'https://gamecon.cz');         // absolutní url uživatelského webu
+define('URL_ADMIN', getenv('URL_ADMIN') ?: 'https://admin.gamecon.cz'); // absolutní url adminu
+define('URL_CACHE', getenv('URL_CACHE') ?: 'https://cache.gamecon.cz'); // url sdílených cachí
 
 define('ANALYTICS', true);
 define('HTTPS_ONLY', true);

--- a/nastaveni/zavadec-nastaveni.php
+++ b/nastaveni/zavadec-nastaveni.php
@@ -15,6 +15,12 @@ if (jsmeNaLocale()) {
     require_once __DIR__ . '/nastaveni-local-default.php'; // výchozí lokální nastavení
 } elseif (jsmeNaBete()) {
     $souborVerejnehoNastaveni = __DIR__ . '/verejne-nastaveni-beta.php';
+} elseif (jsmeNaPreview()) {
+    // Per-branch preview deploys at <slug>.preview.gamecon.cz — must be
+    // checked BEFORE jsmeNaOstre() because that fallback would
+    // historically swallow any *.gamecon.cz host. (We also tightened
+    // jsmeNaOstre's regex to exclude preview hosts, but order belt+braces.)
+    $souborVerejnehoNastaveni = __DIR__ . '/verejne-nastaveni-preview.php';
 } elseif (jsmeNaOstre()) {
     $souborVerejnehoNastaveni = __DIR__ . '/verejne-nastaveni-produkce.php';
 } else {

--- a/tests/funkce/FunkceTest.php
+++ b/tests/funkce/FunkceTest.php
@@ -113,4 +113,47 @@ class FunkceTest extends TestCase
             [' -  10001  ', -10001.0],
         ];
     }
+
+    /**
+     * @test
+     *
+     * @dataProvider providePreviewHostDetection
+     */
+    public function muzuRozpoznatPreviewHostiteleZPreviewSubdomeny(string $host, bool $ocekavaneJePreview): void
+    {
+        self::assertSame($ocekavaneJePreview, jeHostPreview($host));
+    }
+
+    public static function providePreviewHostDetection(): array
+    {
+        return [
+            // Preview hostnames — TRUE.
+            'preview pod slugem'                => ['foo.preview.gamecon.cz', true],
+            'preview pod čtyřčíslicovým slugem' => ['1234.preview.gamecon.cz', true],
+            'preview pod složeným slugem'       => ['feature-bar.preview.gamecon.cz', true],
+            'root preview domain bez slugu'     => ['preview.gamecon.cz', true],
+
+            // Production / beta / archive years — FALSE. The
+            // year-archive pattern is the main reason jsmeNaOstre()'s
+            // regex needs the `!jsmeNaPreview()` guard: '1234.gamecon.cz'
+            // is legitimately ostra-archive but '1234.preview.gamecon.cz'
+            // must be preview.
+            'ostra root'         => ['gamecon.cz', false],
+            'ostra admin'        => ['admin.gamecon.cz', false],
+            'ostra cache'        => ['cache.gamecon.cz', false],
+            'beta'               => ['beta.gamecon.cz', false],
+            'beta admin'         => ['admin.beta.gamecon.cz', false],
+            'archive year 2024'  => ['2024.gamecon.cz', false],
+            'archive year admin' => ['admin.2024.gamecon.cz', false],
+
+            // Adversarial — must not match. A naive
+            // `~preview[.]gamecon[.]cz$~` would falsely match these; the
+            // `(^|[.])` anchor exists exactly to reject them.
+            'xpreview neni preview'     => ['xpreview.gamecon.cz', false],
+            'sneakpreview neni preview' => ['sneakpreview.gamecon.cz', false],
+            'localhost'                 => ['localhost', false],
+            'unrelated domain'          => ['example.com', false],
+            'similar prefix'            => ['preview.example.com', false],
+        ];
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the Ansible→Docker migration ([plan](https://github.com/gamecon-cz/ansible/blob/sops/docs/docker-migration-plan.md)): make the application *subdomain-optional* so per-PR preview deploys can live at `<slug>.preview.gamecon.cz` without admin./cache. subdomain trios.

- New environment detector `jsmeNaPreview()` paired with a pure-function helper `jeHostPreview()` so the regex is unit-testable.
- New settings file `nastaveni/verejne-nastaveni-preview.php` that derives `URL_WEBU` / `URL_ADMIN` / `URL_CACHE` from the actual preview host (path-based routing, mirroring local dev).
- `zavadec-nastaveni.php` checks `jsmeNaPreview()` **before** `jsmeNaOstre()` so the year-archive regex (`<n>.gamecon.cz`) doesn't accidentally swallow `<n>.preview.gamecon.cz`. `jsmeNaOstre()` additionally tightened with a `!jsmeNaPreview()` guard.
- `URL_WEBU` / `URL_ADMIN` / `URL_CACHE` in `verejne-nastaveni-{produkce,beta}.php` now honour env-var overrides (`getenv('URL_WEBU') ?: 'https://gamecon.cz'`). Defaults preserve current FTP-deploy behaviour exactly.
- `.gitignore`: never commit runtime-generated `nastaveni-{produkce,beta,preview}.php` — they hold decrypted DB creds / app secrets.

Zero infra change; this PR is the application-layer prerequisite for Phase 2+ of the migration.

## Test plan

- [x] `tests/funkce/FunkceTest.php` covers `jeHostPreview()` with 16 data-provider cases — preview slugs (incl. 4-digit ones that would collide with year-archive regex), root preview domain, all production hostnames, beta hostnames, archive years, and adversarial fakes (`xpreview.gamecon.cz`, `sneakpreview.gamecon.cz`, `preview.example.com`).
- [x] Full phpunit suite: 730 tests / 2747 assertions, all green
- [x] PHPStan: no errors
- [x] ECS: clean
- [x] Local smoke test (dev container with `ENV=` unset and `SERVER_NAME=foo.preview.gamecon.cz`) confirms boot path produces correct `URL_*` constants and `jsmeNaPreview=true`, `jsmeNaOstre=false`, `jsmeNaBete=false`, `jsmeNaLocale=false`
- [x] Local dev (with `ENV=local`) still hits `nastaveni-local-default.php` — `localhost:85`, `/admin`, `/cache/public` unchanged

## Notes

- The hostname `*.preview.gamecon.cz` resolves through the existing `*.gamecon.cz` DNS wildcard — no DNS work needed at the registrar.
- `verejne-nastaveni-preview.php` requires `nastaveni-preview.php` which is generated at runtime by `vytvorSouborSkrytehoNastaveniPodleEnv()` from env vars, same pattern as produkce/beta. Now gitignored.