### PR TITLE
Back up DB once per endless batch, lock dumps to 0600

### DIFF
--- a/migrace/pomocne/db-migrations/src/Backups.php
+++ b/migrace/pomocne/db-migrations/src/Backups.php
@@ -19,13 +19,24 @@ class Backups
     }
 
     public function backupBefore(Migration $migration) {
+        $this->backup("pre-migration-{$migration->getCode()}");
+    }
+
+    /**
+     * Dump the whole database into a single gzip file named "<name>.sql.gz".
+     * The dump is created with mode 0600 — it contains the full DB, so it must
+     * not be readable by other accounts on the host.
+     */
+    public function backup(string $name): void {
         // skip empty db as workaround for MySQLDump bug
         if (empty($this->getTableNames())) {
             return;
         }
 
+        $file = "{$this->directory}/{$name}.sql.gz";
         $dump = new MySQLDump($this->db);
-        $dump->save("{$this->directory}/pre-migration-{$migration->getCode()}.sql.gz");
+        $dump->save($file);
+        chmod($file, 0600);
     }
 
     public function clearDatabase() {

--- a/migrace/pomocne/db-migrations/src/DbMigrations.php
+++ b/migrace/pomocne/db-migrations/src/DbMigrations.php
@@ -49,7 +49,18 @@ class DbMigrations
 
     private function handleEndlessMigrations(bool $hasUnappliedOneTimeMigrations): void
     {
-        foreach ($this->getEndlessMigrations($hasUnappliedOneTimeMigrations) as $migration) {
+        $endlessMigrations = $this->getEndlessMigrations($hasUnappliedOneTimeMigrations);
+        if (!$endlessMigrations) {
+            return;
+        }
+
+        // One backup before the whole endless batch — not one per endless
+        // migration (apply() skips per-migration backups for endless ones).
+        if ($this->config->doBackups()) {
+            $this->backups->backup('pre-migration-endless');
+        }
+
+        foreach ($endlessMigrations as $migration) {
             $this->apply($migration, true);
         }
     }
@@ -362,7 +373,11 @@ SQL,
         }
 
         // backup db
-        if ($this->config->doBackups()) {
+        // Endless migrations run on every deploy, so per-migration backups
+        // would pile up one dump per endless migration on every run. We back
+        // up once before the whole endless batch instead (see
+        // handleEndlessMigrations), not before each endless migration here.
+        if ($this->config->doBackups() && !$migration->isEndless()) {
             $this->backups->backupBefore($migration);
         }
 
@@ -409,13 +424,18 @@ SQL,
             }
 
             $this->handleUnappliedMigrations($silent);
-            $this->handleEndlessMigrations(true);
 
             if (!$silent) {
                 $this->webGui?->cleanupEnvironment();
             }
         }
 
+        // Endless migrations run on every deploy, even one with no new one-time
+        // migrations — so this is unconditional. It is also the only endless run
+        // in run(): the one-time branch above no longer runs them, which would
+        // otherwise execute the batch twice when one-time migrations exist.
+        // The argument only relaxes the locale 1-hour throttle (see
+        // getEndlessMigrations); on a server it has no effect.
         $this->handleEndlessMigrations($hasUnappliedOneTimeMigrations);
 
         $driver->report_mode = $oldReportMode;

--- a/tests/Db/Migrace/BackupsTest.php
+++ b/tests/Db/Migrace/BackupsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Db\Migrace;
+
+use Godric\DbMigrations\Backups;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+class BackupsTest extends KernelTestCase
+{
+    private \mysqli $connection;
+    private string $backupDir;
+
+    protected function setUp(): void
+    {
+        static::bootKernel();
+
+        $this->connection = dbConnectTemporary();
+        // Aby dump nebyl prázdný (prázdná DB se přeskakuje jako workaround na bug
+        // MySQLDump) — vytvoříme dočasnou tabulku s jedním řádkem.
+        $this->connection->query('CREATE TEMPORARY TABLE tmp_backups_test (id INT PRIMARY KEY)');
+        $this->connection->query('INSERT INTO tmp_backups_test (id) VALUES (1)');
+
+        $this->backupDir = LOGY . '/backups-test-' . uniqid('', false);
+        (new Filesystem())->mkdir($this->backupDir, 0775);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->backupDir);
+    }
+
+    public function testNamedBackupCreatesGzipFileWithMode0600(): void
+    {
+        $backups = new Backups($this->connection, $this->backupDir);
+
+        $backups->backup('pre-migration-endless');
+
+        $file = $this->backupDir . '/pre-migration-endless.sql.gz';
+        self::assertFileExists($file, 'Backup file should be created.');
+        self::assertSame(
+            '0600',
+            substr(sprintf('%o', fileperms($file)), -4),
+            'Backup file must not be readable by other accounts on the host.',
+        );
+    }
+}


### PR DESCRIPTION
Endless migrations (9999_*) run on every deploy, so backing up before each one produced a pile of near-identical pre-migration-*.sql.gz dumps. Now there is a single pre-migration-endless.sql.gz before the whole endless batch; one-time migrations keep their own per-migration backup.

Pre-migration dumps contain the full database, so they are written with mode 0600 instead of being world-readable on the host.

Also refactor DbMigrations::run() so the endless batch runs exactly once (it previously ran twice whenever one-time migrations were present).