### PR TITLE
Build archive 2013 on php:5.6 base, mysql ext

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,7 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        2013) base_image="php:5.6-apache" ;;
                         2014) base_image="php:5.6-apache" ;;
                         2015) base_image="php:5.6-apache" ;;
                         2016) base_image="php:5.6-apache" ;;
@@ -98,6 +99,7 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
+                        2013) php_exts="mysql" ;;
                         2014) php_exts="mysql" ;;
                         2015) php_exts="mysql" ;;
                         2016) php_exts="mysqli" ;;

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -141,6 +141,14 @@ RUN mkdir -p \
         # Without this the archive renders unstyled (css/js 404).
         mkdir -p /var/www/html/gamecon/app/web/cache; \
         ln -sfn ../../../spec/cache /var/www/html/gamecon/app/web/cache/public; \
+    fi \
+    # Oldest era (≤2014, www/+sdilene/+specificke/ framework): the .hhp
+    # framework writes compiled .xtpc templates next to their .xtpl sources
+    # (handled by the COPY --chown above) and appends a merge log to
+    # admin/files/logs/. Ensure that log dir exists + is writable.
+    && if [ -d /var/www/html/gamecon/sdilene ]; then \
+        mkdir -p /var/www/html/gamecon/admin/files/logs; \
+        chown -R www-data:www-data /var/www/html/gamecon/admin/files/logs; \
     fi
 
 # Apache snippet honoring X-Forwarded-Proto from the upstream proxy chain


### PR DESCRIPTION
Maps 2013.gamecon.cz to PHP 5.6 + the mysql extension (oldest www/+sdilene/ era, like 2014/2015) in the year-archive deploy workflow.

Local smoke test passed: framework boots, mysql_connect works, /o-gameconu + /program render real 2013 data, static CSS styled. Authentic host www/sdilene tree committed to archive/2013 (not in git otherwise).

Also **forward-ports the complete old-era Dockerfile to main** — the `admin/files/logs` sdilene guard (previously only on archive/2014) now sits alongside the spec/ cache-subdir block + the /cache/public symlink, giving main the full guard set. All layout-guarded; modern years unaffected.