### PR TITLE
Build archive 2011 as static (no PHP ext)

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -79,6 +79,11 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
+                        # 2011 is a STATIC archive (the live DB + router are
+                        # lost) — flat HTML reconstructed from the Internet
+                        # Archive. Any base works; php:5.6-apache matches its
+                        # neighbours and stays lightweight (no PHP executes).
+                        2011) base_image="php:5.6-apache" ;;
                         2012) base_image="php:5.6-apache" ;;
                         2013) base_image="php:5.6-apache" ;;
                         2014) base_image="php:5.6-apache" ;;
@@ -100,6 +105,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
+                        # 2011 static archive needs no PHP extension at all
+                        # (no DB, no dynamic code) — empty list skips the
+                        # Dockerfile's whole install step.
+                        2011) php_exts="" ;;
                         2012) php_exts="mysql" ;;
                         2013) php_exts="mysql" ;;
                         2014) php_exts="mysql" ;;


### PR DESCRIPTION
## Summary
Adds `2011` rows to the per-year base-image / php-ext maps in `deploy-year-archive.yml` so the year-archive workflow can build `archive/2011`.

2011 is a **static** archive — the live site's database (`dbgacon`) and root router are lost, so it's reconstructed as flat HTML from the Internet Archive (2011-12-31 capture) served over the host's authentic `system_styly/` theme, lightbox and galleries (see the `archive/2011` branch). No PHP executes and there's no DB, so:

- `2011) base_image="php:5.6-apache"` — lightweight, matches its neighbours.
- `2011) php_exts=""` — empty list skips the Dockerfile's extension-install step entirely; only `a2enmod rewrite` (always run) is needed for the `.htaccess` URL mapping.

The deploy script needs no change: `provision_db 2011` creates a harmless unused DB, and the bind-mount detection finds no content dir (assets are baked into the image).

## Test plan
- [x] Built `Dockerfile.archive` locally with the 2011 args (`BASE_IMAGE=php:5.6-apache`, `PHP_EXTS=""`) — image builds, runs PHP 5.6.40.
- [x] All routes return 200 (`/`, `/novinky/novinky`, `/gamecon/o-gameconu`, `/organizatori/organizacni-tym`, `/kontakt`); CSS + gallery image 200; `/favicon.ico` correctly 404s (not rewritten to HTML).
- [x] Rendered pixel-faithful to the real 2011 site in-browser.
- [ ] `workflow_dispatch` build + deploy of `archive/2011` on the host.
- [ ] DNS cutover for `2011.gamecon.cz` (owner-only).