### PR TITLE
Old-era archives: symlink /cache/public to spec/cache (fix unstyled)

### DIFF
--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -131,6 +131,16 @@ RUN mkdir -p \
             /var/www/html/gamecon/spec/cache-priv/fio \
             /var/www/html/gamecon/spec/cache-priv/logs; \
         chown -R www-data:www-data /var/www/html/gamecon/spec/cache /var/www/html/gamecon/spec/cache-priv; \
+        # The app writes compiled css/js to spec/cache/{css,js} (the CACHE
+        # constant) but emits asset URLs under URL_CACHE = /cache/public/...
+        # (path-based; on the original site URL_CACHE was a cache.YYYY
+        # sub-subdomain whose docroot WAS spec/cache). Symlink the served
+        # path app/web/cache/public -> ../../spec/cache so /cache/public/css/X
+        # resolves to the real compiled file (Apache serves the symlinked
+        # file directly, before app/web/.htaccess routes to index.php).
+        # Without this the archive renders unstyled (css/js 404).
+        mkdir -p /var/www/html/gamecon/app/web/cache; \
+        ln -sfn ../../../spec/cache /var/www/html/gamecon/app/web/cache/public; \
     fi
 
 # Apache snippet honoring X-Forwarded-Proto from the upstream proxy chain


### PR DESCRIPTION
Old-era (app/+spec/) year archives (2015, 2016) rendered **unstyled**: the app compiles css/js into `spec/cache/{css,js}` (the CACHE constant) but emits asset URLs under `URL_CACHE = /cache/public/...` — nothing served that path (404). On the original sites URL_CACHE was a `cache.YYYY` sub-subdomain whose docroot WAS spec/cache; the path-based flip broke the linkage.

Fix (in the `[ -d spec ]` guard): symlink `app/web/cache/public -> ../../../spec/cache`, so `/cache/public/css/X` resolves to the real compiled file via Apache .htaccess `!-f`. Verified locally (css+js both 200, page styled). Already on archive/2015 + archive/2016; this forward-ports to main. Modern years + 2014 (no spec/, static css) unaffected.