### PR TITLE
Build archive 2017 on php:5.6 base, mysqli-only

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2017) base_image="php:5.6-apache" ;;
                         2018) base_image="php:5.6-apache" ;;
                         2019) base_image="php:7.3-apache" ;;
                         2020) base_image="php:7.3-apache" ;;
@@ -92,6 +93,7 @@ jobs:
                     # Dockerfile's apt step is skipped. 2018 (PHP 5.6) needs only
                     # mysqli, which builds with no apt packages.
                     case "$year" in
+                        2017) php_exts="mysqli" ;;
                         2018) php_exts="mysqli" ;;
                         *)    php_exts="mysqli pdo_mysql intl exif bcmath gd" ;;
                     esac


### PR DESCRIPTION
Maps 2017.gamecon.cz to PHP 5.6 in the year-archive deploy workflow (same era as 2018).

2017 ran on **PHP 5.6** (Wedos `index.php56` marker). Like 2018, the code's only DB driver is **mysqli** (builds against bundled mysqlnd, no apt — sidesteps the EOL Debian Stretch repos). Two one-line rows added to the per-year maps (`base_image` + `php_exts`); the `PHP_EXTS` build-arg machinery already exists in Dockerfile.archive from the 2018 PR.

Pairs with the `archive/2017` branch (env-driven produkce with VETEV + path constants, web/ rewrite, period-correct vendor; no env-detect patch needed since 2017's zavadec.php routes any non-local/non-beta host to produkce via an else-fallback).