### PR TITLE
Build archive 2016 on php:5.6 base, mysqli-only

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2016) base_image="php:5.6-apache" ;;
                         2017) base_image="php:5.6-apache" ;;
                         2018) base_image="php:5.6-apache" ;;
                         2019) base_image="php:7.3-apache" ;;
@@ -93,6 +94,7 @@ jobs:
                     # Dockerfile's apt step is skipped. 2018 (PHP 5.6) needs only
                     # mysqli, which builds with no apt packages.
                     case "$year" in
+                        2016) php_exts="mysqli" ;;
                         2017) php_exts="mysqli" ;;
                         2018) php_exts="mysqli" ;;
                         *)    php_exts="mysqli pdo_mysql intl exif bcmath gd" ;;


### PR DESCRIPTION
Maps 2016.gamecon.cz to PHP 5.6 in the year-archive deploy workflow — the first **old-era** year (app/+spec/ layout).

2016 ran on PHP 5.6 (Wedos `index.php56` marker), code's only DB driver is mysqli (no apt). Two one-line rows in the per-year maps. The structural old-era handling (app/web docroot via top-level .htaccess, committed env-driven spec/ config, content bind-mount at app/web/soubory) lives on the `archive/2016` branch and a companion ansible deploy-script change (bind-mount layout detection). Validated: image builds on php:5.6-apache, boots, spec/nastaveni.php loads (VETEV, env DB, path-based URLs).