### PR TITLE
Run tests on push to feature branches

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,10 @@ name: Run tests
 on:
     push:
         branches:
+            # Filtr s negacemi musí mít aspoň jeden pozitivní vzor, jinak
+            # nematchuje NIC (GitHub Actions): bez '**' se testy na push do
+            # feature větví vůbec nespouští.
+            - '**'
             # beta a main si pouští testy samy, před deployem,
             # viz deploy-beta.yml a deploy-ostra.yml
             - '!beta'


### PR DESCRIPTION
The `run-tests.yml` push trigger had a **negation-only** `branches` filter (`['!beta', '!main']`). In GitHub Actions a branch filter with only negative patterns matches **nothing** — so pushes to feature branches never triggered the test workflow via `push`. (PRs to `main` still ran it via the separate `pull_request` trigger.)

Add a positive `'**'` pattern first so the negations actually subtract from it:

```yaml
branches:
  - '**'
  - '!beta'
  - '!main'
```

Surfaced while trying to get CI to re-run on a feature branch after a fixup commit.