### PR TITLE
Allow 2007 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2008 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2008..2099" >&2
+                    if (( year < 2007 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2007..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -79,12 +79,13 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
-                        # 2008–2011 are STATIC archives (the live DB + router
+                        # 2007–2011 are STATIC archives (the live DB + router
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2008 is the Altar-era gamecon.altar.cz site (different
-                        # CMS), still pure static HTML — same base applies.
+                        # 2007 & 2008 are the Altar-era gamecon.altar.cz site
+                        # (different CMS), still pure static HTML — same base.
+                        2007) base_image="php:5.6-apache" ;;
                         2008) base_image="php:5.6-apache" ;;
                         2009) base_image="php:5.6-apache" ;;
                         2010) base_image="php:5.6-apache" ;;
@@ -110,9 +111,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2008–2011 static archives need no PHP extension at
+                        # 2007–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        2007) php_exts="" ;;
                         2008) php_exts="" ;;
                         2009) php_exts="" ;;
                         2010) php_exts="" ;;


### PR DESCRIPTION
Lowers the year-archive deploy guard floor from 2008 to 2007 so the new `archive/2007` static reconstruction (the Altar-era `gamecon.altar.cz` site) can deploy.

- Range guard `2008..2099` → `2007..2099`
- Adds `2007)` rows to the `base_image` (`php:5.6-apache`) and `php_exts` (`""`) maps. 2007 is pure static HTML (no PHP), same as 2008–2011.

Companion ansible PR lowers the same floor in `deploy-year-archive.sh` and `ci-preview-wrapper.sh`. All three must merge + `make deploy` before `archive/2007` is pushed.