### PR TITLE
Allow 2009 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2010 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2010..2099" >&2
+                    if (( year < 2009 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2009..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -79,11 +79,12 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
-                        # 2010 and 2011 are STATIC archives (the live DB +
-                        # router are lost) — flat HTML reconstructed from the
+                        # 2009, 2010 and 2011 are STATIC archives (the live DB
+                        # + router are lost) — flat HTML reconstructed from the
                         # Internet Archive. Any base works; php:5.6-apache
                         # matches their neighbours and stays lightweight (no
                         # PHP executes).
+                        2009) base_image="php:5.6-apache" ;;
                         2010) base_image="php:5.6-apache" ;;
                         2011) base_image="php:5.6-apache" ;;
                         2012) base_image="php:5.6-apache" ;;
@@ -107,9 +108,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2010 and 2011 static archives need no PHP extension
-                        # at all (no DB, no dynamic code) — empty list skips
-                        # the Dockerfile's whole install step.
+                        # 2009, 2010 and 2011 static archives need no PHP
+                        # extension at all (no DB, no dynamic code) — empty list
+                        # skips the Dockerfile's whole install step.
+                        2009) php_exts="" ;;
                         2010) php_exts="" ;;
                         2011) php_exts="" ;;
                         2012) php_exts="mysql" ;;


### PR DESCRIPTION
Lowers the year-archive deploy guard floor from 2010 to 2009 so the new `archive/2009` static reconstruction can deploy.

- Range guard `2010..2099` → `2009..2099`
- Adds `2009)` rows to the `base_image` (`php:5.6-apache`) and `php_exts` (`""`) case maps, matching 2010/2011 (static, no PHP executes).

Companion ansible PRs lower the same floor in `deploy-year-archive.sh` and `ci-preview-wrapper.sh`. All three must merge + `make deploy` before `archive/2009` is pushed.

Part of the Wayback static-archive reconstruction (see `docs/generated/archiv-rekonstrukce-z-wayback.md`).