### PR TITLE
Grant switch-user role to devs on preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,33 @@ vendor/bin/phpunit
   - LOGY constant in tests: `/var/www/html/gamecon/logy/tests/{PID}` (inside Docker)
   - These are NOT in `/tmp` - they're in the project's `logy/tests/` directory
 
+### Testing Doctrine repositories: beware the two-connection deadlock
+
+`AbstractTestDb` wraps each test in a transaction on the **legacy `dbQuery`/`mysqli` connection** (via `keepTestClassDbChangesInTransaction` / `keepSingleTestMethodDbChangesInTransaction`, which default to `true`). A Doctrine repository/EntityManager uses a **separate Doctrine DBAL connection**. The two connections do not share a transaction.
+
+If a test inserts fixture rows with legacy `dbQuery(...)` (uncommitted, inside the legacy transaction) and then the repository under test runs a Doctrine query that reads or writes those same rows, the Doctrine connection blocks on the legacy connection's row locks → `SQLSTATE[HY000]: 1205 Lock wait timeout exceeded`. This is **not** a bug in the repository — it's two connections fighting over uncommitted rows.
+
+**Fix:** when testing a Doctrine repository, route **all** fixtures and assertions through the **Doctrine connection** so everything shares one connection, and opt out of the legacy transaction wrapping:
+
+```php
+class UserRoleRepositoryTest extends AbstractTestDb
+{
+    // Legacy per-test transaction wrapping would isolate fixtures from the
+    // Doctrine connection. Reset the DB after the class instead.
+    protected static function keepTestClassDbChangesInTransaction(): bool { return false; }
+    protected static function keepSingleTestMethodDbChangesInTransaction(): bool { return false; }
+    protected static function resetDbAfterClass(): bool { return true; }
+
+    private function connection(): \Doctrine\DBAL\Connection
+    {
+        return $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+    }
+    // ... use $this->connection()->executeStatement(...) / ->fetchOne(...) for fixtures + asserts
+}
+```
+
+Get the custom repository via `->getRepository(SomeEntity::class)` (returns the project's `ServiceEntityRepository`; repos aren't public services by default, so don't `->get()` them by class). Don't mix legacy `dbQuery` and Doctrine writes in the same test against the same tables.
+
 ## Temporary Scripts for Research/Debugging
 - When running multi-step research or debugging inside Docker (grepping vendor files, reading multiple files, testing PHP snippets, etc.), use the `Write` tool to create a temporary script in `symfony/var/`, then execute it with `./bin-docker/php symfony/var/script.php` (or `bash symfony/var/script.sh`). Delete the script after use.
 - Do NOT use inline PHP (`./bin-docker/php -r "..."`) or heredocs — those trigger permission prompts.

--- a/symfony/src/Command/GrantSwitchUserRoleToDevsCommand.php
+++ b/symfony/src/Command/GrantSwitchUserRoleToDevsCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\UserRoleRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:grant-switch-user-role-to-devs',
+    description: 'Grant the current-year "switch to user" role to all Dev-role users (run after restoring the production DB into a preview).',
+)]
+class GrantSwitchUserRoleToDevsCommand extends Command
+{
+    public function __construct(
+        private readonly UserRoleRepository $userRoleRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'year',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Ročník whose switch-user role to grant (default: current ROCNIK)',
+            )
+            ->setHelp(
+                'Preview environments run on a freshly restored production DB. The '
+                . '"switch to user" role is yearly and resets each ročník, so the '
+                . 'restored DB never carries it. This command grants it to every '
+                . 'Dev-role user so developers can impersonate any user on the '
+                . 'preview. The deploy script runs it right after the DB restore.',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $year = $this->resolveYear($input);
+
+        try {
+            $granted = $this->userRoleRepository->grantSwitchUserRoleToDevs($year);
+            $io->success(sprintf(
+                'Granted the switch-user role for year %d to %d Dev user(s).',
+                $year,
+                $granted,
+            ));
+
+            return Command::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $io->error('Granting the role failed: ' . $throwable->getMessage());
+            $io->writeln($throwable->getTraceAsString());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function resolveYear(InputInterface $input): int
+    {
+        $yearOption = $input->getOption('year');
+        if ($yearOption !== null) {
+            return (int) $yearOption;
+        }
+
+        // Legacy bootstrap defines the current ročník as the ROCNIK constant.
+        require_once __DIR__ . '/../../../nastaveni/zavadec-zaklad.php';
+
+        return ROCNIK;
+    }
+}

--- a/symfony/src/Repository/UserRoleRepository.php
+++ b/symfony/src/Repository/UserRoleRepository.php
@@ -18,9 +18,75 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class UserRoleRepository extends ServiceEntityRepository
 {
+    /**
+     * Význam (significance code) of the permanent "developer" role.
+     *
+     * @see \Gamecon\Role\Role::VYZNAM_DEV
+     */
+    private const ROLE_SIGNIFICANCE_DEV = 'DEV';
+
+    /**
+     * Význam of the yearly "may switch to any user in admin" role.
+     *
+     * @see \Gamecon\Role\Role::VYZNAM_PREPINANI_UZIVATELE
+     */
+    private const ROLE_SIGNIFICANCE_SWITCH_USER = 'PREPINANI_NA_UZIVATELE';
+
+    /**
+     * Id of the user representing the system itself (used as "granted by").
+     *
+     * @see \Uzivatel::SYSTEM
+     */
+    private const SYSTEM_USER_ID = 1;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, UserRole::class);
+    }
+
+    /**
+     * Grant the yearly "switch to any user" role to every user who holds the
+     * permanent Dev role.
+     *
+     * Used after a fresh production DB is restored into a preview environment:
+     * the switch-user role is yearly and resets each ročník, so a freshly
+     * restored DB never carries it. Granting it to all developers lets them
+     * impersonate any user on the preview right away.
+     *
+     * Idempotent — re-running skips users who already have the role (the
+     * uzivatele_role UNIQUE(id_uzivatele, id_role) constraint backs the
+     * INSERT IGNORE). Returns the number of newly granted assignments.
+     */
+    public function grantSwitchUserRoleToDevs(int $year): int
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        // INSERT ... SELECT copies the user list straight from the DB; no need
+        // to hydrate entities just to re-insert them. INSERT IGNORE makes the
+        // statement idempotent against the unique (user, role) constraint.
+        return (int) $connection->executeStatement(
+            <<<'SQL'
+            INSERT IGNORE INTO uzivatele_role (id_uzivatele, id_role, posazen, posadil)
+            SELECT
+                dev_role.id_uzivatele,
+                switch_user_role.id_role,
+                NOW(),
+                :systemUserId
+            FROM uzivatele_role AS dev_role
+            JOIN role_seznam AS dev_role_def
+                ON dev_role_def.id_role = dev_role.id_role
+                AND dev_role_def.vyznam_role = :devSignificance
+            JOIN role_seznam AS switch_user_role
+                ON switch_user_role.vyznam_role = :switchUserSignificance
+                AND switch_user_role.rocnik_role = :year
+            SQL,
+            [
+                'systemUserId'           => self::SYSTEM_USER_ID,
+                'devSignificance'        => self::ROLE_SIGNIFICANCE_DEV,
+                'switchUserSignificance' => self::ROLE_SIGNIFICANCE_SWITCH_USER,
+                'year'                   => $year,
+            ],
+        );
     }
 
     public function save(UserRole $entity, bool $flush = false): void

--- a/tests/Repository/UserRoleRepositoryTest.php
+++ b/tests/Repository/UserRoleRepositoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Repository;
+
+use App\Entity\UserRole;
+use App\Repository\UserRoleRepository;
+use Doctrine\DBAL\Connection;
+use Gamecon\Role\Role;
+use Gamecon\Tests\Db\AbstractTestDb;
+
+/**
+ * All fixtures and assertions go through the Doctrine DBAL connection (not the
+ * legacy dbQuery one) so everything shares a single connection. The repository
+ * under test uses the Doctrine connection too; mixing it with the legacy
+ * connection's open transaction would deadlock on the uzivatele_role rows.
+ */
+class UserRoleRepositoryTest extends AbstractTestDb
+{
+    // Legacy per-test transaction wrapping would isolate fixtures from the
+    // Doctrine connection. Reset the DB after the class instead.
+    protected static function keepTestClassDbChangesInTransaction(): bool
+    {
+        return false;
+    }
+
+    protected static function keepSingleTestMethodDbChangesInTransaction(): bool
+    {
+        return false;
+    }
+
+    protected static function resetDbAfterClass(): bool
+    {
+        return true;
+    }
+
+    private function connection(): Connection
+    {
+        return $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+    }
+
+    private function repository(): UserRoleRepository
+    {
+        $repository = $this->getContainer()
+            ->get('doctrine.orm.entity_manager')
+            ->getRepository(UserRole::class);
+        \assert($repository instanceof UserRoleRepository);
+
+        return $repository;
+    }
+
+    private function vytvorUzivatele(string $suffix): int
+    {
+        $connection = $this->connection();
+        $connection->executeStatement(
+            <<<'SQL'
+            INSERT INTO uzivatele_hodnoty
+                SET login_uzivatele = :login,
+                    email1_uzivatele = :email,
+                    jmeno_uzivatele = 'Test',
+                    prijmeni_uzivatele = 'UserRoleRepository'
+            SQL,
+            [
+                'login' => 'test_switch_user_' . $suffix,
+                'email' => 'test.switch.user.' . $suffix . '@example.org',
+            ],
+        );
+
+        return (int) $connection->lastInsertId();
+    }
+
+    private function pridelRoli(int $idUzivatele, int $idRole): void
+    {
+        $this->connection()->executeStatement(
+            'INSERT INTO uzivatele_role (id_uzivatele, id_role, posadil) VALUES (:user, :role, :user)',
+            [
+                'user' => $idUzivatele,
+                'role' => $idRole,
+            ],
+        );
+    }
+
+    private function maRoli(int $idUzivatele, int $idRole): bool
+    {
+        return (bool) $this->connection()->fetchOne(
+            'SELECT 1 FROM uzivatele_role WHERE id_uzivatele = :user AND id_role = :role',
+            [
+                'user' => $idUzivatele,
+                'role' => $idRole,
+            ],
+        );
+    }
+
+    public function testGrantSwitchUserRoleToDevs(): void
+    {
+        $idSwitchUserRole = Role::LETOSNI_PREPINANI_UZIVATELE(ROCNIK);
+
+        $dev = $this->vytvorUzivatele('dev');
+        $this->pridelRoli($dev, Role::DEV);
+        self::assertFalse(
+            $this->maRoli($dev, $idSwitchUserRole),
+            'Dev user does not have the switch-user role yet',
+        );
+
+        $nonDev = $this->vytvorUzivatele('non_dev');
+        $this->pridelRoli($nonDev, Role::ORGANIZATOR);
+
+        $granted = $this->repository()->grantSwitchUserRoleToDevs(ROCNIK);
+
+        self::assertSame(1, $granted, 'Exactly one (Dev) user gets the role');
+        self::assertTrue(
+            $this->maRoli($dev, $idSwitchUserRole),
+            'Dev user received the yearly switch-user role',
+        );
+        self::assertFalse(
+            $this->maRoli($nonDev, $idSwitchUserRole),
+            'Non-Dev user does not receive the switch-user role',
+        );
+    }
+
+    public function testGrantSwitchUserRoleToDevsIsIdempotent(): void
+    {
+        $idSwitchUserRole = Role::LETOSNI_PREPINANI_UZIVATELE(ROCNIK);
+
+        $dev = $this->vytvorUzivatele('dev_idempotence');
+        $this->pridelRoli($dev, Role::DEV);
+
+        $firstRun = $this->repository()->grantSwitchUserRoleToDevs(ROCNIK);
+        $secondRun = $this->repository()->grantSwitchUserRoleToDevs(ROCNIK);
+
+        self::assertSame(1, $firstRun, 'First run grants the role');
+        self::assertSame(0, $secondRun, 'Second run grants nothing new');
+
+        $count = (int) $this->connection()->fetchOne(
+            'SELECT COUNT(*) FROM uzivatele_role WHERE id_uzivatele = :user AND id_role = :role',
+            [
+                'user' => $dev,
+                'role' => $idSwitchUserRole,
+            ],
+        );
+        self::assertSame(1, $count, 'The role is assigned exactly once');
+    }
+}


### PR DESCRIPTION
## What

When a preview environment boots, the deploy script restores the latest **production (ostrá) DB** from a BorgBase backup. The yearly **"Přepínání na uživatele"** (switch-to-any-user) role resets each ročník, so a freshly restored DB never carries it — developers couldn't impersonate users on a fresh preview.

This adds a command that grants the current-year switch-user role to **every user holding the permanent Dev role**, so developers can impersonate any user on the preview right away.

## How

- **`App\Repository\UserRoleRepository::grantSwitchUserRoleToDevs(int $year)`** — single idempotent `INSERT IGNORE … SELECT` (DBAL). Resolves both role IDs by význam in SQL joins (`DEV` + `PREPINANI_NA_UZIVATELE` for the given year) — no hardcoded ID arithmetic. Returns the count of newly granted assignments.
- **`App\Command\GrantSwitchUserRoleToDevsCommand`** — `app:grant-switch-user-role-to-devs` (`--year` defaults to `ROCNIK`). Thin wrapper that injects the repository.
- The command is invoked by the preview deploy script **right after the DB restore** (see the paired ansible PR), once migrations have created both role rows.

## Why a command (not a migration / boot hook)
A migration would run everywhere including production; the anonymized-dump boot path is a different flow. An explicit command lets the deploy script run it at exactly the right seam — after a fresh restore — and never on beta/production, where the rada grants this role deliberately.

## Tests
`tests/Repository/UserRoleRepositoryTest.php`: grants to Dev users only (not non-Dev), and is idempotent (1 then 0). All fixtures/assertions go through the Doctrine connection — mixing legacy `dbQuery` (separate, transaction-wrapped connection) with the Doctrine connection deadlocks on `uzivatele_role`. This gotcha is now documented in `CLAUDE.md`.

## Paired change
Requires the ansible deploy script to call the command: **gamecon-cz/ansible#23** (`grant-switch-user-role-to-devs-on-preview`). Takes effect on the next *fresh* preview deploy after that role is re-deployed.
