### PR TITLE
Build archive 2014 on php:5.6 base, mysql ext

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2014) base_image="php:5.6-apache" ;;
                         2015) base_image="php:5.6-apache" ;;
                         2016) base_image="php:5.6-apache" ;;
                         2017) base_image="php:5.6-apache" ;;
@@ -97,6 +98,7 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
+                        2014) php_exts="mysql" ;;
                         2015) php_exts="mysql" ;;
                         2016) php_exts="mysqli" ;;
                         2017) php_exts="mysqli" ;;


### PR DESCRIPTION
Maps 2014.gamecon.cz to PHP 5.6 + the `mysql` extension (like 2015) in the year-archive deploy workflow.

2014 is the **oldest framework era** (www/+sdilene/+specificke/, .hhp includes, mysql_*) — the authentic bare-metal site, committed to `archive/2014` (the git `app/` tree was a never-live Feb-2015 migration). Local smoke test passed: framework boots, mysql_* connects, /o-gameconu + /program render with real 2014 data, static CSS/JS serve (styled, no cache symlink needed).

Two one-line map rows here; the structural handling (www/ docroot via top .htaccess, env-driven specificke/site-specific.php, www/files bind-mount) lives on the archive/2014 branch + ansible PR #36.