### PR TITLE
Add admin link column to archives list

### DIFF
--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -69,7 +69,8 @@ $nadpisEpochy = [
         <thead>
             <tr>
                 <th>Ročník</th>
-                <th>URL</th>
+                <th>Web</th>
+                <th>Admin</th>
                 <th>Deployed</th>
             </tr>
         </thead>
@@ -80,7 +81,7 @@ $nadpisEpochy = [
             $epocha = $epochaRocniku($archive->year);
             if ($epocha !== $epochaPredchozi && isset($nadpisEpochy[$epocha])) { ?>
                 <tr>
-                    <th colspan="3" style="text-align: left; padding-top: 18px; border-bottom: 2px solid #888;">
+                    <th colspan="4" style="text-align: left; padding-top: 18px; border-bottom: 2px solid #888;">
                         <?php echo htmlspecialchars($nadpisEpochy[$epocha]); ?>
                     </th>
                 </tr>
@@ -93,6 +94,16 @@ $nadpisEpochy = [
                     <a href="<?php echo htmlspecialchars($gateUrl($archive->url)); ?>" target="_blank" rel="noopener">
                         <?php echo htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $archive->url)); ?>
                     </a>
+                </td>
+                <td>
+                    <?php
+                    if ($epocha === 'ziva') {
+                        $adminUrl = rtrim($archive->url, '/') . '/admin';
+                        ?>
+                        <a href="<?php echo htmlspecialchars($gateUrl($adminUrl)); ?>" target="_blank" rel="noopener">/admin</a>
+                    <?php } else { ?>
+                        —
+                    <?php } ?>
                 </td>
                 <td>
                     <?php echo $archive->deployedAt !== null


### PR DESCRIPTION
Kolegové si stěžovali, že u archivních ročníků musí jít na archivní web, přihlásit se a pak přepínat do adminu přes GUI — pletli se v tom, že admin není na subdoméně, ale na cestě `/admin`.

Přidává do seznamu archivů (`/web/stare-rocniky`) nový sloupec **Admin** s odkazem rovnou na admin sekci ročníku. Zobrazený text je jen cesta `/admin`, ale `href` vede na celou URL ročníku přes bránu (stejný `?gate=` token jako sloupec URL, takže proklik projde bez basic-auth dialogu).

Odkaz se ukazuje jen u živých ročníků (2012+, které mají funkční admin); statické kopie a éra Altaru mají v buňce `—`.