### PR TITLE
Build archive 2015 on php:5.6 base, mysql ext (not mysqli)

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2015) base_image="php:5.6-apache" ;;
                         2016) base_image="php:5.6-apache" ;;
                         2017) base_image="php:5.6-apache" ;;
                         2018) base_image="php:5.6-apache" ;;
@@ -91,9 +92,12 @@ jobs:
                     # PHP extensions to install on a bare base. Defaults to the
                     # modern set; very old years that run on an EOL Debian base
                     # (whose apt repos are gone) need a trimmed list so the
-                    # Dockerfile's apt step is skipped. 2018 (PHP 5.6) needs only
-                    # mysqli, which builds with no apt packages.
+                    # Dockerfile's apt step is skipped. 2016-2018 (PHP 5.6) need
+                    # only mysqli; 2015 and older use the even-older mysql_*
+                    # extension (mysql, removed in PHP 7 but installable on 5.6).
+                    # Both build with no apt packages.
                     case "$year" in
+                        2015) php_exts="mysql" ;;
                         2016) php_exts="mysqli" ;;
                         2017) php_exts="mysqli" ;;
                         2018) php_exts="mysqli" ;;

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -109,13 +109,29 @@ RUN rm -rf \
 # Make cache/ and logy/ writable by Apache. cache/public stays (assets
 # committed at archive time); only cache/private was stripped above
 # and we recreate it empty here so the app can write to it at runtime.
+# Old-era years (≤2016, app/+spec/ layout) keep their cache under
+# spec/cache + spec/cache-priv instead — chown those too if present, so
+# the same Dockerfile serves both layouts. The mkdir of the modern paths
+# is harmless on old-era branches (just unused empty dirs).
 RUN mkdir -p \
     /var/www/html/gamecon/cache/private \
     /var/www/html/gamecon/cache/public \
     /var/www/html/gamecon/logy \
     && chown -R www-data:www-data \
         /var/www/html/gamecon/cache \
-        /var/www/html/gamecon/logy
+        /var/www/html/gamecon/logy \
+    && if [ -d /var/www/html/gamecon/spec ]; then \
+        mkdir -p \
+            /var/www/html/gamecon/spec/cache/css \
+            /var/www/html/gamecon/spec/cache/img \
+            /var/www/html/gamecon/spec/cache/js \
+            /var/www/html/gamecon/spec/cache/ttf \
+            /var/www/html/gamecon/spec/cache-priv/xtpl \
+            /var/www/html/gamecon/spec/cache-priv/db-backup \
+            /var/www/html/gamecon/spec/cache-priv/fio \
+            /var/www/html/gamecon/spec/cache-priv/logs; \
+        chown -R www-data:www-data /var/www/html/gamecon/spec/cache /var/www/html/gamecon/spec/cache-priv; \
+    fi
 
 # Apache snippet honoring X-Forwarded-Proto from the upstream proxy chain
 # (HAProxy → Caddy → this container). Reused as-is from the preview


### PR DESCRIPTION
Maps 2015.gamecon.cz to PHP 5.6 in the year-archive deploy workflow.

**Key difference from 2016-2018:** 2015 (and older) use the **old `mysql_*` extension** (`mysql_connect`), not `mysqli` — confirmed by a local smoke test (mysqli gave `Call to undefined function mysql_connect()`; `mysql` ext fixes it). The `mysql` extension is removed in PHP 7 but installs on php:5.6-apache with no apt. Map: `2015 -> php:5.6-apache` + `php_exts=mysql`.

Also **forward-ports the old-era Dockerfile.archive support to main** — the spec/ cache-subdir creation + layout-aware chown guard (previously only on the archive/2015+2016 branches). Modern years unaffected (`if [ -d spec ]` guard). Pairs with the `archive/2015` branch.