### PR TITLE
Archive 2018: build on php:5.6-apache, mysqli-only

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,16 +79,28 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2018) base_image="php:5.6-apache" ;;
                         2019) base_image="php:7.3-apache" ;;
                         2020) base_image="php:7.3-apache" ;;
                         2021) base_image="php:7.3-apache" ;;
                         *)    base_image="gameconcz/gamecon:8.2" ;;
                     esac
 
+                    # PHP extensions to install on a bare base. Defaults to the
+                    # modern set; very old years that run on an EOL Debian base
+                    # (whose apt repos are gone) need a trimmed list so the
+                    # Dockerfile's apt step is skipped. 2018 (PHP 5.6) needs only
+                    # mysqli, which builds with no apt packages.
+                    case "$year" in
+                        2018) php_exts="mysqli" ;;
+                        *)    php_exts="mysqli pdo_mysql intl exif bcmath gd" ;;
+                    esac
+
                     echo "year=$year" >> "$GITHUB_OUTPUT"
                     echo "sha7=$sha7" >> "$GITHUB_OUTPUT"
                     echo "base_image=$base_image" >> "$GITHUB_OUTPUT"
-                    echo "Deploying year $year ($sha7) on base $base_image"
+                    echo "php_exts=$php_exts" >> "$GITHUB_OUTPUT"
+                    echo "Deploying year $year ($sha7) on base $base_image (exts: $php_exts)"
 
             -   name: Log in to GHCR
                 uses: docker/login-action@v3
@@ -126,6 +138,7 @@ jobs:
                     # private.
                     build-args: |
                         BASE_IMAGE=${{ steps.year.outputs.base_image }}
+                        PHP_EXTS=${{ steps.year.outputs.php_exts }}
                         PREVIEW_BASIC_AUTH_USER=${{ secrets.PREVIEW_BASIC_AUTH_USER }}
                         PREVIEW_BASIC_AUTH_PASSWORD=${{ secrets.PREVIEW_BASIC_AUTH_PASSWORD }}
                         ARCHIVE_BASIC_AUTH_USER=${{ secrets.ARCHIVE_BASIC_AUTH_USER }}

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -40,6 +40,14 @@ FROM ${BASE_IMAGE}
 
 USER root
 
+# Which PHP extensions the archived year's code actually needs. Defaults to the
+# modern (7.3/8.2-era) set; very old years that need fewer (and can't apt-install
+# the lib-deps because their base OS is EOL) override it via
+# --build-arg PHP_EXTS. 2018 (PHP 5.6) needs only mysqli, which builds against
+# the bundled mysqlnd with NO apt packages — so passing PHP_EXTS="mysqli" skips
+# the whole apt step and sidesteps Debian Stretch's archived repos.
+ARG PHP_EXTS="mysqli pdo_mysql intl exif bcmath gd"
+
 # Base-agnostic environment setup. Bare official php:X-apache images lack the
 # PHP extensions, Apache modules, and gamecon DocumentRoot that the gameconcz
 # base bakes in; install/enable them here. All steps are safe no-ops when the
@@ -47,19 +55,27 @@ USER root
 # .so exists; a2enmod/sed are idempotent).
 RUN set -eux; \
     need_ext=""; \
-    for ext in mysqli pdo_mysql intl exif bcmath gd; do \
+    for ext in $PHP_EXTS; do \
         php -m | grep -qi "^${ext}$" || need_ext="$need_ext $ext"; \
     done; \
     if [ -n "$need_ext" ]; then \
-        apt-get update; \
-        apt-get install -y --no-install-recommends \
-            libicu-dev libxml2-dev libzip-dev zlib1g-dev \
-            libfreetype6-dev libjpeg62-turbo-dev libpng-dev; \
-        docker-php-ext-configure gd --with-freetype --with-jpeg \
-            || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-            || true; \
+        # Only the lib-backed extensions need apt; mysqli/pdo_mysql/exif/bcmath
+        # build against bundled sources. Run apt ONLY when one of those is in
+        # the to-install set, so years that need just mysqli (e.g. 2018 on the
+        # EOL Stretch base, whose apt repos are gone) never touch apt.
+        case " $need_ext " in \
+            *" gd "*|*" intl "*|*" zip "*) \
+                apt-get update; \
+                apt-get install -y --no-install-recommends \
+                    libicu-dev libxml2-dev libzip-dev zlib1g-dev \
+                    libfreetype6-dev libjpeg62-turbo-dev libpng-dev; \
+                docker-php-ext-configure gd --with-freetype --with-jpeg \
+                    || docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+                    || true; \
+                rm -rf /var/lib/apt/lists/*; \
+                ;; \
+        esac; \
         docker-php-ext-install $need_ext; \
-        rm -rf /var/lib/apt/lists/*; \
     fi; \
     a2enmod rewrite expires headers; \
     sed -ri 's!/var/www/html!/var/www/html/gamecon!g' \


### PR DESCRIPTION
Maps 2018.gamecon.cz to PHP 5.6 in the year-archive deploy workflow — the oldest year dockerized so far.

2018 ran on **PHP 5.6** (confirmed by the Wedos `index.php56` filename marker in the bare-metal year root). The official `php:5.6-apache` base is still pullable, but its Debian Stretch apt repos are archived. The code's only DB driver is **mysqli**, which builds against the bundled mysqlnd with **no apt packages** — so this avoids the EOL-apt problem entirely.

Changes:
- Workflow per-year maps: `2018 → php:5.6-apache` (base image) and `2018 → mysqli` (PHP_EXTS).
- `Dockerfile.archive`: ext-install is now driven by a `PHP_EXTS` build-arg (default = the modern 7.3/8.2 set); apt runs **only** when a lib-backed extension (gd/intl/zip) is in the to-install set, so `PHP_EXTS=mysqli` skips apt. 7.3/8.2 years are unchanged.

Validated: the archive/2018 image builds successfully on `php:5.6-apache` with `PHP_EXTS=mysqli` (no apt step), boots, loads produkce config (`gamecon_2018` / `172.17.0.1`). Pairs with the `archive/2018` branch.