### PR TITLE
Link preview PR by real branch, not lossy slug

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -148,14 +148,27 @@ jobs:
                 # the workflow run. Nothing persists on the host.
                 env:
                     GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    # Raw git branch name, passed as the deploy's 3rd arg so the
+                    # host stores it in the deployment record (the slug is a
+                    # lossy slugification; the admin links the PR by exact
+                    # branch). Via env (not string-interpolated into the script)
+                    # to avoid Actions expression injection from a hostile ref.
+                    BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
                 run: |
                     # Reference the SHA-pinned tag (not the rolling slug
                     # tag) so the deploy is guaranteed to be this commit's
                     # build. If the script falls back to a cached image,
                     # it can only ever match this exact commit.
                     image="ghcr.io/${{ github.repository_owner }}/gamecon:preview-${{ steps.slug.outputs.slug }}-${{ steps.slug.outputs.sha7 }}"
+                    # Append branch as a 3rd arg only when it's safe to embed in
+                    # the single-quoted remote command (no single quote). The
+                    # wrapper's BRANCH_RE rejects shell metachars regardless.
+                    branch_arg=""
+                    if [ -n "$BRANCH" ] && case "$BRANCH" in *\'*) false ;; *) true ;; esac; then
+                        branch_arg=" '$BRANCH'"
+                    fi
                     echo "$GHCR_TOKEN" | ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
-                        "/usr/local/sbin/deploy-preview-branch.sh '${{ steps.slug.outputs.slug }}' '$image'"
+                        "/usr/local/sbin/deploy-preview-branch.sh '${{ steps.slug.outputs.slug }}' '$image'$branch_arg"
 
             -   name: Output preview URL
                 run: |

--- a/admin/scripts/modules/web/previews.php
+++ b/admin/scripts/modules/web/previews.php
@@ -24,11 +24,14 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, PREVIEW_GA
 
 $mailpitUrl = $gateUrl('https://webmail.preview.gamecon.cz/');
 
-// Preview slug = git branch name (viz .github/workflows/deploy-preview.yml).
-// Linkujeme do filtru PR listu — funguje pro open i closed PR a nerozbije
-// se, pokud větev neexistuje / PR ještě nevznikl.
-$prListUrl = static fn (string $slug): string => 'https://github.com/gamecon-cz/gamecon/pulls?q='
-    . rawurlencode('is:pr head:' . $slug);
+// Odkaz do filtru PR listu podle větve. POZOR: slug NENÍ jméno větve — je to
+// jeho slugifikace (podtržítka→pomlčky, diakritika pryč, ořez na 30 znaků; viz
+// deploy-preview.yml). Pro odkaz na PR proto použijeme uloženou původní větev
+// (`$preview->branch`); když chybí (staré záznamy bez branch), spadneme na slug
+// jako dřív. `head:` v GitHub PR hledání matchuje prefix, takže to funguje pro
+// open i closed PR a nerozbije se, pokud větev neexistuje.
+$prListUrl = static fn (string $ref): string => 'https://github.com/gamecon-cz/gamecon/pulls?q='
+    . rawurlencode('is:pr head:' . $ref);
 ?>
 <h2>Preview prostředí</h2>
 
@@ -70,8 +73,9 @@ $prListUrl = static fn (string $slug): string => 'https://github.com/gamecon-cz/
                     </a>
                 </td>
                 <td>
-                    <a href="<?php echo htmlspecialchars($prListUrl($preview->slug)); ?>" target="_blank" rel="noopener">
-                        <?php echo htmlspecialchars($preview->slug); ?>
+                    <?php $prRef = $preview->branch ?? $preview->slug; ?>
+                    <a href="<?php echo htmlspecialchars($prListUrl($prRef)); ?>" target="_blank" rel="noopener">
+                        <?php echo htmlspecialchars($prRef); ?>
                     </a>
                 </td>
                 <td>

--- a/model/Dev/DeploymentsReader.php
+++ b/model/Dev/DeploymentsReader.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\Dev;
@@ -34,7 +35,7 @@ namespace Gamecon\Dev;
 final class DeploymentsReader
 {
     public const DEFAULT_DIRECTORY = '/var/lib/gamecon/deployments';
-    public const SUPPORTED_SCHEMA  = 1;
+    public const SUPPORTED_SCHEMA = 1;
 
     private const SUBDIR_PREVIEWS = 'previews';
     private const SUBDIR_ARCHIVES = 'archives';
@@ -50,16 +51,17 @@ final class DeploymentsReader
      */
     public function unavailableReason(): ?string
     {
-        if (!is_dir($this->directory)) {
+        if (! is_dir($this->directory)) {
             return "Directory `{$this->directory}` does not exist. "
                 . 'It is created by the ansible roles `preview_deployer` / '
                 . '`year_archive_deployer` on the production host. '
                 . 'On local / beta nothing will show.';
         }
-        if (!is_readable($this->directory)) {
+        if (! is_readable($this->directory)) {
             return "Directory `{$this->directory}` is not readable by "
                 . get_current_user() . '. Expected mode 0755 root:root.';
         }
+
         return null;
     }
 
@@ -75,6 +77,7 @@ final class DeploymentsReader
                 $previews[] = $preview;
             }
         }
+
         return $previews;
     }
 
@@ -90,6 +93,7 @@ final class DeploymentsReader
                 $archives[] = $archive;
             }
         }
+
         return $archives;
     }
 
@@ -109,6 +113,7 @@ final class DeploymentsReader
                 }
             }
         }
+
         return $maxStamp;
     }
 
@@ -127,7 +132,7 @@ final class DeploymentsReader
     private function readFilesInSubdir(string $subdir): iterable
     {
         $path = $this->directory . '/' . $subdir;
-        if (!is_dir($path) || !is_readable($path)) {
+        if (! is_dir($path) || ! is_readable($path)) {
             return;
         }
         $files = glob($path . '/*.json') ?: [];
@@ -138,7 +143,7 @@ final class DeploymentsReader
             // and 4-digit years for archives. Anything else is a hand-edited or
             // orphaned file we'd rather skip than misread.
             $name = basename($file, '.json');
-            if (!preg_match('~^[a-z0-9-]{1,30}$~', $name)) {
+            if (! preg_match('~^[a-z0-9-]{1,30}$~', $name)) {
                 continue;
             }
             $raw = @file_get_contents($file);
@@ -146,10 +151,10 @@ final class DeploymentsReader
                 continue;
             }
             $data = json_decode($raw, true);
-            if (!is_array($data)) {
+            if (! is_array($data)) {
                 continue;
             }
-            $schema = isset($data['schema_version']) ? (int)$data['schema_version'] : self::SUPPORTED_SCHEMA;
+            $schema = isset($data['schema_version']) ? (int) $data['schema_version'] : self::SUPPORTED_SCHEMA;
             if ($schema > self::SUPPORTED_SCHEMA) {
                 // Future schema. Skip — better to hide one record than
                 // to render it through a guessed mapping.
@@ -167,17 +172,19 @@ final class DeploymentsReader
      */
     private function buildPreview(array $data): ?Preview
     {
-        $slug = isset($data['slug']) ? (string)$data['slug'] : (string)($data['__filename'] ?? '');
-        $url  = isset($data['url']) ? (string)$data['url'] : null;
+        $slug = isset($data['slug']) ? (string) $data['slug'] : (string) ($data['__filename'] ?? '');
+        $url = isset($data['url']) ? (string) $data['url'] : null;
         if ($slug === '' || $url === null || $url === '') {
             return null;
         }
+
         return new Preview(
-            slug:       $slug,
-            url:        $url,
-            image:      isset($data['image']) ? (string)$data['image'] : null,
-            sha7:       isset($data['sha7']) ? (string)$data['sha7'] : null,
+            slug: $slug,
+            url: $url,
+            image: isset($data['image']) ? (string) $data['image'] : null,
+            sha7: isset($data['sha7']) ? (string) $data['sha7'] : null,
             deployedAt: $this->parseTimestamp($data['deployed_at'] ?? null),
+            branch: isset($data['branch']) && $data['branch'] !== null ? (string) $data['branch'] : null,
         );
     }
 
@@ -187,24 +194,25 @@ final class DeploymentsReader
     private function buildArchive(array $data): ?Archive
     {
         $year = isset($data['year'])
-            ? (int)$data['year']
-            : (ctype_digit((string)($data['__filename'] ?? '')) ? (int)$data['__filename'] : 0);
-        $url = isset($data['url']) ? (string)$data['url'] : null;
+            ? (int) $data['year']
+            : (ctype_digit((string) ($data['__filename'] ?? '')) ? (int) $data['__filename'] : 0);
+        $url = isset($data['url']) ? (string) $data['url'] : null;
         if ($year === 0 || $url === null || $url === '') {
             return null;
         }
+
         return new Archive(
-            year:       $year,
-            url:        $url,
-            image:      isset($data['image']) ? (string)$data['image'] : null,
-            sha7:       isset($data['sha7']) ? (string)$data['sha7'] : null,
+            year: $year,
+            url: $url,
+            image: isset($data['image']) ? (string) $data['image'] : null,
+            sha7: isset($data['sha7']) ? (string) $data['sha7'] : null,
             deployedAt: $this->parseTimestamp($data['deployed_at'] ?? null),
         );
     }
 
     private function parseTimestamp(mixed $value): ?\DateTimeImmutable
     {
-        if (!is_string($value) || $value === '') {
+        if (! is_string($value) || $value === '') {
             return null;
         }
         try {

--- a/model/Dev/Preview.php
+++ b/model/Dev/Preview.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\Dev;
@@ -13,11 +14,16 @@ namespace Gamecon\Dev;
 final readonly class Preview
 {
     public function __construct(
-        public string             $slug,
-        public string             $url,
-        public ?string            $image,
-        public ?string            $sha7,
+        public string $slug,
+        public string $url,
+        public ?string $image,
+        public ?string $sha7,
         public ?\DateTimeImmutable $deployedAt,
+        // Original git branch name. The slug is a lossy slugification
+        // (underscores → hyphens, diacritics stripped, truncated), so the
+        // branch is stored separately to link the PR by its exact ref. Null
+        // for records written before branch tracking, or hand-run deploys.
+        public ?string $branch = null,
     ) {
     }
 }

--- a/tests/Dev/DeploymentsReaderTest.php
+++ b/tests/Dev/DeploymentsReaderTest.php
@@ -35,7 +35,12 @@ class DeploymentsReaderTest extends TestCase
         self::assertCount(2, $previews);
         // glob() + sort() yields alphabetical order: feature-x, phase1-preview
         self::assertSame('feature-x', $previews[0]->slug);
+        // branch is the original git ref (slug 'feature-x' ← branch 'feature_x'),
+        // stored separately because the slug is a lossy slugification.
+        self::assertSame('feature_x', $previews[0]->branch);
         self::assertSame('phase1-preview', $previews[1]->slug);
+        // No "branch" key in this fixture → null (records predating branch tracking).
+        self::assertNull($previews[1]->branch);
         self::assertSame('abc1234', $previews[1]->sha7);
         self::assertSame(
             'ghcr.io/gamecon-cz/gamecon:preview-phase1-preview-abc1234',
@@ -92,6 +97,7 @@ class DeploymentsReaderTest extends TestCase
         self::assertSame('only-required', $previews[0]->slug);
         self::assertNull($previews[0]->image);
         self::assertNull($previews[0]->sha7);
+        self::assertNull($previews[0]->branch);
         self::assertNull($previews[0]->deployedAt);
 
         $archives = $reader->readArchives();

--- a/tests/Dev/fixtures/typical/previews/feature-x.json
+++ b/tests/Dev/fixtures/typical/previews/feature-x.json
@@ -4,5 +4,6 @@
     "url": "https://feature-x.preview.gamecon.cz/",
     "image": "ghcr.io/gamecon-cz/gamecon:preview-feature-x-def5678",
     "sha7": "def5678",
+    "branch": "feature_x",
     "deployed_at": "2026-05-22T07:00:00+02:00"
 }


### PR DESCRIPTION
The admin Previews page linked to GitHub PR search using the **slug** (`head:slevove-kody`), but the slug is a lossy slugification of the branch (underscores→hyphens, diacritics stripped, 30-char truncation). So for branch `slevove_kody` the link found nothing.

**Fix: store the original branch name end-to-end and link by it.**
- CI (`deploy-preview.yml`) passes the raw branch as the deploy's 3rd arg (via env, not string-interpolated, to avoid expression injection; appended single-quoted only when free of single quotes — the wrapper rejects shell metachars anyway).
- `Preview` DTO gains `?string $branch`; `DeploymentsReader` parses `branch` from the JSON (null for old records).
- Admin template links `head:<branch>` (falls back to slug when branch is absent — old records). `head:` does prefix matching so this is robust.

Companion **ansible** PR adds the matching host side (wrapper allowlist accepts an optional 3rd `[branch]` arg with a tight BRANCH_RE; deploy script + deployments-json helper write `branch` into the record). Both are backward-compatible: old 2-arg deploys and pre-branch JSON records still work; existing previews backfill `branch` on their next deploy.

Test: `DeploymentsReaderTest` extended — asserts `branch` parsed from JSON and null when absent (7 tests green).