### PR TITLE
Build archive 2020 on the php:7.3 base

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2020) base_image="php:7.3-apache" ;;
                         2021) base_image="php:7.3-apache" ;;
                         *)    base_image="gameconcz/gamecon:8.2" ;;
                     esac


### PR DESCRIPTION
Adds `2020 → php:7.3-apache` to the per-year base-image map in deploy-year-archive.yml. 2020-era code (PHP 7.3, same as 2021) hits PHP 8.1/8.2 deprecations on the default 8.2 base, which the app's error handler escalates to 500s. Same mechanism + fix as #860 (2021).

Self-contained: uses the official public `php:7.3-apache` via the existing `BASE_IMAGE` build-arg; `Dockerfile.archive`'s setup block installs the needed extensions. No custom base image / registry.

`archive/2020` already carries the matching parameterized `Dockerfile.archive`. After merge, deploy archive/2020 → builds on 7.3.