### PR TITLE
Fix back/sort/paging links in mail logy

### DIFF
--- a/admin/scripts/modules/dev/logy.php
+++ b/admin/scripts/modules/dev/logy.php
@@ -49,7 +49,7 @@ if ($idDetailu > 0) {
     $detail = $mailLogger->detail($idDetailu);
     if ($detail === null) {
         http_response_code(404);
-        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href=".">Zpět na seznam</a></p>';
+        echo '<h1>Záznam nenalezen</h1><p><a class="tlacitko" href="dev/logy">Zpět na seznam</a></p>';
         return;
     }
     $adresatiDetail = json_decode((string) $detail['adresati'], true) ?: [];
@@ -93,7 +93,7 @@ $sestavUrl = static function (array $parametry) use ($filtr): string {
         'smer'   => $parametry['smer']   ?? null,
         'strana' => $parametry['strana'] ?? null,
     ], static fn($hodnota) => $hodnota !== null && $hodnota !== '');
-    return '.?' . http_build_query($vychozi);
+    return 'dev/logy?' . http_build_query($vychozi);
 };
 
 $odkazRazeni = static function (string $sloupec) use ($razeniSloupec, $razeniSmer, $sestavUrl): string {


### PR DESCRIPTION
Follow-up to #887.

Admin pages render with `<base href="{URL_ADMIN}/">` (`admin/index.php`, `admin/templates/main.xtpl`), so relative links resolve against `URL_ADMIN/`, not the document path. In #887 the `.xtpl` was correctly rewritten to `dev/logy`, but `logy.php` used `.` / `.?` instead — which resolve to the admin homepage:

- `'.?' . http_build_query(...)` powers **sorting and pagination** links (`$sestavUrl` → `$odkazRazeni`, prev/next), so every sort/page link pointed at `URL_ADMIN/?...` instead of the log list — sorting and paging were broken.
- the 404 "Zpět na seznam" link `href="."` pointed at `URL_ADMIN/` instead of the list.

Both now use `dev/logy` / `dev/logy?...`, matching the `.xtpl` and resolving to `URL_ADMIN/dev/logy`.
