### PR TITLE
Allow 2008 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2009 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2009..2099" >&2
+                    if (( year < 2008 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2008..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -79,11 +79,13 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
-                        # 2009, 2010 and 2011 are STATIC archives (the live DB
-                        # + router are lost) — flat HTML reconstructed from the
-                        # Internet Archive. Any base works; php:5.6-apache
-                        # matches their neighbours and stays lightweight (no
-                        # PHP executes).
+                        # 2008–2011 are STATIC archives (the live DB + router
+                        # are lost) — flat HTML reconstructed from the Internet
+                        # Archive. Any base works; php:5.6-apache matches their
+                        # neighbours and stays lightweight (no PHP executes).
+                        # 2008 is the Altar-era gamecon.altar.cz site (different
+                        # CMS), still pure static HTML — same base applies.
+                        2008) base_image="php:5.6-apache" ;;
                         2009) base_image="php:5.6-apache" ;;
                         2010) base_image="php:5.6-apache" ;;
                         2011) base_image="php:5.6-apache" ;;
@@ -108,9 +110,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2009, 2010 and 2011 static archives need no PHP
-                        # extension at all (no DB, no dynamic code) — empty list
-                        # skips the Dockerfile's whole install step.
+                        # 2008–2011 static archives need no PHP extension at
+                        # all (no DB, no dynamic code) — empty list skips the
+                        # Dockerfile's whole install step.
+                        2008) php_exts="" ;;
                         2009) php_exts="" ;;
                         2010) php_exts="" ;;
                         2011) php_exts="" ;;


### PR DESCRIPTION
Lowers the year-archive deploy guard floor from 2009 to 2008 so the new `archive/2008` static reconstruction (the Altar-era `gamecon.altar.cz` site) can deploy.

- Range guard `2009..2099` → `2008..2099`
- Adds `2008)` rows to the `base_image` (`php:5.6-apache`) and `php_exts` (`""`) maps. 2008 is pure static HTML (no PHP executes), same as 2009–2011.

Companion ansible PR lowers the same floor in `deploy-year-archive.sh` and `ci-preview-wrapper.sh`. All three must merge + `make deploy` before `archive/2008` is pushed.