### PR TITLE
fix mail logy

### DIFF
--- a/admin/scripts/modules/dev/dev.php
+++ b/admin/scripts/modules/dev/dev.php
@@ -78,6 +78,10 @@ $datumAnonymExportu = AnonymizovanaDatabaze::datumPoslednihoExportu();
         <h3>SQL update pro uzavření financí</h3>
         <p>Vygenerování SQL pro překlápění ročníku (uzavření financí).</p>
     </a>
+    <a href="<?php echo URL_ADMIN; ?>/dev/logy">
+        <h3>Mailové logy</h3>
+        <p></p>
+    </a>
 </div>
 
 <div class="dev-akce">

--- a/admin/scripts/modules/dev/logy.php
+++ b/admin/scripts/modules/dev/logy.php
@@ -5,9 +5,10 @@ use Gamecon\Kanaly\MailLogger;
 use Gamecon\XTemplate\XTemplate;
 
 /**
- * nazev: Logy
- * pravo: 105
- * submenu_group: 8
+ * nazev: Mailové logy
+ * pravo: 113
+ * submenu_group: 1
+ * submenu_order: 4
  */
 
 /** @var Uzivatel $u */
@@ -48,7 +49,7 @@ if ($idDetailu > 0) {
     $detail = $mailLogger->detail($idDetailu);
     if ($detail === null) {
         http_response_code(404);
-        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href="logy">Zpět na seznam</a></p>';
+        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href=".">Zpět na seznam</a></p>';
         return;
     }
     $adresatiDetail = json_decode((string) $detail['adresati'], true) ?: [];
@@ -92,7 +93,7 @@ $sestavUrl = static function (array $parametry) use ($filtr): string {
         'smer'   => $parametry['smer']   ?? null,
         'strana' => $parametry['strana'] ?? null,
     ], static fn($hodnota) => $hodnota !== null && $hodnota !== '');
-    return 'logy?' . http_build_query($vychozi);
+    return '.?' . http_build_query($vychozi);
 };
 
 $odkazRazeni = static function (string $sloupec) use ($razeniSloupec, $razeniSmer, $sestavUrl): string {

--- a/admin/scripts/modules/dev/logy.php
+++ b/admin/scripts/modules/dev/logy.php
@@ -49,7 +49,7 @@ if ($idDetailu > 0) {
     $detail = $mailLogger->detail($idDetailu);
     if ($detail === null) {
         http_response_code(404);
-        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href=".">Zpět na seznam</a></p>';
+        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href="dev/logy">Zpět na seznam</a></p>';
         return;
     }
     $adresatiDetail = json_decode((string) $detail['adresati'], true) ?: [];
@@ -93,7 +93,7 @@ $sestavUrl = static function (array $parametry) use ($filtr): string {
         'smer'   => $parametry['smer']   ?? null,
         'strana' => $parametry['strana'] ?? null,
     ], static fn($hodnota) => $hodnota !== null && $hodnota !== '');
-    return '.?' . http_build_query($vychozi);
+    return 'dev/logy?' . http_build_query($vychozi);
 };
 
 $odkazRazeni = static function (string $sloupec) use ($razeniSloupec, $razeniSmer, $sestavUrl): string {

--- a/admin/scripts/modules/dev/logy.xtpl
+++ b/admin/scripts/modules/dev/logy.xtpl
@@ -8,7 +8,7 @@
     <input type="text" name="filtr" value="{filtr}">
   </label>
   <input type="submit" value="Filtrovat">
-  <!-- begin:zrusitFiltr --><a class="tlacitko" href="logy" title="Zrušit filtr">❌</a><!-- end:zrusitFiltr -->
+  <!-- begin:zrusitFiltr --><a class="tlacitko" href="dev/logy" title="Zrušit filtr">❌</a><!-- end:zrusitFiltr -->
 </form>
 
 <p>Celkem záznamů: {celkem}. Strana {aktualniStrana} / {pocetStran}.</p>
@@ -31,7 +31,7 @@
     <td>{adresati}</td>
     <td style="text-align: center">{prilohy}</td>
     <td>{chyba}</td>
-    <td style="text-align: center"><a class="tlacitko" href="logy?id={id}" title="Zobrazit detail">🔍</a></td>
+    <td style="text-align: center"><a class="tlacitko" href="dev/logy?id={id}" title="Zobrazit detail">🔍</a></td>
   </tr>
   <!-- end:radek -->
 </table>
@@ -51,7 +51,7 @@
       <h3 id="modalTestovaciEmailNadpis">Odeslat testovací email</h3>
       <button type="button" class="logy-modal__zavrit" aria-label="Zavřít" data-zavrit-test-email-modal>&times;</button>
     </div>
-    <form method="post" action="logy">
+    <form method="post">
       <p>Testovací e-mail bude odeslán na: <strong>{emailAdminaProTest}</strong></p>
       <p>
         <label for="testEmailPredmet">Předmět <span aria-hidden="true">*</span></label><br>
@@ -178,7 +178,7 @@
 
 <h1>Detail e-mailu</h1>
 
-<p><a class="tlacitko" href="logy">« Zpět na seznam</a></p>
+<p><a class="tlacitko" href="dev/logy">« Zpět na seznam</a></p>
 
 <table class="zvyraznovana">
   <tr><th>Kdy</th><td>{kdy}</td></tr>


### PR DESCRIPTION
Přesouvá modul **mailových logů** ze sekce *Web* do sekce *Dev* v adminu.

- Soubory `web/logy.php` + `web/logy.xtpl` → `dev/logy.php` + `dev/logy.xtpl`.
- Oprávnění `105` (`ADMINISTRACE_WEB`) → `113` (`ADMINISTRACE_DEV`) — stejně jako sourozenci `chyby` a `previews`.
- Metadata menu: `nazev` na „Mailové logy“, `submenu_group: 1`, `submenu_order: 4`.
- Na rozcestníku *Dev* přibyla dlaždice s odkazem na modul.
- Vnitřní odkazy (zrušení filtru, detail, zpět na seznam) přepsány na novou routu `dev/logy`.
