### PR TITLE
Sign archive/preview links for one-click gate access

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -71,3 +71,6 @@ jobs:
                     PREVIEW_BASIC_AUTH_PASSWORD: ${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                     ARCHIVE_BASIC_AUTH_USER: ${{ secrets.ARCHIVE_BASIC_AUTH_USER }}
                     ARCHIVE_BASIC_AUTH_PASSWORD: ${{ secrets.ARCHIVE_BASIC_AUTH_PASSWORD }}
+                    # Gate-token signing secrets (viz deploy-ostra.yml).
+                    PREVIEW_GATE_SECRET: ${{ secrets.PREVIEW_GATE_SECRET }}
+                    ARCHIVE_GATE_SECRET: ${{ secrets.ARCHIVE_GATE_SECRET }}

--- a/.github/workflows/deploy-ostra.yml
+++ b/.github/workflows/deploy-ostra.yml
@@ -78,3 +78,9 @@ jobs:
                     PREVIEW_BASIC_AUTH_PASSWORD: ${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                     ARCHIVE_BASIC_AUTH_USER: ${{ secrets.ARCHIVE_BASIC_AUTH_USER }}
                     ARCHIVE_BASIC_AUTH_PASSWORD: ${{ secrets.ARCHIVE_BASIC_AUTH_PASSWORD }}
+                    # Gate-token signing secrets — admin podepisuje ?gate=
+                    # odkazy, gate-validator za bránou je ověřuje. Musí být
+                    # shodné s preview.gate.secret / year_archive.gate.secret
+                    # v ansible secrets.yaml.
+                    PREVIEW_GATE_SECRET: ${{ secrets.PREVIEW_GATE_SECRET }}
+                    ARCHIVE_GATE_SECRET: ${{ secrets.ARCHIVE_GATE_SECRET }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -97,15 +97,21 @@ jobs:
                     tags: |
                         ghcr.io/${{ github.repository_owner }}/gamecon:preview-${{ steps.slug.outputs.slug }}
                         ghcr.io/${{ github.repository_owner }}/gamecon:preview-${{ steps.slug.outputs.slug }}-${{ steps.slug.outputs.sha7 }}
-                    # Basic-auth creds for the Caddy gate in front of preview /
-                    # archive envs. Baked into the image so the admin's dev
-                    # rozcestník in the preview renders links identically to
-                    # ostra (with foo:bar@host embedded). GHCR repo is private.
+                    # Basic-auth creds + gate-token signing secrets for the
+                    # Caddy gate in front of preview / archive envs. Baked into
+                    # the image so the admin's dev rozcestník in the preview
+                    # renders links identically to ostra (clean URL + copyable
+                    # creds, and a signed ?gate= token for one-click access).
+                    # These are access-control secrets shared across all
+                    # previews (not user data) — fine to bake. GHCR repo is
+                    # private.
                     build-args: |
                         PREVIEW_BASIC_AUTH_USER=${{ secrets.PREVIEW_BASIC_AUTH_USER }}
                         PREVIEW_BASIC_AUTH_PASSWORD=${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                         ARCHIVE_BASIC_AUTH_USER=${{ secrets.ARCHIVE_BASIC_AUTH_USER }}
                         ARCHIVE_BASIC_AUTH_PASSWORD=${{ secrets.ARCHIVE_BASIC_AUTH_PASSWORD }}
+                        PREVIEW_GATE_SECRET=${{ secrets.PREVIEW_GATE_SECRET }}
+                        ARCHIVE_GATE_SECRET=${{ secrets.ARCHIVE_GATE_SECRET }}
                     # Reuse layers across preview builds — composer + yarn
                     # layers in particular are slow to rebuild.
                     cache-from: type=gha,scope=preview

--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -97,15 +97,21 @@ jobs:
                     tags: |
                         ghcr.io/${{ github.repository_owner }}/gamecon:archive-${{ steps.year.outputs.year }}
                         ghcr.io/${{ github.repository_owner }}/gamecon:archive-${{ steps.year.outputs.year }}-${{ steps.year.outputs.sha7 }}
-                    # Basic-auth creds for the Caddy gate in front of preview /
-                    # archive envs. Baked into the image so the admin's dev
-                    # rozcestník in the archive renders links identically to
-                    # ostra (with foo:bar@host embedded). GHCR repo is private.
+                    # Basic-auth creds + gate-token signing secrets for the
+                    # Caddy gate in front of preview / archive envs. Baked into
+                    # the image so the admin's dev rozcestník in the archive
+                    # renders links identically to ostra (clean URL + copyable
+                    # creds, and a signed ?gate= token for one-click access).
+                    # These are access-control secrets shared across all
+                    # archives (not user data) — fine to bake. GHCR repo is
+                    # private.
                     build-args: |
                         PREVIEW_BASIC_AUTH_USER=${{ secrets.PREVIEW_BASIC_AUTH_USER }}
                         PREVIEW_BASIC_AUTH_PASSWORD=${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                         ARCHIVE_BASIC_AUTH_USER=${{ secrets.ARCHIVE_BASIC_AUTH_USER }}
                         ARCHIVE_BASIC_AUTH_PASSWORD=${{ secrets.ARCHIVE_BASIC_AUTH_PASSWORD }}
+                        PREVIEW_GATE_SECRET=${{ secrets.PREVIEW_GATE_SECRET }}
+                        ARCHIVE_GATE_SECRET=${{ secrets.ARCHIVE_GATE_SECRET }}
                     # Reuse layers across archive builds. Heavy layers
                     # (apt + pecl from the base) come from the base image
                     # so the gha cache mostly helps with the COPY layer

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -77,19 +77,25 @@ RUN a2enconf preview-https
 # `docker run -e`).
 ENV ENV=archive
 
-# Basic-auth credentials for the Caddy gate in front of preview /
-# archive environments. The admin's dev rozcestník embeds them in the
-# rendered links (foo:bar@host). Baked in here so the archive UI
-# behaves identically to ostra. GHCR repo is private; image layers are
-# not publicly readable.
+# Basic-auth credentials + gate-token signing secrets for the Caddy gate
+# in front of preview / archive environments. The admin's dev rozcestník
+# renders the gate login as copyable text and signs a ?gate= token onto
+# the links (one-click access via the gate-validator). Baked in here so
+# the archive UI behaves identically to ostra. Access-control secrets
+# shared across all archives (not user data); GHCR repo is private and
+# image layers are not publicly readable.
 ARG PREVIEW_BASIC_AUTH_USER=""
 ARG PREVIEW_BASIC_AUTH_PASSWORD=""
 ARG ARCHIVE_BASIC_AUTH_USER=""
 ARG ARCHIVE_BASIC_AUTH_PASSWORD=""
+ARG PREVIEW_GATE_SECRET=""
+ARG ARCHIVE_GATE_SECRET=""
 ENV PREVIEW_BASIC_AUTH_USER=$PREVIEW_BASIC_AUTH_USER \
     PREVIEW_BASIC_AUTH_PASSWORD=$PREVIEW_BASIC_AUTH_PASSWORD \
     ARCHIVE_BASIC_AUTH_USER=$ARCHIVE_BASIC_AUTH_USER \
-    ARCHIVE_BASIC_AUTH_PASSWORD=$ARCHIVE_BASIC_AUTH_PASSWORD
+    ARCHIVE_BASIC_AUTH_PASSWORD=$ARCHIVE_BASIC_AUTH_PASSWORD \
+    PREVIEW_GATE_SECRET=$PREVIEW_GATE_SECRET \
+    ARCHIVE_GATE_SECRET=$ARCHIVE_GATE_SECRET
 
 EXPOSE 80
 

--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -79,19 +79,25 @@ RUN a2enconf preview-https
 # would work, but "preview" is descriptive).
 ENV ENV=preview
 
-# Basic-auth credentials for the Caddy gate in front of preview /
-# archive environments. The admin's dev rozcestník embeds them in the
-# rendered links (foo:bar@host). Baked in here so the preview UI
-# behaves identically to ostra — same page, same clickable links.
-# GHCR repo is private; image layers are not publicly readable.
+# Basic-auth credentials + gate-token signing secrets for the Caddy gate
+# in front of preview / archive environments. The admin's dev rozcestník
+# renders the gate login as copyable text and signs a ?gate= token onto
+# the links (one-click access via the gate-validator). Baked in here so
+# the preview UI behaves identically to ostra — same page, same links.
+# Access-control secrets shared across all previews (not user data); GHCR
+# repo is private and image layers are not publicly readable.
 ARG PREVIEW_BASIC_AUTH_USER=""
 ARG PREVIEW_BASIC_AUTH_PASSWORD=""
 ARG ARCHIVE_BASIC_AUTH_USER=""
 ARG ARCHIVE_BASIC_AUTH_PASSWORD=""
+ARG PREVIEW_GATE_SECRET=""
+ARG ARCHIVE_GATE_SECRET=""
 ENV PREVIEW_BASIC_AUTH_USER=$PREVIEW_BASIC_AUTH_USER \
     PREVIEW_BASIC_AUTH_PASSWORD=$PREVIEW_BASIC_AUTH_PASSWORD \
     ARCHIVE_BASIC_AUTH_USER=$ARCHIVE_BASIC_AUTH_USER \
-    ARCHIVE_BASIC_AUTH_PASSWORD=$ARCHIVE_BASIC_AUTH_PASSWORD
+    ARCHIVE_BASIC_AUTH_PASSWORD=$ARCHIVE_BASIC_AUTH_PASSWORD \
+    PREVIEW_GATE_SECRET=$PREVIEW_GATE_SECRET \
+    ARCHIVE_GATE_SECRET=$ARCHIVE_GATE_SECRET
 
 EXPOSE 80
 

--- a/admin/scripts/modules/dev/previews.php
+++ b/admin/scripts/modules/dev/previews.php
@@ -11,7 +11,6 @@ use Gamecon\Dev\GateLink;
  * submenu_group: 1
  * submenu_order: 2
  */
-
 $reader = new DeploymentsReader();
 $unavailableReason = $reader->unavailableReason();
 $previews = $unavailableReason === null ? $reader->readPreviews() : [];
@@ -22,39 +21,39 @@ $previews = $unavailableReason === null ? $reader->readPreviews() : [];
 // session cookie, takže proklik projde bez dialogu. Když token vyprší / secret
 // není nastavený, brána spadne na basic auth — proto údaje ukazujeme jako
 // kopírovatelný text. Viz GateLink + ansible role gate_validator.
-$gateUrl = static fn(string $url): string => GateLink::podepis($url, PREVIEW_GATE_SECRET);
+$gateUrl = static fn (string $url): string => GateLink::podepis($url, PREVIEW_GATE_SECRET);
 
 $mailpitUrl = $gateUrl('https://webmail.preview.gamecon.cz/');
 
 // Preview slug = git branch name (viz .github/workflows/deploy-preview.yml).
 // Linkujeme do filtru PR listu — funguje pro open i closed PR a nerozbije
 // se, pokud větev neexistuje / PR ještě nevznikl.
-$prListUrl = static fn(string $slug): string => 'https://github.com/gamecon-cz/gamecon/pulls?q='
+$prListUrl = static fn (string $slug): string => 'https://github.com/gamecon-cz/gamecon/pulls?q='
     . rawurlencode('is:pr head:' . $slug);
 ?>
 <h2>Preview prostředí</h2>
 
 <div style="margin: 12px 0; padding: 14px 18px; border: 2px solid #2b7cb3; border-radius: 6px; background: #eaf4fb; font-size: 1.05em;">
     📬 Sdílený Mailpit pro všechna preview:
-    <a href="<?= htmlspecialchars($mailpitUrl) ?>" target="_blank" rel="noopener" style="font-weight: bold;">
+    <a href="<?php echo htmlspecialchars($mailpitUrl); ?>" target="_blank" rel="noopener" style="font-weight: bold;">
         webmail.preview.gamecon.cz
     </a>
     <div style="margin-top: 6px; font-size: 0.85em; color: #555;">
         Přihlášení k bráně:
-        <code style="user-select: all;"><?= htmlspecialchars(PREVIEW_BASIC_AUTH_USER) ?></code>
+        <code style="user-select: all;"><?php echo htmlspecialchars(PREVIEW_BASIC_AUTH_USER); ?></code>
         /
-        <code style="user-select: all;"><?= htmlspecialchars(PREVIEW_BASIC_AUTH_PASSWORD) ?></code>
+        <code style="user-select: all;"><?php echo htmlspecialchars(PREVIEW_BASIC_AUTH_PASSWORD); ?></code>
     </div>
 </div>
 
-<?php if ($unavailableReason !== null): ?>
+<?php if ($unavailableReason !== null) { ?>
     <div class="varovani">
         <strong>Data nelze načíst:</strong>
-        <?= nl2br(htmlspecialchars($unavailableReason)) ?>
+        <?php echo nl2br(htmlspecialchars($unavailableReason)); ?>
     </div>
-<?php elseif (count($previews) === 0): ?>
+<?php } elseif (count($previews) === 0) { ?>
     <p><em>Žádné aktivní preview prostředí.</em></p>
-<?php else: ?>
+<?php } else { ?>
     <table class="zvyraznovana" style="width: 100%">
         <thead>
             <tr>
@@ -64,25 +63,25 @@ $prListUrl = static fn(string $slug): string => 'https://github.com/gamecon-cz/g
             </tr>
         </thead>
         <tbody>
-        <?php foreach ($previews as $preview): ?>
+        <?php foreach ($previews as $preview) { ?>
             <tr>
                 <td>
-                    <a href="<?= htmlspecialchars($gateUrl($preview->url)) ?>" target="_blank" rel="noopener">
-                        <?= htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $preview->url)) ?>
+                    <a href="<?php echo htmlspecialchars($gateUrl($preview->url)); ?>" target="_blank" rel="noopener">
+                        <?php echo htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $preview->url)); ?>
                     </a>
                 </td>
                 <td>
-                    <a href="<?= htmlspecialchars($prListUrl($preview->slug)) ?>" target="_blank" rel="noopener">
-                        <?= htmlspecialchars($preview->slug) ?>
+                    <a href="<?php echo htmlspecialchars($prListUrl($preview->slug)); ?>" target="_blank" rel="noopener">
+                        <?php echo htmlspecialchars($preview->slug); ?>
                     </a>
                 </td>
                 <td>
-                    <?= $preview->deployedAt !== null
+                    <?php echo $preview->deployedAt !== null
                         ? htmlspecialchars($preview->deployedAt->format('Y-m-d H:i'))
-                        : '—' ?>
+                        : '—'; ?>
                 </td>
             </tr>
-        <?php endforeach; ?>
+        <?php } ?>
         </tbody>
     </table>
-<?php endif; ?>
+<?php } ?>

--- a/admin/scripts/modules/dev/previews.php
+++ b/admin/scripts/modules/dev/previews.php
@@ -1,6 +1,7 @@
 <?php
 
 use Gamecon\Dev\DeploymentsReader;
+use Gamecon\Dev\GateLink;
 
 /**
  * Seznam aktivních preview prostředí.
@@ -15,12 +16,15 @@ $reader = new DeploymentsReader();
 $unavailableReason = $reader->unavailableReason();
 $previews = $unavailableReason === null ? $reader->readPreviews() : [];
 
-// Caddy před preview prostředími vyžaduje basic auth. Údaje NEvkládáme do
-// odkazu jako foo:bar@host — Chrome takové přihlašovací údaje při kliknutí
-// na <a> zahazuje (anti-phishing), takže by proklik končil na 401. Odkazy
-// proto vedou na čisté URL a údaje ukazujeme jako kopírovatelný text;
-// prohlížeč se zeptá na heslo jen při prvním otevření a dál si ho pamatuje.
-$mailpitUrl = 'https://webmail.preview.gamecon.cz/';
+// Caddy před preview prostředími vyžaduje basic auth. Odkazy vedou na čistou
+// URL (vložené foo:bar@host Chrome při kliknutí zahazuje), navíc k nim
+// připojíme podepsaný ?gate= token: gate-validator za bránou ho vymění za
+// session cookie, takže proklik projde bez dialogu. Když token vyprší / secret
+// není nastavený, brána spadne na basic auth — proto údaje ukazujeme jako
+// kopírovatelný text. Viz GateLink + ansible role gate_validator.
+$gateUrl = static fn(string $url): string => GateLink::podepis($url, PREVIEW_GATE_SECRET);
+
+$mailpitUrl = $gateUrl('https://webmail.preview.gamecon.cz/');
 
 // Preview slug = git branch name (viz .github/workflows/deploy-preview.yml).
 // Linkujeme do filtru PR listu — funguje pro open i closed PR a nerozbije
@@ -63,7 +67,7 @@ $prListUrl = static fn(string $slug): string => 'https://github.com/gamecon-cz/g
         <?php foreach ($previews as $preview): ?>
             <tr>
                 <td>
-                    <a href="<?= htmlspecialchars($preview->url) ?>" target="_blank" rel="noopener">
+                    <a href="<?= htmlspecialchars($gateUrl($preview->url)) ?>" target="_blank" rel="noopener">
                         <?= htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $preview->url)) ?>
                     </a>
                 </td>

--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -12,13 +12,12 @@ use Gamecon\Dev\GateLink;
  * pravo: 105
  * submenu_group: 9
  */
-
 $reader = new DeploymentsReader();
 $unavailableReason = $reader->unavailableReason();
 $archives = $unavailableReason === null ? $reader->readArchives() : [];
 
 // Setřídit od nejnovějšího ročníku.
-usort($archives, static fn($a, $b) => $b->year <=> $a->year);
+usort($archives, static fn ($a, $b) => $b->year <=> $a->year);
 
 // Caddy před archivními ročníky vyžaduje basic auth. Odkaz vede na čistou URL
 // (vložené foo:bar@host Chrome při kliknutí zahazuje), navíc k němu připojíme
@@ -27,23 +26,23 @@ usort($archives, static fn($a, $b) => $b->year <=> $a->year);
 // brána spadne na basic auth — proto vedle ukazujeme údaje jako kopírovatelný
 // text (prohlížeč se zeptá při prvním otevření). Viz GateLink + ansible
 // role gate_validator.
-$gateUrl = static fn(string $url): string => GateLink::podepis($url, ARCHIVE_GATE_SECRET);
+$gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GATE_SECRET);
 ?>
 <h2>Staré ročníky</h2>
 
-<?php if ($unavailableReason !== null): ?>
+<?php if ($unavailableReason !== null) { ?>
     <div class="varovani">
         <strong>Data nelze načíst:</strong>
-        <?= nl2br(htmlspecialchars($unavailableReason)) ?>
+        <?php echo nl2br(htmlspecialchars($unavailableReason)); ?>
     </div>
-<?php elseif (count($archives) === 0): ?>
+<?php } elseif (count($archives) === 0) { ?>
     <p><em>Žádný dockerizovaný archivní ročník zatím není nasazený.</em></p>
-<?php else: ?>
+<?php } else { ?>
     <p style="margin: 8px 0; color: #555;">
         Přihlášení k bráně (zeptá se prohlížeč při prvním otevření):
-        <code style="user-select: all;"><?= htmlspecialchars(ARCHIVE_BASIC_AUTH_USER) ?></code>
+        <code style="user-select: all;"><?php echo htmlspecialchars(ARCHIVE_BASIC_AUTH_USER); ?></code>
         /
-        <code style="user-select: all;"><?= htmlspecialchars(ARCHIVE_BASIC_AUTH_PASSWORD) ?></code>
+        <code style="user-select: all;"><?php echo htmlspecialchars(ARCHIVE_BASIC_AUTH_PASSWORD); ?></code>
     </p>
     <table class="zvyraznovana" style="width: 100%">
         <thead>
@@ -54,21 +53,21 @@ $gateUrl = static fn(string $url): string => GateLink::podepis($url, ARCHIVE_GAT
             </tr>
         </thead>
         <tbody>
-        <?php foreach ($archives as $archive): ?>
+        <?php foreach ($archives as $archive) { ?>
             <tr>
-                <td><?= htmlspecialchars((string)$archive->year) ?></td>
+                <td><?php echo htmlspecialchars((string) $archive->year); ?></td>
                 <td>
-                    <a href="<?= htmlspecialchars($gateUrl($archive->url)) ?>" target="_blank" rel="noopener">
-                        <?= htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $archive->url)) ?>
+                    <a href="<?php echo htmlspecialchars($gateUrl($archive->url)); ?>" target="_blank" rel="noopener">
+                        <?php echo htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $archive->url)); ?>
                     </a>
                 </td>
                 <td>
-                    <?= $archive->deployedAt !== null
+                    <?php echo $archive->deployedAt !== null
                         ? htmlspecialchars($archive->deployedAt->format('Y-m-d H:i'))
-                        : '—' ?>
+                        : '—'; ?>
                 </td>
             </tr>
-        <?php endforeach; ?>
+        <?php } ?>
         </tbody>
     </table>
-<?php endif; ?>
+<?php } ?>

--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -1,6 +1,7 @@
 <?php
 
 use Gamecon\Dev\DeploymentsReader;
+use Gamecon\Dev\GateLink;
 
 /**
  * Seznam dockerizovaných archivních ročníků (YYYY.gamecon.cz).
@@ -19,11 +20,14 @@ $archives = $unavailableReason === null ? $reader->readArchives() : [];
 // Setřídit od nejnovějšího ročníku.
 usort($archives, static fn($a, $b) => $b->year <=> $a->year);
 
-// Caddy před archivními ročníky vyžaduje basic auth. Údaje NEvkládáme do
-// odkazu jako foo:bar@host — Chrome takové přihlašovací údaje při kliknutí
-// na <a> zahazuje (anti-phishing), takže by proklik končil na 401. Odkaz
-// proto vede na čisté URL a údaje ukazujeme vedle jako kopírovatelný text;
-// prohlížeč se zeptá na heslo jen při prvním otevření a dál si ho pamatuje.
+// Caddy před archivními ročníky vyžaduje basic auth. Odkaz vede na čistou URL
+// (vložené foo:bar@host Chrome při kliknutí zahazuje), navíc k němu připojíme
+// podepsaný ?gate= token: gate-validator za bránou ho vymění za session cookie,
+// takže proklik projde bez dialogu. Když token vyprší / secret není nastavený,
+// brána spadne na basic auth — proto vedle ukazujeme údaje jako kopírovatelný
+// text (prohlížeč se zeptá při prvním otevření). Viz GateLink + ansible
+// role gate_validator.
+$gateUrl = static fn(string $url): string => GateLink::podepis($url, ARCHIVE_GATE_SECRET);
 ?>
 <h2>Staré ročníky</h2>
 
@@ -54,7 +58,7 @@ usort($archives, static fn($a, $b) => $b->year <=> $a->year);
             <tr>
                 <td><?= htmlspecialchars((string)$archive->year) ?></td>
                 <td>
-                    <a href="<?= htmlspecialchars($archive->url) ?>" target="_blank" rel="noopener">
+                    <a href="<?= htmlspecialchars($gateUrl($archive->url)) ?>" target="_blank" rel="noopener">
                         <?= htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $archive->url)) ?>
                     </a>
                 </td>

--- a/model/Dev/GateLink.php
+++ b/model/Dev/GateLink.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\Dev;
@@ -39,10 +40,10 @@ final class GateLink
             return $url;
         }
 
-        $expiry      = (string)(($ted ?? time()) + self::TTL_SEKUND);
-        $podpis      = hash_hmac('sha256', $expiry, $secret, true);
-        $token       = self::base64Url($expiry) . '.' . self::base64Url($podpis);
-        $oddelovac   = str_contains($url, '?') ? '&' : '?';
+        $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
+        $podpis = hash_hmac('sha256', $expiry, $secret, true);
+        $token = self::base64Url($expiry) . '.' . self::base64Url($podpis);
+        $oddelovac = str_contains($url, '?') ? '&' : '?';
 
         return $url . $oddelovac . 'gate=' . $token;
     }

--- a/model/Dev/GateLink.php
+++ b/model/Dev/GateLink.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Podepíše „gate" token a připojí ho jako `?gate=` k URL preview / archivního
+ * webu, aby proklik z adminu prošel přes Caddy bránu bez basic-auth dialogu.
+ *
+ * Caddy bránu chrání basic auth; před ní ale sedí `gate-validator` (viz ansible
+ * repo, role `gate_validator`), který přijme podepsaný expirující token, vymění
+ * ho za session cookie a pustí dál. Token NENÍ heslo — je to HMAC podpis času
+ * expirace, takže leaknutý odkaz umře po {@see self::TTL_SEKUND} a nejde ručně
+ * prodloužit.
+ *
+ * Formát tokenu (musí přesně odpovídat ověření v gate-validatoru):
+ *
+ *     gate = base64url(expiry_unix) "." base64url(HMAC_SHA256(expiry_unix, secret))
+ *
+ * `expiry_unix` jsou ASCII číslice unixového času; HMAC se počítá právě nad
+ * těmito bajty (ne nad binárním integerem). base64url = RFC 4648 §5 bez `=`.
+ *
+ * Když secret není nastavený (lokální vývoj), vrací URL beze změny — odkaz pak
+ * vede na čistou URL a uživatel projde přes basic-auth dialog jako dřív.
+ */
+final class GateLink
+{
+    /**
+     * Platnost odkazu. Dost dlouho, aby běžné „otevři a proklikej se" sezení
+     * nevypršelo; dost krátko, aby leaknutý odkaz (Slack, screenshot, sync
+     * historie) byl do druhého dne mrtvý. Změna TTL je čistě na straně podpisu
+     * — validator kontroluje jen `expiry > now`.
+     */
+    public const TTL_SEKUND = 24 * 3600;
+
+    public static function podepis(string $url, string $secret, ?int $ted = null): string
+    {
+        if ($secret === '') {
+            return $url;
+        }
+
+        $expiry      = (string)(($ted ?? time()) + self::TTL_SEKUND);
+        $podpis      = hash_hmac('sha256', $expiry, $secret, true);
+        $token       = self::base64Url($expiry) . '.' . self::base64Url($podpis);
+        $oddelovac   = str_contains($url, '?') ? '&' : '?';
+
+        return $url . $oddelovac . 'gate=' . $token;
+    }
+
+    private static function base64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/model/funkce/skryte-nastaveni-z-env-funkce.php
+++ b/model/funkce/skryte-nastaveni-z-env-funkce.php
@@ -1,9 +1,11 @@
 <?php
+
+declare(strict_types=1);
 function vytvorSouborSkrytehoNastaveniPodleEnv(
     string $souborVerejnehoNastaveni,
 ) {
     $souborSkrytehoNastaveni = souborSkrytehoNastaveniPodleVerejneho($souborVerejnehoNastaveni);
-    if (!is_file($souborSkrytehoNastaveni)) {
+    if (! is_file($souborSkrytehoNastaveni)) {
         // ENV názvy a hodnoty viz například .github/workflows/deploy-ostra.yml
         $DB_USER = getenv('DB_USER');
         $DB_PASS = getenv('DB_PASS');
@@ -49,49 +51,49 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
 
         file_put_contents($souborSkrytehoNastaveni, <<<PHP
             <?php
-            // vygenerováno $ted v $nazevTetoFunkce
+            // vygenerováno {$ted} v {$nazevTetoFunkce}
             
             // uživatel se základním přístupem
-            define('DB_USER', '$DB_USER');
-            define('DB_PASS', '$DB_PASS');
-            define('DB_NAME', '$DB_NAME');
-            define('DB_SERV', '$DB_SERV');
-            define('DB_PORT', '$DB_PORT');
+            define('DB_USER', '{$DB_USER}');
+            define('DB_PASS', '{$DB_PASS}');
+            define('DB_NAME', '{$DB_NAME}');
+            define('DB_SERV', '{$DB_SERV}');
+            define('DB_PORT', '{$DB_PORT}');
             
             // uživatel s přístupem k změnám struktury
-            define('DBM_USER', '$DBM_USER');
-            define('DBM_PASS', '$DBM_PASS');
+            define('DBM_USER', '{$DBM_USER}');
+            define('DBM_PASS', '{$DBM_PASS}');
             
-            define('DB_ANONYM_SERV', '$DB_ANONYM_SERV');
-            define('DB_ANONYM_USER', '$DB_ANONYM_USER');
-            define('DB_ANONYM_PASS', '$DB_ANONYM_PASS');
-            define('DB_ANONYM_NAME', '$DB_ANONYM_NAME');
+            define('DB_ANONYM_SERV', '{$DB_ANONYM_SERV}');
+            define('DB_ANONYM_USER', '{$DB_ANONYM_USER}');
+            define('DB_ANONYM_PASS', '{$DB_ANONYM_PASS}');
+            define('DB_ANONYM_NAME', '{$DB_ANONYM_NAME}');
             
-            define('MIGRACE_HESLO', '$MIGRACE_HESLO');
-            define('SECRET_CRYPTO_KEY', '$SECRET_CRYPTO_KEY');
+            define('MIGRACE_HESLO', '{$MIGRACE_HESLO}');
+            define('SECRET_CRYPTO_KEY', '{$SECRET_CRYPTO_KEY}');
             
-            define('CRON_KEY', '$CRON_KEY'); // pozor změnu CRON_KEY je nutné provést i v https://console.cron-job.org
+            define('CRON_KEY', '{$CRON_KEY}'); // pozor změnu CRON_KEY je nutné provést i v https://console.cron-job.org
             
-            define('GOOGLE_API_CREDENTIALS', json_decode('$GOOGLE_API_CREDENTIALS', true));
+            define('GOOGLE_API_CREDENTIALS', json_decode('{$GOOGLE_API_CREDENTIALS}', true));
             
-            define('FIO_TOKEN', '$FIO_TOKEN'); // platnost do 11.9.2030
+            define('FIO_TOKEN', '{$FIO_TOKEN}'); // platnost do 11.9.2030
             
-            define('MAILER_DSN', '$MAILER_DSN');
+            define('MAILER_DSN', '{$MAILER_DSN}');
             
             // Symfony
-            define('APP_ENV', '$APP_ENV');
-            define('APP_DEBUG', $APP_DEBUG);
-            define('APP_SECRET', '$APP_SECRET');
+            define('APP_ENV', '{$APP_ENV}');
+            define('APP_DEBUG', {$APP_DEBUG});
+            define('APP_SECRET', '{$APP_SECRET}');
 
             // Basic-auth pro Caddy bránu před preview / archive prostředími
-            define('PREVIEW_BASIC_AUTH_USER', '$PREVIEW_BASIC_AUTH_USER');
-            define('PREVIEW_BASIC_AUTH_PASSWORD', '$PREVIEW_BASIC_AUTH_PASSWORD');
-            define('ARCHIVE_BASIC_AUTH_USER', '$ARCHIVE_BASIC_AUTH_USER');
-            define('ARCHIVE_BASIC_AUTH_PASSWORD', '$ARCHIVE_BASIC_AUTH_PASSWORD');
+            define('PREVIEW_BASIC_AUTH_USER', '{$PREVIEW_BASIC_AUTH_USER}');
+            define('PREVIEW_BASIC_AUTH_PASSWORD', '{$PREVIEW_BASIC_AUTH_PASSWORD}');
+            define('ARCHIVE_BASIC_AUTH_USER', '{$ARCHIVE_BASIC_AUTH_USER}');
+            define('ARCHIVE_BASIC_AUTH_PASSWORD', '{$ARCHIVE_BASIC_AUTH_PASSWORD}');
 
             // Tajemství pro podpis gate tokenu (one-click přístup přes bránu)
-            define('PREVIEW_GATE_SECRET', '$PREVIEW_GATE_SECRET');
-            define('ARCHIVE_GATE_SECRET', '$ARCHIVE_GATE_SECRET');
+            define('PREVIEW_GATE_SECRET', '{$PREVIEW_GATE_SECRET}');
+            define('ARCHIVE_GATE_SECRET', '{$ARCHIVE_GATE_SECRET}');
             PHP,
         );
     }
@@ -119,7 +121,7 @@ function vytvorSouborServerNastaveniPodleEnv(
     string $souborVerejnehoNastaveni,
 ) {
     $souborServerNastaveniPodleEnv = souborServerNastaveniPodleEnv($souborVerejnehoNastaveni);
-    if (!is_file($souborServerNastaveniPodleEnv)) {
+    if (! is_file($souborServerNastaveniPodleEnv)) {
         // ENV názvy a hodnoty viz například .github/workflows/deploy-ostra.yml
         $SERVER_NAME = getenv('SERVER_NAME');
 
@@ -128,9 +130,9 @@ function vytvorSouborServerNastaveniPodleEnv(
 
         file_put_contents($souborServerNastaveniPodleEnv, <<<PHP
             <?php
-            // vygenerováno $ted v $nazevTetoFunkce
+            // vygenerováno {$ted} v {$nazevTetoFunkce}
             
-            define('SERVER_NAME', '$SERVER_NAME');
+            define('SERVER_NAME', '{$SERVER_NAME}');
             PHP,
         );
     }

--- a/model/funkce/skryte-nastaveni-z-env-funkce.php
+++ b/model/funkce/skryte-nastaveni-z-env-funkce.php
@@ -29,11 +29,20 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
         $APP_SECRET = getenv('APP_SECRET');
 
         // Basic-auth pro Caddy bránu před preview / archive prostředími.
-        // Admin rozcestník je vykresluje rovnou v odkazech (foo:bar@host).
+        // Admin rozcestník u odkazů ukazuje tyto údaje jako kopírovatelný text
+        // (prohlížeč se zeptá při prvním otevření).
         $PREVIEW_BASIC_AUTH_USER = getenv('PREVIEW_BASIC_AUTH_USER');
         $PREVIEW_BASIC_AUTH_PASSWORD = getenv('PREVIEW_BASIC_AUTH_PASSWORD');
         $ARCHIVE_BASIC_AUTH_USER = getenv('ARCHIVE_BASIC_AUTH_USER');
         $ARCHIVE_BASIC_AUTH_PASSWORD = getenv('ARCHIVE_BASIC_AUTH_PASSWORD');
+
+        // Tajemství pro podpis „gate" tokenu, kterým admin rozcestník připojí
+        // ?gate=<podpis> k odkazům na preview / archive. Musí být shodné s tím,
+        // co drží gate-validator (ansible repo, role gate_validator), aby
+        // podepsaný token prošel ověřením. Dvě oddělená tajemství = izolace
+        // preview vs. archive (dvě instance validatoru). Viz GateLink.
+        $PREVIEW_GATE_SECRET = getenv('PREVIEW_GATE_SECRET');
+        $ARCHIVE_GATE_SECRET = getenv('ARCHIVE_GATE_SECRET');
 
         $ted = date(DATE_ATOM);
         $nazevTetoFunkce = __FUNCTION__;
@@ -79,6 +88,10 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
             define('PREVIEW_BASIC_AUTH_PASSWORD', '$PREVIEW_BASIC_AUTH_PASSWORD');
             define('ARCHIVE_BASIC_AUTH_USER', '$ARCHIVE_BASIC_AUTH_USER');
             define('ARCHIVE_BASIC_AUTH_PASSWORD', '$ARCHIVE_BASIC_AUTH_PASSWORD');
+
+            // Tajemství pro podpis gate tokenu (one-click přístup přes bránu)
+            define('PREVIEW_GATE_SECRET', '$PREVIEW_GATE_SECRET');
+            define('ARCHIVE_GATE_SECRET', '$ARCHIVE_GATE_SECRET');
             PHP,
         );
     }

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -72,4 +72,9 @@ if (!defined('PREVIEW_BASIC_AUTH_PASSWORD')) define('PREVIEW_BASIC_AUTH_PASSWORD
 if (!defined('ARCHIVE_BASIC_AUTH_USER')) define('ARCHIVE_BASIC_AUTH_USER', getenv('ARCHIVE_BASIC_AUTH_USER') ?: '');
 if (!defined('ARCHIVE_BASIC_AUTH_PASSWORD')) define('ARCHIVE_BASIC_AUTH_PASSWORD', getenv('ARCHIVE_BASIC_AUTH_PASSWORD') ?: '');
 
+// Tajemství pro podpis gate tokenu (one-click přístup přes bránu).
+// Lokálně prázdné — GateLink pak vrátí čistou URL a proklik jde přes dialog.
+if (!defined('PREVIEW_GATE_SECRET')) define('PREVIEW_GATE_SECRET', getenv('PREVIEW_GATE_SECRET') ?: '');
+if (!defined('ARCHIVE_GATE_SECRET')) define('ARCHIVE_GATE_SECRET', getenv('ARCHIVE_GATE_SECRET') ?: '');
+
 error_reporting(E_ALL);

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -1,80 +1,158 @@
 <?php
+
+declare(strict_types=1);
 ini_set('display_errors', true); // zobrazovat chyby při lokálním vývoji (pokud by se stala chyba dřív, než zobrazování chyb převezme Tracy)
 
 // uživatel s základním přístupem
-if (!defined('DB_USER')) define('DB_USER', getenv('DB_USER')
-    ?: 'root');
-if (!defined('DB_PASS')) define('DB_PASS', getenv('DB_PASS')
-    ?: '');
-if (!defined('DB_NAME')) define('DB_NAME', getenv('DB_NAME')
-    ?: 'gamecon');
-if (!defined('DB_SERV')) define('DB_SERV', getenv('DB_SERV')
-    ?: '127.0.0.1');
-if (!defined('DB_PORT')) define('DB_PORT', (int)(getenv('DB_PORT')
-    ?: '3306'));
+if (! defined('DB_USER')) {
+    define('DB_USER', getenv('DB_USER')
+        ?: 'root');
+}
+if (! defined('DB_PASS')) {
+    define('DB_PASS', getenv('DB_PASS')
+        ?: '');
+}
+if (! defined('DB_NAME')) {
+    define('DB_NAME', getenv('DB_NAME')
+        ?: 'gamecon');
+}
+if (! defined('DB_SERV')) {
+    define('DB_SERV', getenv('DB_SERV')
+        ?: '127.0.0.1');
+}
+if (! defined('DB_PORT')) {
+    define('DB_PORT', (int) (getenv('DB_PORT')
+        ?: '3306'));
+}
 
 // uživatel s přístupem k změnám struktury
-if (!defined('DBM_USER')) define('DBM_USER', getenv('DBM_USER')
-    ?: DB_USER);
-if (!defined('DBM_PASS')) define('DBM_PASS', getenv('DBM_PASS')
-    ?: DB_PASS);
+if (! defined('DBM_USER')) {
+    define('DBM_USER', getenv('DBM_USER')
+        ?: DB_USER);
+}
+if (! defined('DBM_PASS')) {
+    define('DBM_PASS', getenv('DBM_PASS')
+        ?: DB_PASS);
+}
 
-if (!defined('DB_ANONYM_SERV')) define('DB_ANONYM_SERV', getenv('DB_ANONYM_SERV')
-    ?: DB_SERV);
-if (!defined('DB_ANONYM_USER')) define('DB_ANONYM_USER', getenv('DB_ANONYM_USER')
-    ?: DBM_USER);
-if (!defined('DB_ANONYM_PASS')) define('DB_ANONYM_PASS', getenv('DB_ANONYM_PASS')
-    ?: DBM_PASS);
-//if (!defined('DB_ANONYM_PORT')) define('DB_ANONYM_PORT', DB_PORT);
-if (!defined('DB_ANONYM_NAME')) define('DB_ANONYM_NAME', getenv('DB_ANONYM_NAME')
-    ?: 'anonymni_databaze');
+if (! defined('DB_ANONYM_SERV')) {
+    define('DB_ANONYM_SERV', getenv('DB_ANONYM_SERV')
+        ?: DB_SERV);
+}
+if (! defined('DB_ANONYM_USER')) {
+    define('DB_ANONYM_USER', getenv('DB_ANONYM_USER')
+        ?: DBM_USER);
+}
+if (! defined('DB_ANONYM_PASS')) {
+    define('DB_ANONYM_PASS', getenv('DB_ANONYM_PASS')
+        ?: DBM_PASS);
+}
+// if (!defined('DB_ANONYM_PORT')) define('DB_ANONYM_PORT', DB_PORT);
+if (! defined('DB_ANONYM_NAME')) {
+    define('DB_ANONYM_NAME', getenv('DB_ANONYM_NAME')
+        ?: 'anonymni_databaze');
+}
 
 $baseUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'
         ? 'https'
         : 'http') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost');
-if (!defined('URL_WEBU')) getenv('URL_WEBU')
-    ?: define('URL_WEBU', $baseUrl . '/web'); // absolutní url uživatelského webu
-if (!defined('URL_ADMIN')) getenv('URL_ADMIN')
-    ?: define('URL_ADMIN', $baseUrl . '/admin'); // absolutní url adminu
-if (!defined('URL_CACHE')) getenv('URL_CACHE')
-    ?: define('URL_CACHE', $baseUrl . '/cache/public'); // url sdílených cachí
+if (! defined('URL_WEBU')) {
+    getenv('URL_WEBU')
+        ?: define('URL_WEBU', $baseUrl . '/web');
+} // absolutní url uživatelského webu
+if (! defined('URL_ADMIN')) {
+    getenv('URL_ADMIN')
+        ?: define('URL_ADMIN', $baseUrl . '/admin');
+} // absolutní url adminu
+if (! defined('URL_CACHE')) {
+    getenv('URL_CACHE')
+        ?: define('URL_CACHE', $baseUrl . '/cache/public');
+} // url sdílených cachí
 
-if (!defined('ANALYTICS')) define('ANALYTICS', false);
-if (!defined('MIGRACE_HESLO')) define('MIGRACE_HESLO', '');
-if (!defined('HTTPS_ONLY')) define('HTTPS_ONLY', false);
-if (!defined('SECRET_CRYPTO_KEY')) define('SECRET_CRYPTO_KEY', 'def0000066cba9ae32fdda839a143276cc0646b3880920c93876ecc1bbaca96ee6ed251559516b1804f4742c2165e4c7eb3ed5c7a5abe857c6db8608e3b5fe97a8cdf15a');
+if (! defined('ANALYTICS')) {
+    define('ANALYTICS', false);
+}
+if (! defined('MIGRACE_HESLO')) {
+    define('MIGRACE_HESLO', '');
+}
+if (! defined('HTTPS_ONLY')) {
+    define('HTTPS_ONLY', false);
+}
+if (! defined('SECRET_CRYPTO_KEY')) {
+    define('SECRET_CRYPTO_KEY', 'def0000066cba9ae32fdda839a143276cc0646b3880920c93876ecc1bbaca96ee6ed251559516b1804f4742c2165e4c7eb3ed5c7a5abe857c6db8608e3b5fe97a8cdf15a');
+}
 
-if (!defined('GOOGLE_API_CREDENTIALS')) define('GOOGLE_API_CREDENTIALS', []);
-if (!defined('POVOLEN_OPAKOVANY_IMPORT_AKTIVIT_ZE_STEJNEHO_SOUBORU')) define('POVOLEN_OPAKOVANY_IMPORT_AKTIVIT_ZE_STEJNEHO_SOUBORU', true);
-if (!defined('IMPOR_AKTIVIT_JENOM_JAKO')) define('IMPOR_AKTIVIT_JENOM_JAKO', false);
+if (! defined('GOOGLE_API_CREDENTIALS')) {
+    define('GOOGLE_API_CREDENTIALS', []);
+}
+if (! defined('POVOLEN_OPAKOVANY_IMPORT_AKTIVIT_ZE_STEJNEHO_SOUBORU')) {
+    define('POVOLEN_OPAKOVANY_IMPORT_AKTIVIT_ZE_STEJNEHO_SOUBORU', true);
+}
+if (! defined('IMPOR_AKTIVIT_JENOM_JAKO')) {
+    define('IMPOR_AKTIVIT_JENOM_JAKO', false);
+}
 
 // nepovinné konstanty
-if (!defined('CRON_KEY')) define('CRON_KEY', '123');
-if (!defined('UNIVERZALNI_HESLO')) define('UNIVERZALNI_HESLO', getenv('UNIVERZALNI_HESLO')
-    ?: ''); // obejití zadávání hesla pro vývojové prostředí
-if (!defined('FIO_TOKEN')) define('FIO_TOKEN', '123456'); // přístup k api fio banky pro načítání plateb
-if (!defined('AUTOMATICKE_MIGRACE')) define('AUTOMATICKE_MIGRACE', true);
-if (!defined('PROFILOVACI_LISTA')) define('PROFILOVACI_LISTA', true);
-if (!defined('CACHE_SLOZKY_PRAVA')) define('CACHE_SLOZKY_PRAVA', 0777);
-if (!defined('ZOBRAZIT_STACKTRACE_VYJIMKY')) define('ZOBRAZIT_STACKTRACE_VYJIMKY', true);
+if (! defined('CRON_KEY')) {
+    define('CRON_KEY', '123');
+}
+if (! defined('UNIVERZALNI_HESLO')) {
+    define('UNIVERZALNI_HESLO', getenv('UNIVERZALNI_HESLO')
+        ?: '');
+} // obejití zadávání hesla pro vývojové prostředí
+if (! defined('FIO_TOKEN')) {
+    define('FIO_TOKEN', '123456');
+} // přístup k api fio banky pro načítání plateb
+if (! defined('AUTOMATICKE_MIGRACE')) {
+    define('AUTOMATICKE_MIGRACE', true);
+}
+if (! defined('PROFILOVACI_LISTA')) {
+    define('PROFILOVACI_LISTA', true);
+}
+if (! defined('CACHE_SLOZKY_PRAVA')) {
+    define('CACHE_SLOZKY_PRAVA', 0777);
+}
+if (! defined('ZOBRAZIT_STACKTRACE_VYJIMKY')) {
+    define('ZOBRAZIT_STACKTRACE_VYJIMKY', true);
+}
 
-if (!defined('MAILER_DSN')) define('MAILER_DSN', getenv('MAILER_DSN')
-    ?: '');
-if (!defined('MAILY_DO_SOUBORU')) define('MAILY_DO_SOUBORU', MAILER_DSN ? false : __DIR__ . '/../cache/private/maily.log');
-if (!defined('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB')) define('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB', false);
-if (!defined('APP_SECRET')) define('APP_SECRET', getenv('APP_SECRET')
-    ?: 'someRandomStringForAppSecretThatYouShouldChange');
+if (! defined('MAILER_DSN')) {
+    define('MAILER_DSN', getenv('MAILER_DSN')
+        ?: '');
+}
+if (! defined('MAILY_DO_SOUBORU')) {
+    define('MAILY_DO_SOUBORU', MAILER_DSN ? false : __DIR__ . '/../cache/private/maily.log');
+}
+if (! defined('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB')) {
+    define('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB', false);
+}
+if (! defined('APP_SECRET')) {
+    define('APP_SECRET', getenv('APP_SECRET')
+        ?: 'someRandomStringForAppSecretThatYouShouldChange');
+}
 
 // Basic-auth pro Caddy bránu před preview / archive prostředími.
 // Lokálně prázdné — odkazy se vykreslí bez vložených přihlašovacích údajů.
-if (!defined('PREVIEW_BASIC_AUTH_USER')) define('PREVIEW_BASIC_AUTH_USER', getenv('PREVIEW_BASIC_AUTH_USER') ?: '');
-if (!defined('PREVIEW_BASIC_AUTH_PASSWORD')) define('PREVIEW_BASIC_AUTH_PASSWORD', getenv('PREVIEW_BASIC_AUTH_PASSWORD') ?: '');
-if (!defined('ARCHIVE_BASIC_AUTH_USER')) define('ARCHIVE_BASIC_AUTH_USER', getenv('ARCHIVE_BASIC_AUTH_USER') ?: '');
-if (!defined('ARCHIVE_BASIC_AUTH_PASSWORD')) define('ARCHIVE_BASIC_AUTH_PASSWORD', getenv('ARCHIVE_BASIC_AUTH_PASSWORD') ?: '');
+if (! defined('PREVIEW_BASIC_AUTH_USER')) {
+    define('PREVIEW_BASIC_AUTH_USER', getenv('PREVIEW_BASIC_AUTH_USER') ?: '');
+}
+if (! defined('PREVIEW_BASIC_AUTH_PASSWORD')) {
+    define('PREVIEW_BASIC_AUTH_PASSWORD', getenv('PREVIEW_BASIC_AUTH_PASSWORD') ?: '');
+}
+if (! defined('ARCHIVE_BASIC_AUTH_USER')) {
+    define('ARCHIVE_BASIC_AUTH_USER', getenv('ARCHIVE_BASIC_AUTH_USER') ?: '');
+}
+if (! defined('ARCHIVE_BASIC_AUTH_PASSWORD')) {
+    define('ARCHIVE_BASIC_AUTH_PASSWORD', getenv('ARCHIVE_BASIC_AUTH_PASSWORD') ?: '');
+}
 
 // Tajemství pro podpis gate tokenu (one-click přístup přes bránu).
 // Lokálně prázdné — GateLink pak vrátí čistou URL a proklik jde přes dialog.
-if (!defined('PREVIEW_GATE_SECRET')) define('PREVIEW_GATE_SECRET', getenv('PREVIEW_GATE_SECRET') ?: '');
-if (!defined('ARCHIVE_GATE_SECRET')) define('ARCHIVE_GATE_SECRET', getenv('ARCHIVE_GATE_SECRET') ?: '');
+if (! defined('PREVIEW_GATE_SECRET')) {
+    define('PREVIEW_GATE_SECRET', getenv('PREVIEW_GATE_SECRET') ?: '');
+}
+if (! defined('ARCHIVE_GATE_SECRET')) {
+    define('ARCHIVE_GATE_SECRET', getenv('ARCHIVE_GATE_SECRET') ?: '');
+}
 
 error_reporting(E_ALL);

--- a/tests/Dev/GateLinkTest.php
+++ b/tests/Dev/GateLinkTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Dev;
+
+use Gamecon\Dev\GateLink;
+use PHPUnit\Framework\TestCase;
+
+class GateLinkTest extends TestCase
+{
+    private const SECRET = 'test-secret-do-not-use-in-prod';
+
+    public function testPrazdnySecretVraciUrlBeZeZmeny(): void
+    {
+        $url = 'https://2024.gamecon.cz/';
+        self::assertSame($url, GateLink::podepis($url, '', 1_700_000_000));
+    }
+
+    public function testPripojiGateParametrSOtaznikem(): void
+    {
+        $podepsana = GateLink::podepis('https://2024.gamecon.cz/', self::SECRET, 1_700_000_000);
+        self::assertStringStartsWith('https://2024.gamecon.cz/?gate=', $podepsana);
+    }
+
+    public function testPripojiGateParametrSAmpersandemKdyzUrlJizMaQuery(): void
+    {
+        $podepsana = GateLink::podepis('https://2024.gamecon.cz/?foo=bar', self::SECRET, 1_700_000_000);
+        self::assertStringContainsString('?foo=bar&gate=', $podepsana);
+    }
+
+    public function testTokenMaTvarExpiryTeckaPodpis(): void
+    {
+        $podepsana = GateLink::podepis('https://host/', self::SECRET, 1_700_000_000);
+        $gate      = $this->vytahniGate($podepsana);
+
+        self::assertStringContainsString('.', $gate);
+        [$expiryPart, $podpisPart] = explode('.', $gate, 2);
+        self::assertNotSame('', $expiryPart);
+        self::assertNotSame('', $podpisPart);
+        // base64url: žádné +, /, ani = padding.
+        self::assertDoesNotMatchRegularExpression('~[+/=]~', $gate);
+    }
+
+    public function testExpiryJeCasPlusTtl(): void
+    {
+        $ted       = 1_700_000_000;
+        $podepsana = GateLink::podepis('https://host/', self::SECRET, $ted);
+        $gate      = $this->vytahniGate($podepsana);
+
+        [$expiryPart] = explode('.', $gate, 2);
+        $expiry       = self::base64UrlDecode($expiryPart);
+
+        self::assertSame((string)($ted + GateLink::TTL_SEKUND), $expiry);
+    }
+
+    /**
+     * Interop: token MUSÍ být ověřitelný stejným HMAC výpočtem, jaký dělá
+     * gate-validator (Go) — HMAC-SHA256 nad ASCII bajty expiry, base64url.
+     * Tady přepočítáme očekávaný podpis nezávisle a porovnáme.
+     */
+    public function testPodpisOdpovidaNezavislemuHmacVypoctu(): void
+    {
+        $ted       = 1_700_000_000;
+        $expiry    = (string)($ted + GateLink::TTL_SEKUND);
+        $podepsana = GateLink::podepis('https://host/', self::SECRET, $ted);
+        $gate      = $this->vytahniGate($podepsana);
+
+        [$expiryPart, $podpisPart] = explode('.', $gate, 2);
+
+        // Nezávislý přepočet (jako validator): HMAC nad dekódovaným expiry.
+        $expiryBytes      = self::base64UrlDecode($expiryPart);
+        $ocekavanyPodpis  = hash_hmac('sha256', $expiryBytes, self::SECRET, true);
+        $skutecnyPodpis   = self::base64UrlDecode($podpisPart);
+
+        self::assertSame($expiry, $expiryBytes);
+        self::assertTrue(hash_equals($ocekavanyPodpis, $skutecnyPodpis));
+    }
+
+    public function testRuznySecretDavaRuznyPodpis(): void
+    {
+        $ted = 1_700_000_000;
+        $a   = GateLink::podepis('https://host/', 'secret-a', $ted);
+        $b   = GateLink::podepis('https://host/', 'secret-b', $ted);
+        self::assertNotSame($a, $b);
+    }
+
+    private function vytahniGate(string $url): string
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+        parse_str((string)$query, $params);
+        self::assertArrayHasKey('gate', $params);
+
+        return $params['gate'];
+    }
+
+    private static function base64UrlDecode(string $data): string
+    {
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+}

--- a/tests/Dev/GateLinkTest.php
+++ b/tests/Dev/GateLinkTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Dev;
@@ -31,7 +32,7 @@ class GateLinkTest extends TestCase
     public function testTokenMaTvarExpiryTeckaPodpis(): void
     {
         $podepsana = GateLink::podepis('https://host/', self::SECRET, 1_700_000_000);
-        $gate      = $this->vytahniGate($podepsana);
+        $gate = $this->vytahniGate($podepsana);
 
         self::assertStringContainsString('.', $gate);
         [$expiryPart, $podpisPart] = explode('.', $gate, 2);
@@ -43,14 +44,14 @@ class GateLinkTest extends TestCase
 
     public function testExpiryJeCasPlusTtl(): void
     {
-        $ted       = 1_700_000_000;
+        $ted = 1_700_000_000;
         $podepsana = GateLink::podepis('https://host/', self::SECRET, $ted);
-        $gate      = $this->vytahniGate($podepsana);
+        $gate = $this->vytahniGate($podepsana);
 
         [$expiryPart] = explode('.', $gate, 2);
-        $expiry       = self::base64UrlDecode($expiryPart);
+        $expiry = self::base64UrlDecode($expiryPart);
 
-        self::assertSame((string)($ted + GateLink::TTL_SEKUND), $expiry);
+        self::assertSame((string) ($ted + GateLink::TTL_SEKUND), $expiry);
     }
 
     /**
@@ -60,17 +61,17 @@ class GateLinkTest extends TestCase
      */
     public function testPodpisOdpovidaNezavislemuHmacVypoctu(): void
     {
-        $ted       = 1_700_000_000;
-        $expiry    = (string)($ted + GateLink::TTL_SEKUND);
+        $ted = 1_700_000_000;
+        $expiry = (string) ($ted + GateLink::TTL_SEKUND);
         $podepsana = GateLink::podepis('https://host/', self::SECRET, $ted);
-        $gate      = $this->vytahniGate($podepsana);
+        $gate = $this->vytahniGate($podepsana);
 
         [$expiryPart, $podpisPart] = explode('.', $gate, 2);
 
         // Nezávislý přepočet (jako validator): HMAC nad dekódovaným expiry.
-        $expiryBytes      = self::base64UrlDecode($expiryPart);
-        $ocekavanyPodpis  = hash_hmac('sha256', $expiryBytes, self::SECRET, true);
-        $skutecnyPodpis   = self::base64UrlDecode($podpisPart);
+        $expiryBytes = self::base64UrlDecode($expiryPart);
+        $ocekavanyPodpis = hash_hmac('sha256', $expiryBytes, self::SECRET, true);
+        $skutecnyPodpis = self::base64UrlDecode($podpisPart);
 
         self::assertSame($expiry, $expiryBytes);
         self::assertTrue(hash_equals($ocekavanyPodpis, $skutecnyPodpis));
@@ -79,15 +80,15 @@ class GateLinkTest extends TestCase
     public function testRuznySecretDavaRuznyPodpis(): void
     {
         $ted = 1_700_000_000;
-        $a   = GateLink::podepis('https://host/', 'secret-a', $ted);
-        $b   = GateLink::podepis('https://host/', 'secret-b', $ted);
+        $a = GateLink::podepis('https://host/', 'secret-a', $ted);
+        $b = GateLink::podepis('https://host/', 'secret-b', $ted);
         self::assertNotSame($a, $b);
     }
 
     private function vytahniGate(string $url): string
     {
         $query = parse_url($url, PHP_URL_QUERY);
-        parse_str((string)$query, $params);
+        parse_str((string) $query, $params);
         self::assertArrayHasKey('gate', $params);
 
         return $params['gate'];
@@ -95,6 +96,6 @@ class GateLinkTest extends TestCase
 
     private static function base64UrlDecode(string $data): string
     {
-        return base64_decode(strtr($data, '-_', '+/'));
+        return base64_decode(strtr($data, '-_', '+/'), true);
     }
 }


### PR DESCRIPTION
Připojí k odkazům na preview / archive v adminu **podepsaný expirující `?gate=` token**, aby proklik prošel přes Caddy bránu **bez basic-auth dialogu** (one-click). Navazuje na #853 (čisté URL) a na druhou stranu téhož řešení v ansible repu (role `gate_validator`, [ansible PR #25](https://github.com/gamecon-cz/ansible/pull/25)).

## Jak to funguje

`GateLink::podepis()` připojí `?gate=base64url(expiry).base64url(HMAC_SHA256(expiry, secret))` (TTL 24 h). `gate-validator` za bránou token ověří a vymění za session cookie → proklik bez dialogu. Když token vyprší nebo secret není nastavený, brána spadne na `basic_auth` → proto u odkazů necháváme přihlašovací údaje jako kopírovatelný text (z #853).

- **Token ≠ heslo** — je to HMAC podpis času expirace, bezpečný i v historii / logu. Leaknutý odkaz umře do 24 h.
- **Dvě oddělená tajemství** — `PREVIEW_GATE_SECRET` / `ARCHIVE_GATE_SECRET` (dvě instance validatoru, izolace preview vs. archive).

## Změny

- **`model/Dev/GateLink.php`** + **test** — podpis tokenu. Test obsahuje **interop kontrolu**: nezávisle přepočítá HMAC stejně jako Go validator, takže formát tokenu je zaručeně kompatibilní napříč jazyky.
- **`previews.php` / `stare-rocniky.php`** — `href` nově nese podepsaný `?gate=` (text odkazu i kopírovatelné údaje beze změny).
- **Env propagace** (mirror-ostra): `skryte-nastaveni-z-env-funkce.php` + `nastaveni-local-default.php`, `env:` v `deploy-ostra.yml` / `deploy-beta.yml`, `build-args:` v `deploy-preview.yml` / `deploy-year-archive.yml`, `ARG`+`ENV` v `Dockerfile.preview` / `Dockerfile.archive`.

## Pořadí nasazení (důležité)

1. **Nejdřív ansible strana** ([PR #25](https://github.com/gamecon-cz/ansible/pull/25)) — `make deploy` postaví gate-validator a nastaví `secrets.yaml` (`preview.gate.secret` / `year_archive.gate.secret`).
2. **Přidat GitHub secrets** do `gamecon-cz/gamecon`: `PREVIEW_GATE_SECRET`, `ARCHIVE_GATE_SECRET` — **stejné hodnoty** jako v ansible vaultu.
3. **Pak tento PR** — bez secretů je `?gate=` neškodný no-op: validator ho neexistuje / nedostane secret → token se buď nepřipojí (prázdný secret → čistá URL), nebo brána spadne na basic auth. **Žádné rozbití**, jen zatím bez one-click.

Lokálně (prázdný secret) `GateLink` vrací čistou URL — admin se chová jako po #853.

## Test

`phpunit tests/Dev/GateLinkTest.php` → 7 testů zeleně (vč. interop). `php -l` na všech změněných souborech OK. YAML workflows validní.

