### PR TITLE
Build archive 2019 on the php:7.3 base too

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2019) base_image="php:7.3-apache" ;;
                         2020) base_image="php:7.3-apache" ;;
                         2021) base_image="php:7.3-apache" ;;
                         *)    base_image="gameconcz/gamecon:8.2" ;;


### PR DESCRIPTION
Maps 2019.gamecon.cz to the `php:7.3-apache` base image in the year-archive deploy workflow.

2019 ran on PHP 7.3 — confirmed by the Wedos `index.php73` filename marker in the bare-metal year root (same evidence used for 2020/2021, its framework twins). One-line addition to the per-year `case` map; default-era years are unaffected.

Pairs with the `archive/2019` branch (env-driven produkce, web/ rewrite, period-correct vendor).