### PR TITLE
Per-year PHP base image for archive builds

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -67,9 +67,26 @@ jobs:
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
+
+                    # Per-year base image map. Older years' code predates
+                    # PHP 8.1/8.2 deprecations (the app's error handler
+                    # escalates any deprecation to a fatal 500), so they must
+                    # build on a period-correct PHP. We use the official,
+                    # publicly-pullable php:<ver>-apache images directly —
+                    # Dockerfile.archive's setup block installs the needed
+                    # extensions on a bare base — so no custom base image /
+                    # registry is involved. Default (unlisted years) = the
+                    # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
+                    # Add a row when a year's PHP era is confirmed during recon.
+                    case "$year" in
+                        2021) base_image="php:7.3-apache" ;;
+                        *)    base_image="gameconcz/gamecon:8.2" ;;
+                    esac
+
                     echo "year=$year" >> "$GITHUB_OUTPUT"
                     echo "sha7=$sha7" >> "$GITHUB_OUTPUT"
-                    echo "Deploying year $year ($sha7)"
+                    echo "base_image=$base_image" >> "$GITHUB_OUTPUT"
+                    echo "Deploying year $year ($sha7) on base $base_image"
 
             -   name: Log in to GHCR
                 uses: docker/login-action@v3
@@ -106,6 +123,7 @@ jobs:
                     # archives (not user data) — fine to bake. GHCR repo is
                     # private.
                     build-args: |
+                        BASE_IMAGE=${{ steps.year.outputs.base_image }}
                         PREVIEW_BASIC_AUTH_USER=${{ secrets.PREVIEW_BASIC_AUTH_USER }}
                         PREVIEW_BASIC_AUTH_PASSWORD=${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                         ARCHIVE_BASIC_AUTH_USER=${{ secrets.ARCHIVE_BASIC_AUTH_USER }}

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -24,9 +24,48 @@
 # verified in the recon log in the ansible repo
 # (docs/year-archive-phase0-recon.md).
 
-FROM gameconcz/gamecon:8.2
+# Base image is parameterized so older archive years can build on a
+# period-correct PHP. Modern years (2022+) use the default
+# gameconcz/gamecon:8.2, which already ships Apache + all needed PHP
+# extensions + the gamecon DocumentRoot. Pre-2022 years whose code predates
+# PHP 8.1/8.2 deprecations (e.g. 2021, written for PHP 7.3) override it via
+# --build-arg BASE_IMAGE=php:7.3-apache (the official, publicly-pullable
+# image — no custom registry, so the archive deploy gains no new external
+# dependency). The setup block below is idempotent and base-agnostic: on the
+# gameconcz base the extensions/modules are already present (no-op); on a
+# bare php:X-apache base it installs exactly what the app needs. The workflow
+# (deploy-year-archive.yml) picks BASE_IMAGE per year via an explicit map.
+ARG BASE_IMAGE=gameconcz/gamecon:8.2
+FROM ${BASE_IMAGE}
 
 USER root
+
+# Base-agnostic environment setup. Bare official php:X-apache images lack the
+# PHP extensions, Apache modules, and gamecon DocumentRoot that the gameconcz
+# base bakes in; install/enable them here. All steps are safe no-ops when the
+# base already provides them (docker-php-ext-install is skipped per-ext if the
+# .so exists; a2enmod/sed are idempotent).
+RUN set -eux; \
+    need_ext=""; \
+    for ext in mysqli pdo_mysql intl exif bcmath gd; do \
+        php -m | grep -qi "^${ext}$" || need_ext="$need_ext $ext"; \
+    done; \
+    if [ -n "$need_ext" ]; then \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+            libicu-dev libxml2-dev libzip-dev zlib1g-dev \
+            libfreetype6-dev libjpeg62-turbo-dev libpng-dev; \
+        docker-php-ext-configure gd --with-freetype --with-jpeg \
+            || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+            || true; \
+        docker-php-ext-install $need_ext; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi; \
+    a2enmod rewrite expires headers; \
+    sed -ri 's!/var/www/html!/var/www/html/gamecon!g' \
+        /etc/apache2/sites-available/*.conf \
+        /etc/apache2/apache2.conf \
+        /etc/apache2/conf-available/docker-php.conf 2>/dev/null || true
 
 # Bake the entire archived branch's working tree in. The chown matches
 # the runtime user; matches Dockerfile.preview's approach.


### PR DESCRIPTION
Lets older archive years build on a period-correct PHP without a custom base image or registry.

## Why

Archive years before ~2022 run code written for PHP 7.3. On the `gameconcz/gamecon:8.2` base, that code hits PHP 8.1/8.2 deprecations (e.g. `parse_url(null)`, the `EPDO::query` signature) — and the app's error handler (`Vyjimkovac`) escalates **any** deprecation to a fatal **500**. Patching each one would make the frozen snapshot non-canonical; the right fix (per the dockerize skill's "going further back") is to run each year on its native PHP.

## What

- **`Dockerfile.archive`**: `ARG BASE_IMAGE` (default `gameconcz/gamecon:8.2`) + a base-agnostic, idempotent setup block that installs the needed PHP extensions (`mysqli pdo_mysql intl exif bcmath gd`), enables Apache modules, and sets the gamecon docroot **when the base is a bare official `php:X-apache`** — and no-ops on the gameconcz base.
- **`deploy-year-archive.yml`**: an explicit per-year base-image map (`2021 → php:7.3-apache`, default → `8.2`) feeding a `BASE_IMAGE` build-arg.

Uses the **official, publicly-pullable `php:7.3-apache`** directly — no custom base image, no extra registry, so the archive deploy gains **no new external dependency** (per the requirement to not add deploy obstacles).

## Verified locally

- `archive/2021` built with `--build-arg BASE_IMAGE=php:7.3-apache` runs on **PHP 7.3.33**, all required extensions present, and boots **past** the EPDO/`parse_url(null)` 8.2 wall (reaches the DB connection — the only remaining step, which works on the host where `gamecon_2021` exists).
- The modern path (default 8.2 base) still builds cleanly — the setup block no-ops.

## After merge

Trigger `deploy-year-archive.yml` for `archive/2021` — it'll build on 7.3 and serve. (`archive/2021` already carries the matching parameterized `Dockerfile.archive`.)