### PR TITLE
Allow 2001 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2002 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2002..2099" >&2
+                    if (( year < 2001 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 2001..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -83,10 +83,12 @@ jobs:
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2002–2008 are the Altar-era sites (2002–2005 = altar.cz
+                        # 2001–2008 are the Altar-era sites (2001–2005 = altar.cz
                         # /gamecon/ path; 2006–2008 = gamecon.altar.cz subdomain;
                         # different CMS), still pure static HTML — same base.
-                        # (2002 = the Avalcon/Eurocon year in Chotěboř.)
+                        # (2002 = the Avalcon/Eurocon year in Chotěboř; 2001 =
+                        # minimal results-only archive — Wayback caught no full site.)
+                        2001) base_image="php:5.6-apache" ;;
                         2002) base_image="php:5.6-apache" ;;
                         2003) base_image="php:5.6-apache" ;;
                         2004) base_image="php:5.6-apache" ;;
@@ -118,9 +120,10 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2002–2011 static archives need no PHP extension at
+                        # 2001–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        2001) php_exts="" ;;
                         2002) php_exts="" ;;
                         2003) php_exts="" ;;
                         2004) php_exts="" ;;


### PR DESCRIPTION
Lowers the year-archive floor to **2001** (range guard `2001..2099` + `2001` rows in the case maps).

2001 is a **minimal, results-centric** static archive: Wayback never preserved a genuine GameCon 2001 festival site (no gamecon.cz domain/subdomain existed then; the only 2001 homepage capture is the off-season placeholder). It serves the real 2001 DrD results (vysledky01, from a 2004 capture) + 98/99/00 + publisher nav + era theme. The `archive/2001` branch is held until the ansible guards are `make deploy`-ed.

Pairs with the ansible year-guard PR.