### PR TITLE
Fix local dev env setup and migration tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ init:
 	docker compose up -d
 	# has to explicitly use direnv exec to use the freshly allowed .envrc in current prompt instance
 	direnv exec bin-docker/composer install
-	npm --prefix ui run build
+	# install ui deps before building — restores a wiped/incomplete ui/node_modules
+	# (e.g. after a hard reset mid-install), otherwise the build fails with "tsc: not found"
+	direnv exec bin-docker/yarn install --frozen-lockfile
+	direnv exec bin-docker/yarn build
 	@make cache
 	@echo 'Gamecon initialized ✅'
 
@@ -51,7 +54,10 @@ static: fix phpstan
 
 migrations-run:
 	./bin-docker/php ./bin/console migrations:continue
-	./bin-docker/php ./bin/console app:cache:doctrine:invalidate
+	# invalidate Doctrine caches so the app picks up the migrated schema
+	# (app:cache:doctrine:invalidate never existed — was a dangling reference)
+	./bin-docker/php ./bin/console doctrine:cache:clear-metadata
+	./bin-docker/php ./bin/console doctrine:cache:clear-result
 
 migrations-diff:
 	./bin-docker/php ./bin/console --env=test migrations:continue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       # XDEBUG_CONFIG: "client_host=172.17.0.1 client_port=9003 remote_log=/tmp/xdebug.log log_level=0"
       # XDEBUG_TRIGGER: "yes" # to start XDebug for EVERY request (use `export XDEBUG_TRIGGER: "yes"` to enable it in CLI and `unset XDEBUG_TRIGGER` to disable for CLI again - in browser use same-named variable in GET, POST or COOKIE, or legacy named via some browser extension)
       # COMPOSER_AUTH: '{"github-oauth":{"github.com":""}}' # Go to https://github.com/settings/tokens to generate new (read only) access token to let Github pair your requests to your account and to raise the cap of allowed requests (during Composer Github-related actions like install, update, require etc)
+      APP_ENV: "dev"
       PHP_IDE_CONFIG: "serverName=gamecon"
       COMPOSER_PROCESS_TIMEOUT: -1 # to let composer downloading large libraries indefinitely
       DB_USER: "root"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,10 @@
          displayDetailsOnTestsThatTriggerWarnings="false"
          displayDetailsOnPhpunitDeprecations="false">
     <php>
+        <!-- force=true so the test kernel boots the test env even when the
+             container sets APP_ENV=dev (docker-compose); without this, Foundry
+             can't find test.service_container -->
+        <env name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="App\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1"/>
         <env name="SHELL_VERBOSITY" value="-1"/>

--- a/symfony/src/Command/MigrationsContinueCommand.php
+++ b/symfony/src/Command/MigrationsContinueCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'migrations:continue',
-    description: 'Updates database schema by running all new migrations (legacy + Doctrine)',
+    description: 'Runs all new SQL migrations via the legacy runner and marks the JSON program cache dirty',
 )]
 class MigrationsContinueCommand extends Command
 {


### PR DESCRIPTION
Opravy lokálního dev prostředí a nástrojů pro migrace, narazil jsem na ně při obnově lokální DB.

- **`make init`/`run`**: před buildem UI se nově nainstalují závislosti (`yarn install --frozen-lockfile`). Dřív `init` jen spouštěl `npm run build` a spoléhal na existující `ui/node_modules` — po smazání/nedokončené instalaci (např. hard reset uprostřed instalace) build padal na `tsc: not found`.
- **`docker-compose.yml`**: nastaven `APP_ENV=dev`, aby `bin/console` fungoval i bez `.env` souboru.
- **`make migrations-run`**: nahrazen nikdy neexistující příkaz `app:cache:doctrine:invalidate` reálnými `doctrine:cache:clear-metadata` + `clear-result`.
- **`migrations:continue`**: opraven popis příkazu, aby odpovídal skutečnosti (legacy SQL runner + označení JSON program cache jako dirty; žádné Doctrine migrace neběží).