### PR TITLE
Show mail log body as readable HTML preview

### DIFF
--- a/admin/scripts/modules/dev/logy.php
+++ b/admin/scripts/modules/dev/logy.php
@@ -2,6 +2,7 @@
 
 use Gamecon\Kanaly\GcMail;
 use Gamecon\Kanaly\MailLogger;
+use Gamecon\Kanaly\MimeNahled;
 use Gamecon\XTemplate\XTemplate;
 
 /**
@@ -54,6 +55,13 @@ if ($idDetailu > 0) {
     }
     $adresatiDetail = json_decode((string) $detail['adresati'], true) ?: [];
 
+    // čitelný náhled: přednostně samostatně uložené HTML, jinak dekódovat ze syrové MIME zprávy
+    $teloHtml = $detail['telo_html'] ?? null;
+    if ($teloHtml === null || $teloHtml === '') {
+        $tela     = MimeNahled::vytahniTela((string) $detail['telo']);
+        $teloHtml = $tela['html'] ?? ($tela['text'] !== null ? nl2br(htmlspecialchars($tela['text'])) : null);
+    }
+
     $t = new XTemplate(__DIR__ . '/logy.xtpl');
     $t->assign('kdy', htmlspecialchars((string) $detail['kdy']));
     $t->assign('predmet', htmlspecialchars((string) $detail['predmet']));
@@ -61,7 +69,12 @@ if ($idDetailu > 0) {
     $t->assign('adresati', htmlspecialchars(implode(', ', array_map('strval', $adresatiDetail))));
     $t->assign('prilohy', (int) $detail['prilohy_count']);
     $t->assign('chyba', $detail['chyba'] !== null ? htmlspecialchars((string) $detail['chyba']) : '—');
+    // náhled běží v izolovaném iframe (srcdoc), aby HTML e-mailu neovlivnilo admin stránku
+    $t->assign('nahledSrcdoc', $teloHtml !== null ? htmlspecialchars($teloHtml, ENT_QUOTES) : '');
     $t->assign('telo', htmlspecialchars((string) $detail['telo']));
+    if ($teloHtml !== null) {
+        $t->parse('detail.nahled');
+    }
     $t->parse('detail');
     $t->out('detail');
     return;

--- a/admin/scripts/modules/dev/logy.xtpl
+++ b/admin/scripts/modules/dev/logy.xtpl
@@ -189,7 +189,15 @@
   <tr><th>Chyba</th><td>{chyba}</td></tr>
 </table>
 
-<h2>Tělo e-mailu</h2>
-<pre style="white-space: pre-wrap; word-break: break-word; background: #f5f5f5; padding: 1em; border: 1px solid #ddd">{telo}</pre>
+<!-- begin:nahled -->
+<h2>Náhled e-mailu</h2>
+<iframe srcdoc="{nahledSrcdoc}" sandbox="" title="Náhled e-mailu" style="width: 100%; min-height: 24em; background: #fff; border: 1px solid #ddd"></iframe>
+<!-- end:nahled -->
+
+<h2>Zdroj (syrová MIME zpráva)</h2>
+<details>
+  <summary>Zobrazit zdroj</summary>
+  <pre style="white-space: pre-wrap; word-break: break-word; background: #f5f5f5; padding: 1em; border: 1px solid #ddd">{telo}</pre>
+</details>
 
 <!-- end:detail -->

--- a/model/Kanaly/GcMail.php
+++ b/model/Kanaly/GcMail.php
@@ -72,8 +72,10 @@ class GcMail
             ->subject($predmet);
         $body = $this->pridejPrefixPodleProstredi($this->dejText());
         $mail->text(strip_tags($body));
+        $teloHtml = null;
         if ($format === self::FORMAT_HTML) {
             $mail->html($body);
+            $teloHtml = $body;
         }
 
         $odeslano = false;
@@ -82,7 +84,7 @@ class GcMail
         if ($adresatiDoSouboru) {
             $mail->addBcc(...$adresatiDoSouboru);
             $odeslano = $this->zalogovatDo(MAILY_DO_SOUBORU, $mail->toString()) || $odeslano;
-            $this->zalogujOdeslani($predmet, $format, $adresatiDoSouboru, $mail->toString());
+            $this->zalogujOdeslani($predmet, $format, $adresatiDoSouboru, $mail->toString(), $teloHtml);
         }
         $adresati = $this->adresatiPovoleniPodleRoli();
         if ($adresati) {
@@ -98,9 +100,9 @@ class GcMail
             try {
                 $mailer->send($mail);
                 $odeslano = true;
-                $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString());
+                $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString(), $teloHtml);
             } catch (Throwable $chyba) {
-                $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString(), $chyba->getMessage());
+                $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString(), $teloHtml, $chyba->getMessage());
                 throw $chyba;
             }
         }
@@ -112,6 +114,7 @@ class GcMail
         string  $format,
         array   $adresati,
         string  $telo,
+        ?string $teloHtml = null,
         ?string $chyba = null,
     ): void {
         $mailLogger = $this->mailLogger ?? MailLogger::zGlobals();
@@ -127,6 +130,7 @@ class GcMail
             adresati: $adresati,
             pocetPriloh: $pocetPriloh,
             telo: $telo,
+            teloHtml: $teloHtml,
             chyba: $chyba,
         );
     }

--- a/model/Kanaly/MailLogger.php
+++ b/model/Kanaly/MailLogger.php
@@ -35,11 +35,12 @@ class MailLogger
         array  $adresati,
         int    $pocetPriloh,
         string $telo,
+        ?string $teloHtml = null,
         ?string $chyba = null,
     ): void {
         $dotaz = $this->databaze()->prepare(
-            'INSERT INTO maily (kdy, predmet, predmet_lower, format, adresati, prilohy_count, telo, chyba)
-             VALUES (:kdy, :predmet, :predmet_lower, :format, :adresati, :prilohy_count, :telo, :chyba)'
+            'INSERT INTO maily (kdy, predmet, predmet_lower, format, adresati, prilohy_count, telo, telo_html, chyba)
+             VALUES (:kdy, :predmet, :predmet_lower, :format, :adresati, :prilohy_count, :telo, :telo_html, :chyba)'
         );
         $dotaz->execute([
             ':kdy'           => date('c'),
@@ -49,6 +50,7 @@ class MailLogger
             ':adresati'      => json_encode(array_values($adresati), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             ':prilohy_count' => $pocetPriloh,
             ':telo'          => $telo,
+            ':telo_html'     => $teloHtml,
             ':chyba'         => $chyba,
         ]);
     }
@@ -89,7 +91,7 @@ class MailLogger
     public function detail(int $id): ?array
     {
         $dotaz = $this->databaze()->prepare(
-            'SELECT id, kdy, predmet, format, adresati, prilohy_count, telo, chyba
+            'SELECT id, kdy, predmet, format, adresati, prilohy_count, telo, telo_html, chyba
              FROM maily
              WHERE id = :id'
         );
@@ -154,6 +156,7 @@ class MailLogger
                 adresati        JSON NOT NULL,
                 prilohy_count   INTEGER NOT NULL DEFAULT 0,
                 telo            TEXT NOT NULL,
+                telo_html       TEXT,
                 chyba           TEXT
             )
             SQLITE3);
@@ -161,6 +164,21 @@ class MailLogger
         $sqlite->query('CREATE INDEX IF NOT EXISTS idx_maily_prilohy_count ON maily (prilohy_count)');
         $sqlite->query('CREATE INDEX IF NOT EXISTS idx_maily_predmet_lower ON maily (predmet_lower)');
 
-        return $this->sqlite = $sqlite;
+        $this->sqlite = $sqlite;
+        $this->dodejSloupecTeloHtml();
+
+        return $sqlite;
+    }
+
+    /**
+     * Doplní sloupec `telo_html` do již existující databáze, která vznikla
+     * před jeho zavedením (SQLite nemá ADD COLUMN IF NOT EXISTS).
+     */
+    private function dodejSloupecTeloHtml(): void
+    {
+        $sloupce = $this->sqlite->query('PRAGMA table_info(maily)')->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('telo_html', $sloupce, true)) {
+            $this->sqlite->query('ALTER TABLE maily ADD COLUMN telo_html TEXT');
+        }
     }
 }

--- a/model/Kanaly/MimeNahled.php
+++ b/model/Kanaly/MimeNahled.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Kanaly;
+
+/**
+ * Vytáhne čitelné tělo (HTML, případně text) ze syrové MIME zprávy,
+ * jakou ukládá {@see MailLogger} do sloupce `telo` (výstup Symfony
+ * Email::toString()). Slouží jako fallback pro starší záznamy, které
+ * nemají samostatně uložený dekódovaný HTML obsah (`telo_html`).
+ */
+final class MimeNahled
+{
+    /**
+     * @return array{html: ?string, text: ?string} dekódované části;
+     *                                             `null`, pokud daná část v MIME zprávě není
+     */
+    public static function vytahniTela(string $mime): array
+    {
+        [$hlavicky, $telo] = self::rozdelHlavickyATelo($mime);
+
+        $contentType = $hlavicky['content-type'] ?? '';
+        $boundary = self::boundary($contentType);
+
+        if ($boundary === null) {
+            // jednoduchá (ne-multipart) zpráva
+            $obsah = self::dekodujTelo($telo, $hlavicky['content-transfer-encoding'] ?? '', $contentType);
+            $jeHtml = stripos($contentType, 'text/html') !== false;
+
+            return [
+                'html' => $jeHtml ? $obsah : null,
+                'text' => $jeHtml ? null : $obsah,
+            ];
+        }
+
+        $html = null;
+        $text = null;
+        foreach (self::rozdelNaCasti($telo, $boundary) as $cast) {
+            [$castHlavicky, $castTelo] = self::rozdelHlavickyATelo($cast);
+            $castContentType = $castHlavicky['content-type'] ?? '';
+
+            // vnořený multipart (např. multipart/related kolem HTML) – rekurze
+            if (self::boundary($castContentType) !== null) {
+                $vnoreno = self::vytahniTela($cast);
+                $html ??= $vnoreno['html'];
+                $text ??= $vnoreno['text'];
+                continue;
+            }
+
+            $obsah = self::dekodujTelo(
+                $castTelo,
+                $castHlavicky['content-transfer-encoding'] ?? '',
+                $castContentType,
+            );
+            if (stripos($castContentType, 'text/html') !== false) {
+                $html ??= $obsah;
+            } elseif (stripos($castContentType, 'text/plain') !== false) {
+                $text ??= $obsah;
+            }
+        }
+
+        return [
+            'html' => $html,
+            'text' => $text,
+        ];
+    }
+
+    /**
+     * @return array{0: array<string, string>, 1: string} [hlavičky (klíče lowercase), tělo]
+     */
+    private static function rozdelHlavickyATelo(string $mime): array
+    {
+        $mime = str_replace("\r\n", "\n", $mime);
+        $delic = strpos($mime, "\n\n");
+        if ($delic === false) {
+            return [[], $mime];
+        }
+
+        $hlavickovaCast = substr($mime, 0, $delic);
+        $telo = substr($mime, $delic + 2);
+
+        // rozbalení skládaných (folded) hlaviček – pokračovací řádek začíná mezerou/tabem
+        $hlavickovaCast = preg_replace('/\n[ \t]+/', ' ', $hlavickovaCast) ?? $hlavickovaCast;
+
+        $hlavicky = [];
+        foreach (explode("\n", $hlavickovaCast) as $radek) {
+            $dvojtecka = strpos($radek, ':');
+            if ($dvojtecka === false) {
+                continue;
+            }
+            $nazev = strtolower(trim(substr($radek, 0, $dvojtecka)));
+            $hlavicky[$nazev] = trim(substr($radek, $dvojtecka + 1));
+        }
+
+        return [$hlavicky, $telo];
+    }
+
+    private static function boundary(string $contentType): ?string
+    {
+        if (stripos($contentType, 'multipart/') === false) {
+            return null;
+        }
+        if (preg_match('/boundary="?([^";]+)"?/i', $contentType, $shoda) !== 1) {
+            return null;
+        }
+
+        return $shoda[1];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function rozdelNaCasti(string $telo, string $boundary): array
+    {
+        $casti = explode('--' . $boundary, $telo);
+        // první prvek je preambule, poslední uzávěr ("--boundary--") + epilog
+        array_shift($casti);
+        $vysledek = [];
+        foreach ($casti as $cast) {
+            // uzavírací delimiter "--" hned za boundary ⇒ konec
+            if (str_starts_with($cast, '--')) {
+                break;
+            }
+            $vysledek[] = ltrim($cast, "\n");
+        }
+
+        return $vysledek;
+    }
+
+    private static function dekodujTelo(string $telo, string $kodovani, string $contentType): string
+    {
+        $kodovani = strtolower(trim($kodovani));
+        $obsah = match ($kodovani) {
+            'quoted-printable' => quoted_printable_decode($telo),
+            'base64'           => (string) base64_decode(trim($telo), true),
+            default            => $telo,
+        };
+
+        $charset = self::charset($contentType);
+        if ($charset !== null && strtolower($charset) !== 'utf-8') {
+            $prevedeno = @mb_convert_encoding($obsah, 'UTF-8', $charset);
+            if ($prevedeno !== false) {
+                $obsah = $prevedeno;
+            }
+        }
+
+        return rtrim($obsah, "\n");
+    }
+
+    private static function charset(string $contentType): ?string
+    {
+        if (preg_match('/charset="?([^";]+)"?/i', $contentType, $shoda) !== 1) {
+            return null;
+        }
+
+        return $shoda[1];
+    }
+}

--- a/tests/Model/Kanaly/MailLoggerTest.php
+++ b/tests/Model/Kanaly/MailLoggerTest.php
@@ -126,7 +126,7 @@ class MailLoggerTest extends TestCase
     public function detailVraciCeleTeloAChybuNeboNullProNeznameId(): void
     {
         $logger = new MailLogger($this->cestaSqlite);
-        $logger->zalogujOdeslani('Detail test', 'html', ['x@y.cz'], 1, 'plné tělo e-mailu', null);
+        $logger->zalogujOdeslani('Detail test', 'html', ['x@y.cz'], 1, 'plné tělo e-mailu', '<p>HTML</p>', null);
 
         $zaznamy = $logger->najdi();
         $id = (int) $zaznamy[0]['id'];
@@ -135,6 +135,7 @@ class MailLoggerTest extends TestCase
         self::assertNotNull($detail);
         self::assertSame('Detail test', $detail['predmet']);
         self::assertSame('plné tělo e-mailu', $detail['telo']);
+        self::assertSame('<p>HTML</p>', $detail['telo_html']);
         self::assertNull($detail['chyba']);
 
         self::assertNull($logger->detail(999999));
@@ -146,9 +147,24 @@ class MailLoggerTest extends TestCase
     public function zaznamuSChybouMaVyplnenouChybu(): void
     {
         $logger = new MailLogger($this->cestaSqlite);
-        $logger->zalogujOdeslani('Nepodařilo se', 'html', ['x@y.cz'], 0, 'telo', 'SMTP server nereaguje');
+        $logger->zalogujOdeslani('Nepodařilo se', 'html', ['x@y.cz'], 0, 'telo', null, 'SMTP server nereaguje');
 
         $zaznam = $logger->najdi()[0];
         self::assertSame('SMTP server nereaguje', $zaznam['chyba']);
+    }
+
+    /**
+     * @test
+     */
+    public function ukladaIVraciSamostatnyHtmlNahled(): void
+    {
+        $logger = new MailLogger($this->cestaSqlite);
+        $logger->zalogujOdeslani('S HTML', 'html', ['a@b.cz'], 0, 'raw mime', '<p>Ahoj</p>');
+        $logger->zalogujOdeslani('Bez HTML', 'text', ['c@d.cz'], 0, 'jen text');
+
+        $zaznamy = array_column($logger->najdi(razeniSloupec: 'kdy', razeniSmer: 'ASC'), null, 'predmet');
+
+        self::assertSame('<p>Ahoj</p>', $logger->detail((int) $zaznamy['S HTML']['id'])['telo_html']);
+        self::assertNull($logger->detail((int) $zaznamy['Bez HTML']['id'])['telo_html']);
     }
 }

--- a/tests/Model/Kanaly/MimeNahledTest.php
+++ b/tests/Model/Kanaly/MimeNahledTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Kanaly;
+
+use Gamecon\Kanaly\MimeNahled;
+use PHPUnit\Framework\TestCase;
+
+class MimeNahledTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function vytahneHtmlITextSDekodovanymiDiakritikamiZMultipartZpravy(): void
+    {
+        $mime = "From: GameCon <gamecon.fallback@seznam.cz>\r\n"
+            . "Subject: =?utf-8?Q?Voln=C3=A9_m=C3=ADsto?=\r\n"
+            . "MIME-Version: 1.0\r\n"
+            . "Content-Type: multipart/alternative; boundary=IzEog0sX\r\n"
+            . "\r\n"
+            . "--IzEog0sX\r\n"
+            . "Content-Type: text/plain; charset=utf-8\r\n"
+            . "Content-Transfer-Encoding: quoted-printable\r\n"
+            . "\r\n"
+            . "Na aktivit=C4=9B se uvolnilo m=C3=ADsto.\r\n"
+            . "--IzEog0sX\r\n"
+            . "Content-Type: text/html; charset=utf-8\r\n"
+            . "Content-Transfer-Encoding: quoted-printable\r\n"
+            . "\r\n"
+            . "<html><body>Na aktivit=C4=9B se uvolnilo m=C3=ADsto. P=C5=99ihla=C5=A1 se p=C5=99es <a=\r\n"
+            . " href=3D\"https://gamecon.cz/program\">program</a>.</body></html>\r\n"
+            . "--IzEog0sX--\r\n";
+
+        $tela = MimeNahled::vytahniTela($mime);
+
+        self::assertSame('Na aktivitě se uvolnilo místo.', $tela['text']);
+        self::assertNotNull($tela['html']);
+        self::assertStringContainsString('Na aktivitě se uvolnilo místo.', $tela['html']);
+        self::assertStringContainsString('Přihlaš se přes', $tela['html']);
+        self::assertStringContainsString('href="https://gamecon.cz/program"', $tela['html']);
+        // quoted-printable soft line break (=\n) i =3D musí zmizet
+        self::assertStringNotContainsString('=3D', $tela['html']);
+        self::assertStringNotContainsString('=C5', $tela['html']);
+    }
+
+    /**
+     * @test
+     */
+    public function zvladneJednoduchouNeMultipartHtmlZpravu(): void
+    {
+        $mime = "Content-Type: text/html; charset=utf-8\r\n"
+            . "Content-Transfer-Encoding: quoted-printable\r\n"
+            . "\r\n"
+            . '<p>M=C3=ADsto</p>';
+
+        $tela = MimeNahled::vytahniTela($mime);
+
+        self::assertSame('<p>Místo</p>', $tela['html']);
+        self::assertNull($tela['text']);
+    }
+
+    /**
+     * @test
+     */
+    public function dekodujeBase64Telo(): void
+    {
+        $obsah = '<p>Příliš žluťoučký kůň</p>';
+        $mime = "Content-Type: text/html; charset=utf-8\r\n"
+            . "Content-Transfer-Encoding: base64\r\n"
+            . "\r\n"
+            . chunk_split(base64_encode($obsah));
+
+        $tela = MimeNahled::vytahniTela($mime);
+
+        self::assertSame($obsah, $tela['html']);
+    }
+}


### PR DESCRIPTION
Detail mailového logu dosud zobrazoval syrovou MIME zprávu (hlavičky, multipart boundary, quoted-printable) — nečitelnou, s rozsypanou diakritikou. Nově ukazuje vyrenderovaný HTML náhled s dekódovanou diakritikou.

## Co se mění

- **Ukládá se i dekódované HTML tělo** (`telo_html`) – nový sloupec v SQLite `maily`. `GcMail` ho při odeslání naplní HTML verzí těla (u text-only mailů zůstává `NULL`). Sloupec se doplní i do již existující DB (`ALTER TABLE`, SQLite nemá `ADD COLUMN IF NOT EXISTS`).
- **Detail zobrazí HTML, je-li k dispozici**, jinak ho **dekóduje ze syrové MIME** přes nový `MimeNahled` (vytáhne `text/html`, fallback `text/plain`, dekóduje quoted-printable / base64, převede charset na UTF-8). Funguje tedy i pro **starší záznamy** bez `telo_html`.
- Náhled běží v **izolovaném `<iframe sandbox srcdoc>`**, aby HTML e-mailu neovlivnilo admin stránku (žádné skripty, žádný same-origin). Syrová MIME zpráva zůstává dostupná ve sbalitelném `<details>`.

## Testy

- `MimeNahledTest` – multipart (HTML+text) s reálným příkladem, jednoduchá ne-multipart zpráva, base64; ověřuje dekódování diakritiky a spojení quoted-printable soft-breaků.
- `MailLoggerTest` – uložení/načtení `telo_html` (vč. `NULL` u text mailu), aktualizované signatury.
- Celá sada `tests/Model/Kanaly/` zelená (17 testů).
