### PR TITLE
Allow 2002 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2003 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2003..2099" >&2
+                    if (( year < 2002 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2002..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -83,9 +83,11 @@ jobs:
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2003–2008 are the Altar-era sites (2003–2005 = altar.cz
+                        # 2002–2008 are the Altar-era sites (2002–2005 = altar.cz
                         # /gamecon/ path; 2006–2008 = gamecon.altar.cz subdomain;
                         # different CMS), still pure static HTML — same base.
+                        # (2002 = the Avalcon/Eurocon year in Chotěboř.)
+                        2002) base_image="php:5.6-apache" ;;
                         2003) base_image="php:5.6-apache" ;;
                         2004) base_image="php:5.6-apache" ;;
                         2005) base_image="php:5.6-apache" ;;
@@ -116,9 +118,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2003–2011 static archives need no PHP extension at
+                        # 2002–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        2002) php_exts="" ;;
                         2003) php_exts="" ;;
                         2004) php_exts="" ;;
                         2005) php_exts="" ;;


### PR DESCRIPTION
Lowers the year-archive floor to **2002** (range guard `2002..2099` + `2002` rows in the `base_image`/`php_exts` case maps). 2002 is a static reconstruction (no DB), like 2003–2011.

GameCon 2002 was the **Avalcon/Eurocon** year (held in Chotěboř, not Olomouc). The reconstructed `archive/2002` branch (Wayback, altar.cz/gamecon/ path era, cp1250) is held until the ansible guards are `make deploy`-ed to the host.

Pairs with the ansible year-guard PR.