### PR TITLE
Allow 1998-2000 in year-archive deploy

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -62,8 +62,8 @@ jobs:
                         exit 1
                     fi
                     year="${BASH_REMATCH[1]}"
-                    if (( year < 2001 || year > 2099 )); then
-                        echo "::error::Year $year outside supported range 2001..2099" >&2
+                    if (( year < 1998 || year > 2099 )); then
+                        echo "::error::Year $year outside supported range 1998..2099" >&2
                         exit 1
                     fi
                     sha7=$(git rev-parse --short=7 HEAD)
@@ -83,11 +83,15 @@ jobs:
                         # are lost) — flat HTML reconstructed from the Internet
                         # Archive. Any base works; php:5.6-apache matches their
                         # neighbours and stays lightweight (no PHP executes).
-                        # 2001–2008 are the Altar-era sites (2001–2005 = altar.cz
+                        # 1998–2008 are the Altar-era sites (1998–2005 = altar.cz
                         # /gamecon/ path; 2006–2008 = gamecon.altar.cz subdomain;
                         # different CMS), still pure static HTML — same base.
-                        # (2002 = the Avalcon/Eurocon year in Chotěboř; 2001 =
-                        # minimal results-only archive — Wayback caught no full site.)
+                        # (2002 = the Avalcon/Eurocon year in Chotěboř; 1998–2001 =
+                        # minimal results-centric archives — Wayback caught only the
+                        # 1998 homepage + the DrD-championship results listings.)
+                        1998) base_image="php:5.6-apache" ;;
+                        1999) base_image="php:5.6-apache" ;;
+                        2000) base_image="php:5.6-apache" ;;
                         2001) base_image="php:5.6-apache" ;;
                         2002) base_image="php:5.6-apache" ;;
                         2003) base_image="php:5.6-apache" ;;
@@ -120,9 +124,12 @@ jobs:
                     # extension (mysql, removed in PHP 7 but installable on 5.6).
                     # Both build with no apt packages.
                     case "$year" in
-                        # 2001–2011 static archives need no PHP extension at
+                        # 1998–2011 static archives need no PHP extension at
                         # all (no DB, no dynamic code) — empty list skips the
                         # Dockerfile's whole install step.
+                        1998) php_exts="" ;;
+                        1999) php_exts="" ;;
+                        2000) php_exts="" ;;
                         2001) php_exts="" ;;
                         2002) php_exts="" ;;
                         2003) php_exts="" ;;


### PR DESCRIPTION
Reconstructs the **three earliest GameCon years** (1998, 1999, 2000) as static Altar-era archives from the Internet Archive, and lowers the deploy floor accordingly.

Changes to `deploy-year-archive.yml`:
- Year-range guard **2001 → 1998**
- `base_image` rows: 1998/1999/2000 → `php:5.6-apache` (period-correct, static — no PHP executes)
- `php_exts` rows: 1998/1999/2000 → empty (skips the Dockerfile install step)

Source ground truth (Wayback CDX on `altar.cz/gamecon/`): exactly **one** early homepage capture (Dec 1998, title "Gamecon 1998") plus standalone results pages `vysledky98/99/00`. There was no separate captured homepage for 1999/2000 (the site was one evolving Altar section), so:
- **1998** = the genuine captured homepage + `vysledky98`
- **1999/2000** = period-correct Altar-layout homepages pointing at that year's results + previous years

The matching `archive/1998`, `archive/1999`, `archive/2000` content branches are pushed separately (they don't carry this workflow — the thin `archive-push-redeploy.yml` dispatcher invokes this workflow as-defined-on-main).

Paired with gamecon-cz/ansible#55 (host-side floor).