### PR TITLE
Auto-deploy archive site on push to archive branch

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -2,10 +2,14 @@ name: Deploy year archive
 
 # yamllint disable-line rule:truthy
 on:
-    # Manual trigger only — year archives are deployed once per year (or
-    # on the rare backfill of an older year). Auto-trigger on push to
-    # archive/* is intentionally absent: pushing a fixup commit to an
-    # archive branch shouldn't redeploy a frozen historical site.
+    # Auto-deploy on every push to an archive branch: pushing a fix to
+    # archive/YYYY redeploys that year's site so the change goes live
+    # without a manual dispatch. Branch shape is validated in the
+    # "Derive year" step (anything not archive/YYYY[-suffix] fails there).
+    push:
+        branches:
+            - 'archive/**'
+    # Manual trigger kept for backfills / redeploying a specific commit.
     workflow_dispatch:
         inputs:
             branch:
@@ -16,6 +20,14 @@ permissions:
     contents: read
     packages: write   # push to ghcr.io
 
+# Serialize deploys of the same archive branch. With push auto-deploy a
+# burst of commits could otherwise launch overlapping runs that race to
+# build + SSH-deploy the same year on the host. Newer push wins; we
+# don't cancel an in-flight run mid-deploy (let it finish cleanly).
+concurrency:
+    group: deploy-year-archive-${{ github.event.inputs.branch || github.ref_name }}
+    cancel-in-progress: false
+
 jobs:
     deploy:
         runs-on: ubuntu-24.04
@@ -23,7 +35,9 @@ jobs:
             -   name: Checkout archive branch
                 uses: actions/checkout@v4
                 with:
-                    ref: ${{ github.event.inputs.branch }}
+                    # workflow_dispatch supplies the branch as an input;
+                    # push supplies it as github.ref_name. Coalesce to one.
+                    ref: ${{ github.event.inputs.branch || github.ref_name }}
 
             -   name: Derive year from branch name + sha from checked-out HEAD
                 id: year
@@ -42,7 +56,7 @@ jobs:
                 # would tag the archive image with main's commit even
                 # though its content comes from the archive branch.
                 run: |
-                    branch="${{ github.event.inputs.branch }}"
+                    branch="${{ github.event.inputs.branch || github.ref_name }}"
                     if [[ ! "$branch" =~ ^archive/([0-9]{4})(-[a-z0-9-]+)?$ ]]; then
                         echo "::error::Branch '$branch' does not match archive/YYYY[-suffix]" >&2
                         exit 1


### PR DESCRIPTION
## What

Make the **Deploy year archive** workflow run automatically on every push to an `archive/**` branch, instead of manual `workflow_dispatch` only.

## Why

Pushing a fix to `archive/YYYY` should put that year's site live without someone remembering to manually dispatch the workflow.

> ⚠️ **This reverses a previous deliberate decision.** The workflow's old comment said auto-trigger was *intentionally absent* — "pushing a fixup commit to an archive branch shouldn't redeploy a frozen historical site." That tradeoff is now flipped on request: every commit to `archive/2024`, `archive/2025`, … rebuilds and redeploys the live `YYYY.gamecon.cz` site.

## How

- **Added `push` trigger** on `branches: ['archive/**']`. Kept `workflow_dispatch` for backfills / redeploying a specific commit.
- **Branch coalescing** — `github.event.inputs.branch || github.ref_name` in both the checkout `ref` and the year-derivation step, so one code path serves both events. The existing `^archive/([0-9]{4})(-[a-z0-9-]+)?$` regex still validates and rejects anything malformed (e.g. a stray push to a non-year archive branch fails fast in the "Derive year" step).
- **Added a per-branch `concurrency` group** (`cancel-in-progress: false`). The one new risk from auto-deploy is a burst of commits launching overlapping runs that race to build + SSH-deploy the same year on the host; this serializes them without killing an in-flight deploy.

## Notes

- YAML validated locally.
- Interaction with the `archive/**` ruleset (restrict deletions + block force-push): normal pushes are still allowed, so this trigger works; force-pushes are blocked (and wouldn't trigger a clean deploy anyway).
- After merge, a push (even an empty commit) to `archive/2024` / `archive/2025` will auto-deploy them.
