### PR TITLE
Remove dead nav links from program-test harness

### DIFF
--- a/admin/scripts/zvlastni/program-test.php
+++ b/admin/scripts/zvlastni/program-test.php
@@ -202,8 +202,6 @@ $check = static fn(bool $v): string => $v ? '<span class="flag-true">✓</span>'
            style="float:right;width:100px;height:35px">
     <?= $uPracovni ? $uPracovni->jmenoNick() : '(mock uživatel)' ?><br>
     <?= $uPracovni ? '<span id="stavUctu">' . $uPracovni->finance()->formatovanyStav() . '</span><br>' : '' ?>
-    <a href="program-uzivatele" class="program-odkaz">Program</a> |
-    <a href="program-osobni"    class="program-odkaz">Program účastníka</a>
 </div>
 
 <!-- ================================================================ -->


### PR DESCRIPTION
## Summary

- `admin/scripts/zvlastni/program-test.php` is a dev/QA harness that renders the program preact UI against mocked endpoints — it has no real selected user (header literally shows `(mock uživatel)`).
- The sticky header was copy-pasted from `program-uzivatele.php` and included two nav links (`Program` / `Program účastníka`) that send you out of the mock environment into the real admin pages, defeating the whole point of the harness.
- This PR removes those two links. The rest of the harness header (close button, nick/balance) stays — those have sensible fallbacks for the mock case.

Spotted during review of #835.

## Test plan

- [x] `/admin/program-test` still renders the mock panel and preact program
- [x] No `a.program-odkaz` elements in the harness header
- [x] Close button still works