### PR TITLE
Allow 2005 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2006 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2006..2099" >&2
+                    if (( year < 2005 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2005..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -79,12 +79,14 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
-                        # 2006–2011 are STATIC archives (the live DB + router
+                        # 2005–2011 are STATIC archives (the live DB + router
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2006–2008 are the Altar-era gamecon.altar.cz site
-                        # (different CMS), still pure static HTML — same base.
+                        # 2005–2008 are the Altar-era sites (2005 = altar.cz
+                        # /gamecon/ path; 2006–2008 = gamecon.altar.cz subdomain;
+                        # different CMS), still pure static HTML — same base.
+                        2005) base_image="php:5.6-apache" ;;
                         2006) base_image="php:5.6-apache" ;;
                         2007) base_image="php:5.6-apache" ;;
                         2008) base_image="php:5.6-apache" ;;
@@ -112,9 +114,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2006–2011 static archives need no PHP extension at
+                        # 2005–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        2005) php_exts="" ;;
                         2006) php_exts="" ;;
                         2007) php_exts="" ;;
                         2008) php_exts="" ;;


### PR DESCRIPTION
Lowers the year-archive deploy guard floor from 2006 to 2005 so the new `archive/2005` static reconstruction can deploy.

2005 is the oldest/messiest source so far: GameCon was a *section* of the whole altar.cz publisher site (path `altar.cz/gamecon/`, predating the gamecon.altar.cz subdomain). Scope: GameCon pages only (incl. the 1995–2004 DrD results archive); cross-site Altar chrome links fall to the themed 404. Pure static HTML.

- Range guard `2006..2099` → `2005..2099`
- Adds `2005)` rows to `base_image` (`php:5.6-apache`) and `php_exts` (`""`).

Companion ansible PR lowers the same floor. All three must merge + `make deploy` before `archive/2005` is pushed.