### PR TITLE
Fixes for generated discounts table

### DIFF
--- a/migrace/2026-06-03-1234-discounts-generated.sql
+++ b/migrace/2026-06-03-1234-discounts-generated.sql
@@ -1,9 +1,18 @@
 CREATE TABLE IF NOT EXISTS `discounts_generated`
 (
-    `id`           bigint unsigned NOT NULL AUTO_INCREMENT primary key,
-    `id_uzivatele` bigint unsigned not null references uzivatele_hodnoty (id_uzivatele) on delete cascade,
-    `rok`          int             not null,
-    `castka`       decimal(10, 2)  not null default 0,
-    `id_akce`      bigint unsigned null references akce_seznam (id_akce) on delete cascade,
-    `id_nakupu`    bigint unsigned null references shop_nakupy (id_nakupu) on delete cascade
-);
+    `id`           bigint unsigned NOT NULL AUTO_INCREMENT,
+    `id_uzivatele` bigint unsigned NOT NULL,
+    `rok`          int             NOT NULL,
+    `castka`       decimal(10, 2)  NOT NULL DEFAULT 0,
+    `id_akce`      bigint unsigned          DEFAULT NULL,
+    `id_nakupu`    bigint unsigned          DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY (`id_uzivatele`),
+    KEY (`id_akce`),
+    KEY (`id_nakupu`),
+    FOREIGN KEY (`id_uzivatele`) REFERENCES `uzivatele_hodnoty` (`id_uzivatele`) ON DELETE CASCADE,
+    FOREIGN KEY (`id_akce`) REFERENCES `akce_seznam` (`id_akce`) ON DELETE CASCADE,
+    FOREIGN KEY (`id_nakupu`) REFERENCES `shop_nakupy` (`id_nakupu`) ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb3
+  COLLATE=utf8mb3_czech_ci;

--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -619,7 +619,10 @@ JOIN akce_seznam AS aktivita
     ON prihlaseni.id_akce = aktivita.id_akce
 JOIN akce_prihlaseni_stavy AS stav_prihlaseni
     ON prihlaseni.id_stavu_prihlaseni = stav_prihlaseni.id_stavu_prihlaseni
-LEFT JOIN discounts_generated on discounts_generated.id_akce = aktivita.id_akce and discounts_generated.rok = aktivita.rok
+LEFT JOIN discounts_generated
+    ON discounts_generated.id_akce = aktivita.id_akce
+    AND discounts_generated.rok = aktivita.rok
+    AND discounts_generated.id_uzivatele = $idUcastnika
 WHERE aktivita.rok = $rok
 SQL;
 
@@ -645,7 +648,9 @@ SQL;
                     $this->brigadnickaOdmena += (float)$r['cena'];
                 }
             } else {
-                $this->cenaAktivit += $r['cena'];
+                // sleva_prima (generovaná sleva k aktivitě) snižuje účtovanou cenu;
+                // storno níže ale počítáme z plné ceny — penále za neúčast se slevou nesnižujeme.
+                $this->cenaAktivit += $r['cena'] - ($r['sleva_prima'] ?? 0.0);
                 $idStavuPrihlaseni = (int)$r['id_stavu_prihlaseni'];
                 if ($idStavuPrihlaseni === StavPrihlaseni::PRIHLASEN_ALE_NEDORAZIL) {
                     $this->sumaStorna += $r['cena'];

--- a/tests/Model/AccountingTest.php
+++ b/tests/Model/AccountingTest.php
@@ -200,6 +200,22 @@ SQL,
         );
     }
 
+    private function vlozGenerovanouSlevu(
+        float $castka,
+        ?int $idAkce = null,
+        int $idUzivatele = 555,
+    ): void {
+        dbQuery(
+            'INSERT INTO discounts_generated(id_uzivatele, rok, castka, id_akce) VALUES($0, $1, $2, $3)',
+            [
+                0 => $idUzivatele,
+                1 => ROCNIK,
+                2 => $castka,
+                3 => $idAkce,
+            ],
+        );
+    }
+
     private function pridelPravo(int $idPrava): void
     {
         $unique = uniqid('', true);
@@ -665,5 +681,45 @@ SQL,
 
         self::assertStringContainsString('<td>ubytování 2×</td><td>400</td>', $html);
         self::assertStringContainsString('<td>Sleva z ubytování 2×</td><td>-400</td>', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function testGenerovanaSlevaJinehoUzivateleNeovlivniCenuAktivity(): void
+    {
+        // Uživatel 556 dostane generovanou slevu na aktivitu 55610. Uživatel 555
+        // je na téže aktivitě přihlášen, ale slevu nemá → jeho cena musí zůstat plná.
+        dbQuery(
+            "INSERT INTO uzivatele_hodnoty SET id_uzivatele = 556, login_uzivatele = 'TestAccounting2', email1_uzivatele = 'test.accounting2@example.org'",
+        );
+        $this->vlozAktivitu(idAktivity: 55610, nazev: 'Kubb', cena: 250);
+        $this->vlozGenerovanouSlevu(castka: 100, idAkce: 55610, idUzivatele: 556);
+
+        $account = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false);
+        $aktivity = array_values(array_filter(
+            $account->getTransactions(),
+            fn ($transaction) => $transaction->getCategory() === TransactionCategoryEnum::ACTIVITY,
+        ));
+
+        self::assertCount(1, $aktivity, 'Aktivita se nesmí kvůli join na cizí slevu zduplikovat');
+        self::assertSame(-250, $aktivity[0]->getTotalAmount(), 'Generovaná sleva jiného uživatele nesmí snížit cenu aktivity tohoto uživatele');
+    }
+
+    /**
+     * @test
+     */
+    public function testGenerovanaSlevaSnizujeCenuAktivitVCelkovemStavu(): void
+    {
+        $this->vlozAktivitu(idAktivity: 55611, nazev: 'Kubb', cena: 250);
+        $this->vlozGenerovanouSlevu(castka: 100, idAkce: 55611);
+
+        $finance = $this->dejUzivatele()->finance();
+
+        self::assertSame(
+            150.0,
+            $finance->cenaAktivit(),
+            'Cena aktivit (a tím i celkový stav financí) musí být snížena o generovanou slevu k aktivitě, ne jen řádek v rozpisu',
+        );
     }
 }

--- a/tests/Model/AccountingTest.php
+++ b/tests/Model/AccountingTest.php
@@ -722,4 +722,47 @@ SQL,
             'Cena aktivit (a tím i celkový stav financí) musí být snížena o generovanou slevu k aktivitě, ne jen řádek v rozpisu',
         );
     }
+
+    private function pocetGenerovanychSlev(): int
+    {
+        return (int) dbOneLine('SELECT COUNT(*) AS pocet FROM discounts_generated')['pocet'];
+    }
+
+    /**
+     * @test
+     */
+    public function testSmazaniAktivitySmazeGenerovanouSlevuKACi(): void
+    {
+        $this->vlozAktivitu(idAktivity: 55612, nazev: 'Kubb', cena: 250);
+        $this->vlozGenerovanouSlevu(castka: 100, idAkce: 55612);
+        self::assertSame(1, $this->pocetGenerovanychSlev());
+
+        // Přihlášku odebíráme zvlášť — má vlastní FK na akce_seznam bez cascade,
+        // takže by jinak smazání aktivity zablokovala. Testujeme cascade na slevu.
+        dbQuery('DELETE FROM akce_prihlaseni WHERE id_akce = $0', [55612]);
+        dbQuery('DELETE FROM akce_seznam WHERE id_akce = $0', [55612]);
+
+        self::assertSame(
+            0,
+            $this->pocetGenerovanychSlev(),
+            'FK ON DELETE CASCADE musí smazat generovanou slevu, když zanikne navázaná aktivita (jinak osiřelý řádek dál snižuje cenu)',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testSmazaniUzivateleSmazeJehoGenerovaneSlevy(): void
+    {
+        $this->vlozGenerovanouSlevu(castka: 100);
+        self::assertSame(1, $this->pocetGenerovanychSlev());
+
+        dbQuery('DELETE FROM uzivatele_hodnoty WHERE id_uzivatele = $0', [555]);
+
+        self::assertSame(
+            0,
+            $this->pocetGenerovanychSlev(),
+            'FK ON DELETE CASCADE musí smazat generované slevy zaniklého uživatele',
+        );
+    }
 }


### PR DESCRIPTION
Navazuje na #906 (větev `generated-discounts-table`) — opravy nalezené při review.

## Co řeší

**1. Generovaná sleva k aktivitě protékala mezi uživateli (reálná chyba s penězi).**
`LEFT JOIN discounts_generated` v `Finance::zapoctiAktivity()` spojoval jen přes `id_akce` + `rok`, bez `id_uzivatele`. Sleva jiného účastníka tak snižovala cenu aktivity tomuto uživateli (a při více řádcích mohla aktivitu zduplikovat). Join je nově omezen na daného účastníka.

**2. Sleva se neodečítala z `cenaAktivit` (jen z rozpisu BFGR).**
Hlavní součet aktivit — a tím i Celková cena a výsledný Stav financí — slevu ignoroval, zatímco položkový rozpis ji zobrazoval. Oba pohledy si protiřečily. Sleva se nyní odečítá i z `cenaAktivit`; storno penále se dál počítá z plné ceny (záměrně).

**3. Explicitní definice cizích klíčů v migraci.**
Inline `references ... on delete cascade` na MariaDB funguje (skutečně vytvoří FK), ale standardní MySQL je tiše ignoruje a snadno se přehlédne. Přepsáno na table-level `FOREIGN KEY` + explicitní `ENGINE`/charset, ve stylu ostatních migrací. Výsledné schéma je identické (ověřeno). Migrace zatím není nasazená na ostré.

**4. Regresní testy cascade-delete.**
Smazání navázané aktivity / uživatele musí kaskádově smazat jeho generované slevy — pojistka proti tichému ztracení FK při případném přepisu na inline MySQL syntax.

## Testy
`AccountingTest` rozšířen o 4 testy (cross-user leak, odečet z `cenaAktivit`, 2× cascade). Celá třída zelená (29 testů).