### PR TITLE
Cap archive Apache workers to fit 256 MiB container

### DIFF
--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -70,6 +70,15 @@ RUN mkdir -p \
 COPY preview/apache-https.conf /etc/apache2/conf-available/preview-https.conf
 RUN a2enconf preview-https
 
+# Cap Apache's prefork worker count to fit the 256 MiB container memory
+# limit (the deploy script's cgroup cap). Without this, the base image's
+# stock MaxRequestWorkers 150 lets a few concurrent heavy pages (/admin,
+# /prihlaseni — ~140 MiB/child) overrun the cgroup → kernel OOM-kills an
+# apache2 child → upstream Caddy sees a dropped connection → 502. The
+# config (and the full reasoning) lives in preview/archive-mpm.conf.
+COPY preview/archive-mpm.conf /etc/apache2/conf-available/archive-mpm.conf
+RUN a2enconf archive-mpm
+
 # Pick up the archive-specific verejne-nastaveni file (created on each
 # archive/NNNN branch). The base image ships ENV=local; archive
 # overrides to "archive" so zavadec-nastaveni.php takes the archive

--- a/preview/archive-mpm.conf
+++ b/preview/archive-mpm.conf
@@ -1,0 +1,28 @@
+# Cap Apache's prefork worker count to fit the archive container memory
+# limit. COPY'd into /etc/apache2/conf-available/ and enabled by
+# Dockerfile.archive.
+#
+# The base image (gameconcz/gamecon:8.2) ships mpm_prefork with the stock
+# MaxRequestWorkers 150. A single heavy archive page (e.g. /admin,
+# /prihlaseni) can grow one apache2 child to ~140 MiB RSS, so under the
+# deploy script's 256 MiB cgroup cap a handful of concurrent heavy
+# requests — exactly what a browser fires loading an admin page with its
+# sub-requests — overruns the cgroup and the kernel OOM-kills an apache2
+# child, which the upstream Caddy sees as a dropped connection →
+# intermittent 502.
+#
+# With ~140 MiB worst-case per child, 256 MiB realistically holds only a
+# few PHP workers. Capping MaxRequestWorkers makes Apache QUEUE excess
+# requests (a brief wait) instead of spawning memory-bombs that get
+# OOM-killed. 10 workers leaves headroom under the cap while keeping the
+# common single-visitor case fully concurrent. ServerLimit must be >=
+# MaxRequestWorkers for prefork. MaxConnectionsPerChild recycles workers
+# periodically to bound any slow per-process memory growth.
+<IfModule mpm_prefork_module>
+    StartServers            2
+    MinSpareServers         2
+    MaxSpareServers         5
+    ServerLimit             10
+    MaxRequestWorkers       10
+    MaxConnectionsPerChild  1000
+</IfModule>


### PR DESCRIPTION
Archive containers run Apache `mpm_prefork` with the base image's stock `MaxRequestWorkers 150`. A heavy archive page (`/admin`, `/prihlaseni`) can briefly grow one apache2 child to ~140 MiB RSS; under the deploy script's 256 MiB cgroup cap, enough concurrent *heavy* requests could overrun the cgroup → kernel OOM-kills an apache2 child → upstream Caddy sees a dropped connection. Left unbounded, that's a latent way to produce 502s under load.

**This PR is preventive hardening, not the fix for any specific reported 502.** The 502s seen on 2022 during cutover were traced to a *stale Caddy upstream port* (a manual `docker restart` reassigned the container's published port without updating the Caddy site block) — re-running the deploy fixed those. This change is unrelated to that and does not claim to fix it.

What it does: caps Apache's prefork worker count to fit the 256 MiB container, so a burst of heavy requests **queues** instead of OOM-killing workers.

Change: add `preview/archive-mpm.conf` (`MaxRequestWorkers 10`, `ServerLimit 10`, `MaxConnectionsPerChild 1000`) and COPY+enable it in `Dockerfile.archive`. Config lives in a committed file (like `preview/apache-https.conf`) rather than an inline Dockerfile heredoc.

Verified on archive/2022 (rebuilt + redeployed): 12 parallel `/admin/?req=` → all 200 (Apache logs `AH00161: server reached MaxRequestWorkers` = queuing, not crashing), peak mem 146/256 MiB, no OOM.

Applies to all archive years on rebuild; archive/2022 already carries it.

**Follow-up worth tracking:** `MaxRequestWorkers 10` is conservative. If real traffic shows the connection backlog is too small for a browser's landing-page asset burst, raise it (steady-state workers are ~30 MiB each; only heavy PHP pages peak ~140 MiB) — possibly alongside a small memory-cap bump or PHP-FPM split. Not blocking for this PR.
