### PR TITLE
Dockerfile.archive + CI workflow for per-year archives

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -1,0 +1,93 @@
+name: Deploy year archive
+
+# yamllint disable-line rule:truthy
+on:
+    # Manual only for now. Auto-trigger on push to archive/* branches will
+    # land once the host's ci-preview-wrapper (or its successor) is
+    # extended to allowlist deploy-year-archive.sh. Today the existing
+    # GAMECON_DEPLOY_SSH_KEY can only invoke deploy-preview-branch.sh,
+    # so the first year-archive cutovers are operator-driven from the
+    # GitHub Actions UI.
+    workflow_dispatch:
+        inputs:
+            branch:
+                description: 'archive/YYYY branch to deploy (e.g. archive/2024)'
+                required: true
+
+permissions:
+    contents: read
+    packages: write   # push to ghcr.io
+
+jobs:
+    deploy:
+        runs-on: ubuntu-24.04
+        steps:
+            -   name: Checkout archive branch
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.event.inputs.branch }}
+
+            -   name: Derive year from branch name
+                id: year
+                # Branch shape is enforced: archive/<4 digits>. Anything else
+                # is rejected here so we don't accidentally build an image
+                # from an unrelated branch via workflow_dispatch typo.
+                run: |
+                    branch="${{ github.event.inputs.branch }}"
+                    if [[ ! "$branch" =~ ^archive/([0-9]{4})$ ]]; then
+                        echo "::error::Branch '$branch' does not match archive/YYYY" >&2
+                        exit 1
+                    fi
+                    year="${BASH_REMATCH[1]}"
+                    if (( year < 2011 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2011..2099" >&2
+                        exit 1
+                    fi
+                    sha7="${GITHUB_SHA::7}"
+                    echo "year=$year" >> "$GITHUB_OUTPUT"
+                    echo "sha7=$sha7" >> "$GITHUB_OUTPUT"
+                    echo "Deploying year $year ($sha7)"
+
+            -   name: Log in to GHCR
+                uses: docker/login-action@v3
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v3
+
+            -   name: Build + push archive image
+                # Two tags pushed per build:
+                #   archive-<year>            — rolling "latest for this year"
+                #   archive-<year>-<sha7>     — immutable, points at exactly
+                #                                this commit's image
+                # The deploy step always references the SHA-pinned tag, so
+                # the server can never accidentally use a stale image if a
+                # pull-fallback path runs against a cached layer.
+                uses: docker/build-push-action@v6
+                with:
+                    context: .
+                    file: Dockerfile.archive
+                    push: true
+                    tags: |
+                        ghcr.io/${{ github.repository_owner }}/gamecon:archive-${{ steps.year.outputs.year }}
+                        ghcr.io/${{ github.repository_owner }}/gamecon:archive-${{ steps.year.outputs.year }}-${{ steps.year.outputs.sha7 }}
+                    # Reuse layers across archive builds. Heavy layers
+                    # (apt + pecl from the base) come from the base image
+                    # so the gha cache mostly helps with the COPY layer
+                    # invalidation across closely-related archive
+                    # branches.
+                    cache-from: type=gha,scope=archive
+                    cache-to: type=gha,scope=archive,mode=max
+
+            -   name: Output image ref
+                # The host-side cutover is operator-driven for now (see
+                # workflow note at the top). Print the exact SSH command an
+                # operator can paste to finish the deploy.
+                run: |
+                    image="ghcr.io/${{ github.repository_owner }}/gamecon:archive-${{ steps.year.outputs.year }}-${{ steps.year.outputs.sha7 }}"
+                    echo "::notice::Image pushed: $image"
+                    echo "::notice::To deploy on gamecon.cz:"
+                    echo "::notice::  ssh root@gamecon.cz /usr/local/sbin/deploy-year-archive.sh ${{ steps.year.outputs.year }} '$image'"

--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -11,7 +11,7 @@ on:
     workflow_dispatch:
         inputs:
             branch:
-                description: 'archive/YYYY branch to deploy (e.g. archive/2024)'
+                description: 'archive/YYYY or archive/YYYY-<suffix> branch (e.g. archive/2024, archive/2024-test)'
                 required: true
 
 permissions:
@@ -29,13 +29,18 @@ jobs:
 
             -   name: Derive year from branch name
                 id: year
-                # Branch shape is enforced: archive/<4 digits>. Anything else
-                # is rejected here so we don't accidentally build an image
-                # from an unrelated branch via workflow_dispatch typo.
+                # Branch shape: archive/<4 digits> for the canonical archive
+                # branch, or archive/<4 digits>-<suffix> for test/scratch
+                # variants (archive/2024-test, archive/2024-dbg, …). The
+                # year is taken from the digits; suffix is ignored, so a
+                # test branch deploys with the same image tag base and the
+                # same host-side cmd as the real branch. Anything else is
+                # rejected so we don't accidentally build an image from
+                # an unrelated branch via a workflow_dispatch typo.
                 run: |
                     branch="${{ github.event.inputs.branch }}"
-                    if [[ ! "$branch" =~ ^archive/([0-9]{4})$ ]]; then
-                        echo "::error::Branch '$branch' does not match archive/YYYY" >&2
+                    if [[ ! "$branch" =~ ^archive/([0-9]{4})(-[a-z0-9-]+)?$ ]]; then
+                        echo "::error::Branch '$branch' does not match archive/YYYY[-suffix]" >&2
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -1,0 +1,82 @@
+# Year-archive image for NNNN.gamecon.cz.
+#
+# Built once per archived year by .github/workflows/deploy-year-archive.yml
+# from the corresponding archive/NNNN branch. Tagged
+# ghcr.io/gamecon-cz/gamecon:archive-<year>-<sha7> and pulled by the
+# host's deploy-year-archive.sh script.
+#
+# Differs from Dockerfile.preview in two important ways:
+#   1. NO composer install / yarn build at build time. Archived branches
+#      are expected to have committed vendor/ and ui/ build artifacts
+#      already (see .htdeployment artifacts in the 2024 on-disk
+#      snapshot). Skipping these saves ~3 min of build time per year
+#      and avoids depending on whichever Composer/Node version happened
+#      to be installed in the archived branch's base image.
+#   2. NO migration / cache-refresh hooks at deploy time. Archives are
+#      read-only-ish — the DB is a frozen point in time, code is frozen
+#      at the branch tip. Nothing to migrate.
+#
+# Apache vhost is the base image's default (DocumentRoot
+# /var/www/html/gamecon, AllowOverride All via the upstream
+# docker-php.conf), same as preview. The top-level .htaccess routes
+# requests into web/, cache/private/.htaccess denies direct access,
+# admin/ and cache/public/ are reachable as subdirectories. All
+# verified in the recon log in the ansible repo
+# (docs/year-archive-phase0-recon.md).
+
+FROM gameconcz/gamecon:8.2
+
+USER root
+
+# Bake the entire archived branch's working tree in. The chown matches
+# the runtime user; matches Dockerfile.preview's approach.
+COPY --chown=www-data:www-data . /var/www/html/gamecon
+
+WORKDIR /var/www/html/gamecon
+
+# Strip dev / runtime junk that snuck in via COPY .. cache/private gets
+# rebuilt on demand, no point baking historical entries into the image.
+# .git is ~tens of MB and never read at runtime. .htdeployment is the
+# deployment ledger; archived branches won't be re-deployed via that
+# mechanism so its presence is just dead weight (~120 KB but pointless).
+RUN rm -rf \
+    /var/www/html/gamecon/.git \
+    /var/www/html/gamecon/.github \
+    /var/www/html/gamecon/.docker \
+    /var/www/html/gamecon/.htdeployment \
+    /var/www/html/gamecon/node_modules \
+    /var/www/html/gamecon/ui/node_modules \
+    /var/www/html/gamecon/tests \
+    /var/www/html/gamecon/phpunit*.* \
+    /var/www/html/gamecon/phpstan*.* \
+    /var/www/html/gamecon/cache/private
+
+# Make cache/ and logy/ writable by Apache. cache/public stays (assets
+# committed at archive time); only cache/private was stripped above
+# and we recreate it empty here so the app can write to it at runtime.
+RUN mkdir -p \
+    /var/www/html/gamecon/cache/private \
+    /var/www/html/gamecon/cache/public \
+    /var/www/html/gamecon/logy \
+    && chown -R www-data:www-data \
+        /var/www/html/gamecon/cache \
+        /var/www/html/gamecon/logy
+
+# Apache snippet honoring X-Forwarded-Proto from the upstream proxy chain
+# (HAProxy → Caddy → this container). Reused as-is from the preview
+# tier: same proxy chain, same need. Without it, $_SERVER['HTTPS'] is
+# unset in PHP and generated URLs (<base href>, redirects, cookies)
+# come out as http://.
+COPY preview/apache-https.conf /etc/apache2/conf-available/preview-https.conf
+RUN a2enconf preview-https
+
+# Pick up the archive-specific verejne-nastaveni file (created on each
+# archive/NNNN branch). The base image ships ENV=local; archive
+# overrides to "archive" so zavadec-nastaveni.php takes the archive
+# path and reads DB creds from getenv() (set by the deploy script's
+# `docker run -e`).
+ENV ENV=archive
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]


### PR DESCRIPTION
## Summary

Per-year archive container infrastructure on the gamecon-repo side.
Companion to ansible-side PR
[gamecon-cz/ansible#15](https://github.com/gamecon-cz/ansible/pull/15)
which adds the host script + HAProxy SNI ACL.

Adds two new files and nothing else.

### What's in this PR

- **`Dockerfile.archive`** — mirrors `Dockerfile.preview`'s shape but
  skips composer install and yarn build. Archived branches commit
  `vendor/` and `ui/` artifacts at archival time, so the runtime image
  just needs the source baked in. Sets `ENV=archive` so
  `zavadec-nastaveni.php` reads DB creds from `getenv()` (set by the
  host script via `docker run -e`).

- **`.github/workflows/deploy-year-archive.yml`** — `workflow_dispatch`
  only. Validates the input branch matches `archive/YYYY` with a year
  in 2011..2099, then builds + pushes to
  `ghcr.io/gamecon-cz/gamecon:archive-<year>-<sha7>` (and a rolling
  `archive-<year>` tag). Outputs a notice with the exact SSH command
  an operator runs to finish the deploy.

### Why `workflow_dispatch` only?

The existing `GAMECON_DEPLOY_SSH_KEY` is forced-command-pinned to
`/usr/local/sbin/ci-preview-wrapper`, which only allowlists
`deploy-preview-branch.sh`. Allowing year-archive deploys from CI
needs that wrapper extended (or a separate key) — a small follow-up
in the ansible repo. Until then, first archive cutovers are
operator-driven: trigger the workflow from the UI, then SSH as
yourself to run the printed command. Frequency is low (~once per
year for new archives, plus the one-time 2011–2023 backfill) so this
is acceptable.

### Out of scope (follow-ups)

- Creating the `archive/2024` branch (from `cb9d9844c^` per design
  doc decision). Source-of-truth + the three small patches from
  `docs/year-archive-phase0-recon.md` (URL_* constants,
  KontextZobrazeni order flip, env-driven DB creds) are direct
  commits on that branch — not loose `.patch` files.
- Extending the host's CI wrapper to allowlist
  `deploy-year-archive.sh` (ansible repo).
- On-demand container lifecycle (Phase 2.5 in the plan) — needed
  before backfilling 2011–2023 so the 4 GiB server doesn't OOM.

### Risk

Trivial — two new files; nothing modified. Workflow is
`workflow_dispatch` only so it can't accidentally fire on a regular
push. `Dockerfile.archive` isn't built by any existing CI path.

## Test plan

- [ ] Once `archive/2024` branch lands, trigger the workflow against
      it from the Actions UI.
- [ ] Confirm GHCR shows `ghcr.io/gamecon-cz/gamecon:archive-2024-<sha7>`
      and a rolling `archive-2024` tag.
- [ ] Confirm workflow output prints the SSH deploy command.
- [ ] Operator runs the printed SSH command, verifies the container
      starts, Caddy site block lands at
      `/etc/caddy/conf.d/archive-2024.conf`, and a `curl --resolve`
      smoke test against `127.0.0.1:443` returns the 2024 archive site.
