### PR TITLE
Move Previews to web section, rename mail-log labels

### DIFF
--- a/admin/scripts/modules/dev/dev.php
+++ b/admin/scripts/modules/dev/dev.php
@@ -6,7 +6,7 @@ use Gamecon\SystemoveNastaveni\AnonymizovanaDatabaze;
 /**
  * Rozcestník pro vývojářské nástroje.
  *
- * Naviguje na Previews / Staré ročníky / SQL update.
+ * Naviguje na Chyby / SQL update / Mail logy.
  * Anonymizovaná databáze se generuje cronem
  * (admin/cron/anonymizace_databaze.php) jednou denně; tato stránka
  * jen zpřístupní poslední vygenerovaný soubor ke stažení rovnou
@@ -66,10 +66,6 @@ $datumAnonymExportu = AnonymizovanaDatabaze::datumPoslednihoExportu();
     }
 </style>
 <div class="dev-rozcestnik">
-    <a href="<?php echo URL_ADMIN; ?>/dev/previews">
-        <h3>Previews</h3>
-        <p>Aktivní preview prostředí (dockerizovaná nasazení feature větví).</p>
-    </a>
     <a href="<?php echo URL_ADMIN; ?>/dev/chyby">
         <h3>Chyby</h3>
         <p>Zachycené výjimky a chyby aplikace.</p>
@@ -79,8 +75,8 @@ $datumAnonymExportu = AnonymizovanaDatabaze::datumPoslednihoExportu();
         <p>Vygenerování SQL pro překlápění ročníku (uzavření financí).</p>
     </a>
     <a href="<?php echo URL_ADMIN; ?>/dev/logy">
-        <h3>Mailové logy</h3>
-        <p></p>
+        <h3>Mail logy</h3>
+        <p>Záznamy odeslaných e-mailů.</p>
     </a>
 </div>
 

--- a/admin/scripts/modules/dev/logy.php
+++ b/admin/scripts/modules/dev/logy.php
@@ -6,7 +6,7 @@ use Gamecon\Kanaly\MimeNahled;
 use Gamecon\XTemplate\XTemplate;
 
 /**
- * nazev: Mailové logy
+ * nazev: Mail logy
  * pravo: 113
  * submenu_group: 1
  * submenu_order: 4

--- a/admin/scripts/modules/dev/logy.xtpl
+++ b/admin/scripts/modules/dev/logy.xtpl
@@ -194,7 +194,7 @@
 <iframe srcdoc="{nahledSrcdoc}" sandbox="" title="Náhled e-mailu" style="width: 100%; min-height: 24em; background: #fff; border: 1px solid #ddd"></iframe>
 <!-- end:nahled -->
 
-<h2>Zdroj (syrová MIME zpráva)</h2>
+<h2>Odeslané MIME</h2>
 <details>
   <summary>Zobrazit zdroj</summary>
   <pre style="white-space: pre-wrap; word-break: break-word; background: #f5f5f5; padding: 1em; border: 1px solid #ddd">{telo}</pre>

--- a/admin/scripts/modules/web/previews.php
+++ b/admin/scripts/modules/web/previews.php
@@ -7,9 +7,8 @@ use Gamecon\Dev\GateLink;
  * Seznam aktivních preview prostředí.
  *
  * nazev: Previews
- * pravo: 113
- * submenu_group: 1
- * submenu_order: 2
+ * pravo: 105
+ * submenu_group: 9
  */
 $reader = new DeploymentsReader();
 $unavailableReason = $reader->unavailableReason();

--- a/admin/scripts/modules/web/previews.php
+++ b/admin/scripts/modules/web/previews.php
@@ -38,7 +38,7 @@ $prListUrl = static fn (string $slug): string => 'https://github.com/gamecon-cz/
         webmail.preview.gamecon.cz
     </a>
     <div style="margin-top: 6px; font-size: 0.85em; color: #555;">
-        Přihlášení k bráně:
+        Přihlášení k bráně (basic auth):
         <code style="user-select: all;"><?php echo htmlspecialchars(PREVIEW_BASIC_AUTH_USER); ?></code>
         /
         <code style="user-select: all;"><?php echo htmlspecialchars(PREVIEW_BASIC_AUTH_PASSWORD); ?></code>

--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -39,7 +39,7 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GA
     <p><em>Žádný dockerizovaný archivní ročník zatím není nasazený.</em></p>
 <?php } else { ?>
     <p style="margin: 8px 0; color: #555;">
-        Přihlášení k bráně (zeptá se prohlížeč při prvním otevření):
+        Přihlášení k bráně (basic auth):
         <code style="user-select: all;"><?php echo htmlspecialchars(ARCHIVE_BASIC_AUTH_USER); ?></code>
         /
         <code style="user-select: all;"><?php echo htmlspecialchars(ARCHIVE_BASIC_AUTH_PASSWORD); ?></code>

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'gamecon-cz/gamecon',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '8024bf24eda600b6cc6fee38fcd501fd59b7a960',
+        'reference' => '57cd60c75faceaac954a60acfe1eaf4ca6b059c8',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -202,7 +202,7 @@
         'gamecon-cz/gamecon' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '8024bf24eda600b6cc6fee38fcd501fd59b7a960',
+            'reference' => '57cd60c75faceaac954a60acfe1eaf4ca6b059c8',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Drobné úpravy admin sekcí kolem mailových logů a preview.

## Co se mění

- **Previews přesunuty ze sekce *Dev* do sekce *Web*.** Soubor `dev/previews.php` → `web/previews.php`; oprávnění `113` (`ADMINISTRACE_DEV`) → `105` (`ADMINISTRACE_WEB`); zařazeno do `submenu_group: 9` (vedle *Staré ročníky*). Modul nemá žádné vnitřní odkazy ani `__DIR__`-závislosti, přesun je tedy bezpečný. Dlaždice *Previews* odebrána z rozcestníku *Dev*.
- **`Mailové logy` → `Mail logy`** (název v menu i dlaždice na rozcestníku *Dev*; prázdný popisek dlaždice doplněn).
- **`Zdroj (syrová MIME zpráva)` → `Odeslané MIME`** (nadpis v detailu mailu).
