### PR TITLE
Enable 2003 static archive

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2004 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2004..2099" >&2
+                    if (( year < 2003 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2003..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -79,13 +79,14 @@ jobs:
                     # gameconcz/gamecon:8.2 image baked into Dockerfile.archive.
                     # Add a row when a year's PHP era is confirmed during recon.
                     case "$year" in
-                        # 2004–2011 are STATIC archives (the live DB + router
+                        # 2003–2011 are STATIC archives (the live DB + router
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2004–2008 are the Altar-era sites (2004–2005 = altar.cz
+                        # 2003–2008 are the Altar-era sites (2003–2005 = altar.cz
                         # /gamecon/ path; 2006–2008 = gamecon.altar.cz subdomain;
                         # different CMS), still pure static HTML — same base.
+                        2003) base_image="php:5.6-apache" ;;
                         2004) base_image="php:5.6-apache" ;;
                         2005) base_image="php:5.6-apache" ;;
                         2006) base_image="php:5.6-apache" ;;
@@ -115,9 +116,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2004–2011 static archives need no PHP extension at
+                        # 2003–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        2003) php_exts="" ;;
                         2004) php_exts="" ;;
                         2005) php_exts="" ;;
                         2006) php_exts="" ;;

--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -27,6 +27,27 @@ usort($archives, static fn ($a, $b) => $b->year <=> $a->year);
 // text (prohlížeč se zeptá při prvním otevření). Viz GateLink + ansible
 // role gate_validator.
 $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GATE_SECRET);
+
+// Ročníky spadají do tří epoch podle toho, co archiv reálně obsahuje (hranice
+// jsou shodné s base_image / reconstruction érami v deploy-year-archive.yml):
+//   - 2012+      živá PHP aplikace nad vlastní DB (plně funkční admin) — bez nadpisu
+//   - 2009–2011  statická kopie z Internet Archive (gamecon.cz éra, žádná DB)
+//   - ≤2008      éra Altaru (altar.cz/gamecon/ path 2003–2005, gamecon.altar.cz
+//                subdoména 2006–2008) — taky statická, ale jiný web/CMS
+$epochaRocniku = static function (int $year): string {
+    if ($year >= 2012) {
+        return 'ziva';
+    }
+    if ($year >= 2009) {
+        return 'staticka';
+    }
+
+    return 'altar';
+};
+$nadpisEpochy = [
+    'staticka' => 'Pouze statické kopie',
+    'altar'    => 'Věk Altaru',
+];
 ?>
 <h2>Staré ročníky</h2>
 
@@ -53,7 +74,19 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GA
             </tr>
         </thead>
         <tbody>
+        <?php $epochaPredchozi = null; ?>
         <?php foreach ($archives as $archive) { ?>
+            <?php
+            $epocha = $epochaRocniku($archive->year);
+            if ($epocha !== $epochaPredchozi && isset($nadpisEpochy[$epocha])) { ?>
+                <tr>
+                    <th colspan="3" style="text-align: left; padding-top: 18px; border-bottom: 2px solid #888;">
+                        <?php echo htmlspecialchars($nadpisEpochy[$epocha]); ?>
+                    </th>
+                </tr>
+            <?php }
+            $epochaPredchozi = $epocha;
+            ?>
             <tr>
                 <td><?php echo htmlspecialchars((string) $archive->year); ?></td>
                 <td>


### PR DESCRIPTION
Lowers the year-archive floor to **2003** and groups the admin archive list by era.

## Changes
- `deploy-year-archive.yml` — range guard `2003..2099`; `2003` rows added to the `base_image` (`php:5.6-apache`) and `php_exts` (empty) maps. 2003 is a static reconstruction (no DB), like 2004–2011.
- `admin/.../web/stare-rocniky.php` — the archive list now shows era headings: dynamic years (2012+) on top with no heading, then **Pouze statické kopie** (2009–2011, gamecon.cz static), then **Věk Altaru** (≤2008, altar.cz era).

Pairs with ansible PR (year-guard in `deploy-year-archive.sh` + `ci-preview-wrapper.sh`). Per the archive playbook, the ansible guards must be `make deploy`-ed to the host **before** `archive/2003` is pushed.

The `archive/2003` branch (reconstructed pages + the new Před/Po epoch switcher) is held until the host knows 2003.