### PR TITLE
Magic login into archives from admin list

### DIFF
--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -1,7 +1,9 @@
 <?php
 
+use Gamecon\Dev\CrossSiteLogin;
 use Gamecon\Dev\DeploymentsReader;
 use Gamecon\Dev\GateLink;
+use Gamecon\Dev\SsoParovaciCookie;
 
 /**
  * Seznam dockerizovaných archivních ročníků (YYYY.gamecon.cz).
@@ -27,6 +29,31 @@ usort($archives, static fn ($a, $b) => $b->year <=> $a->year);
 // text (prohlížeč se zeptá při prvním otevření). Viz GateLink + ansible
 // role gate_validator.
 $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GATE_SECRET);
+
+// Magické přihlášení do archivního adminu: k odkazu na /admin připojíme podepsaný
+// ?gcsso= token vázaný na e-mail přihlášeného admina + náhodný nonce, který zároveň
+// uložíme do spárovací cookie (.gamecon.cz). Archiv pak admina přihlásí podle e-mailu
+// — ale jen když nonce z tokenu sedí s nonce z cookie, takže pouhé sdílení odkazu
+// nikoho nepřihlásí (cizí prohlížeč cookie nemá). Bez secretu / e-mailu se token
+// nepřipojí a chování zůstává jako dřív (jen basic-auth brána). Viz CrossSiteLogin
+// + SsoParovaciCookie + admin/scripts/prihlaseni.php (ověřovací strana).
+$ssoNonce = null;
+$ssoEmail = $u->mail() ?? '';
+if ($ssoEmail !== '' && SECRET_CRYPTO_KEY !== '') {
+    $ssoNonce = randHex(40);
+    SsoParovaciCookie::nastav($ssoNonce);
+}
+$adminUrlSeSso = static function (string $adminUrl) use ($ssoNonce, $ssoEmail, $gateUrl): string {
+    if ($ssoNonce !== null) {
+        $gcsso = CrossSiteLogin::podepis($ssoEmail, $ssoNonce, SECRET_CRYPTO_KEY);
+        if ($gcsso !== '') {
+            $oddelovac = str_contains($adminUrl, '?') ? '&' : '?';
+            $adminUrl .= $oddelovac . 'gcsso=' . $gcsso;
+        }
+    }
+
+    return $gateUrl($adminUrl);
+};
 
 // Ročníky spadají do tří epoch podle toho, co archiv reálně obsahuje (hranice
 // jsou shodné s base_image / reconstruction érami v deploy-year-archive.yml):
@@ -100,7 +127,7 @@ $nadpisEpochy = [
                     if ($epocha === 'ziva') {
                         $adminUrl = rtrim($archive->url, '/') . '/admin';
                         ?>
-                        <a href="<?php echo htmlspecialchars($gateUrl($adminUrl)); ?>" target="_blank" rel="noopener">/admin</a>
+                        <a href="<?php echo htmlspecialchars($adminUrlSeSso($adminUrl)); ?>" target="_blank" rel="noopener">/admin</a>
                     <?php } else { ?>
                         —
                     <?php } ?>

--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -1,6 +1,6 @@
 <?php
 
-use Gamecon\Dev\CrossSiteLogin;
+use Gamecon\Dev\ArchivSsoPrihlaseni;
 use Gamecon\Dev\SsoParovaciCookie;
 use Gamecon\Login\Login;
 use Gamecon\Exceptions\UzivatelNenalezen;
@@ -31,23 +31,15 @@ $u = Uzivatel::zSession();
 // nikdo není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný,
 // nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
 // URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
-// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení.
-// Viz CrossSiteLogin + SsoParovaciCookie + admin/scripts/modules/web/stare-rocniky.php.
+// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení. Pravidla
+// rozhodnutí drží ArchivSsoPrihlaseni (sdílí je s testem).
+// Viz ArchivSsoPrihlaseni + SsoParovaciCookie + admin/scripts/modules/web/stare-rocniky.php.
 if (($gcsso = get('gcsso')) !== null) {
-    if (! $u) {
-        $overene = CrossSiteLogin::over((string) $gcsso, SECRET_CRYPTO_KEY);
-        $nonceCookie = SsoParovaciCookie::precti();
-        if (
-            $overene !== null
-            && $nonceCookie !== null
-            && hash_equals($overene->nonce, $nonceCookie)
-        ) {
-            $uzivatelDleMailu = Uzivatel::zEmailu($overene->email);
-            if ($uzivatelDleMailu !== null) {
-                $u = Uzivatel::prihlasId($uzivatelDleMailu->id());
-            }
-        }
-    }
+    $u = (new ArchivSsoPrihlaseni(SECRET_CRYPTO_KEY))->prihlas(
+        (string) $gcsso,
+        SsoParovaciCookie::precti(),
+        $u,
+    );
     back(getCurrentUrlWithQuery([
         'gcsso' => null,
     ]));

--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -1,5 +1,7 @@
 <?php
 
+use Gamecon\Dev\CrossSiteLogin;
+use Gamecon\Dev\SsoParovaciCookie;
 use Gamecon\Login\Login;
 use Gamecon\Exceptions\UzivatelNenalezen;
 use Gamecon\Pravo;
@@ -22,6 +24,35 @@ if (post(Login::LOGIN_INPUT_NAME) && post(Login::PASSWORD_INPUT_NAME)) {
     back();
 }
 $u = Uzivatel::zSession();
+
+// Magické přihlášení z administračního rozcestníku na ostré (?gcsso= token).
+// Hlavní admin podepsal token na e-mail klikajícího uživatele + nonce a uložil
+// stejný nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě
+// nikdo není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný,
+// nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
+// URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
+// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení.
+// Viz CrossSiteLogin + SsoParovaciCookie + admin/scripts/modules/web/stare-rocniky.php.
+if (($gcsso = get('gcsso')) !== null) {
+    if (! $u) {
+        $overene = CrossSiteLogin::over((string) $gcsso, SECRET_CRYPTO_KEY);
+        $nonceCookie = SsoParovaciCookie::precti();
+        if (
+            $overene !== null
+            && $nonceCookie !== null
+            && hash_equals($overene->nonce, $nonceCookie)
+        ) {
+            $uzivatelDleMailu = Uzivatel::zEmailu($overene->email);
+            if ($uzivatelDleMailu !== null) {
+                $u = Uzivatel::prihlasId($uzivatelDleMailu->id());
+            }
+        }
+    }
+    back(getCurrentUrlWithQuery([
+        'gcsso' => null,
+    ]));
+}
+
 if (post('odhlasNAdm')) {
     if ($u) {
         $u->odhlas(false);

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
+ * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě, aby je
+ * sdílel procedurální admin/scripts/prihlaseni.php i test.
+ *
+ * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
+ * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
+ * (podpis) a {@see SsoParovaciCookie} (spárovací cookie).
+ */
+final class ArchivSsoPrihlaseni
+{
+    public function __construct(
+        private readonly string $secret,
+    ) {
+    }
+
+    /**
+     * Přihlásí uživatele podle tokenu, nebo vrátí $jizPrihlaseny beze změny.
+     *
+     * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
+     * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím
+     * e-mailem v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     *
+     * @param string         $token         hodnota `?gcsso=` z URL
+     * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
+     * @param \Uzivatel|null $jizPrihlaseny uživatel už přihlášený v session, nebo null
+     */
+    public function prihlas(
+        string $token,
+        ?string $nonceZCookie,
+        ?\Uzivatel $jizPrihlaseny,
+    ): ?\Uzivatel {
+        if ($jizPrihlaseny !== null) {
+            return $jizPrihlaseny;
+        }
+        if ($nonceZCookie === null) {
+            return null;
+        }
+
+        $overene = CrossSiteLogin::over($token, $this->secret);
+        if ($overene === null) {
+            return null;
+        }
+        if (! hash_equals($overene->nonce, $nonceZCookie)) {
+            return null;
+        }
+
+        $uzivatel = \Uzivatel::zEmailu($overene->email);
+        if ($uzivatel === null) {
+            return null;
+        }
+
+        return \Uzivatel::prihlasId($uzivatel->id());
+    }
+}

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
+ * token vázaný na e-mail přihlášeného uživatele, archiv (NNNN.gamecon.cz) ho ověří
+ * a uživatele podle e-mailu přihlásí — bez zadávání hesla.
+ *
+ * Token nese jen IDENTITU (e-mail) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
+ * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
+ * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
+ * se nonce z tokenu shoduje s nonce z cookie. Sdílená URL nonce v cizím prohlížeči
+ * nemá → nepřihlásí. Viz {@see GateLink} (ten řeší jen průchod bránou,
+ * ne přihlášení) a admin/scripts/prihlaseni.php (ověřovací strana).
+ *
+ * Podpis stojí na `SECRET_CRYPTO_KEY`, který je BAJTOVĚ STEJNÝ na ostré i ve všech
+ * archivních images (viz audit v CLAUDE.md) — archiv tak umí ověřit, co hlavní admin
+ * podepsal, bez zavádění nového tajemství.
+ *
+ * Formát tokenu (`?gcsso=`):
+ *
+ *     gcsso = base64url(email "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *
+ * `expiry` jsou ASCII číslice unixového času; HMAC se počítá nad celým payloadem
+ * (e-mail|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ *
+ * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
+ * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
+ */
+final class CrossSiteLogin
+{
+    /**
+     * Krátká platnost: token je jednorázový proklik z administračního rozcestníku,
+     * ne dlouhé sezení. Stačí na přesměrování přes bránu a přihlášení v archivu;
+     * leaknutý odkaz je tak po pár minutách mrtvý.
+     */
+    public const TTL_SEKUND = 5 * 60;
+
+    private const ODDELOVAC_PAYLOADU = '|';
+
+    /**
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro daný
+     * e-mail a nonce. Prázdný řetězec, pokud secret není nastavený — volající pak
+     * `?gcsso=` nepřipojuje.
+     */
+    public static function podepis(
+        string $email,
+        string $nonce,
+        string $secret,
+        ?int $ted = null,
+    ): string {
+        if ($secret === '') {
+            return '';
+        }
+
+        $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
+        $payload = $email . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $podpis = hash_hmac('sha256', $payload, $secret, true);
+
+        return self::base64Url($payload) . '.' . self::base64Url($podpis);
+    }
+
+    /**
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřený e-mail +
+     * nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
+     * vypršení). Shodu nonce s cookie kontroluje volající.
+     */
+    public static function over(string $token, string $secret): ?OvereneSso
+    {
+        if ($secret === '') {
+            return null;
+        }
+        if (! str_contains($token, '.')) {
+            return null;
+        }
+
+        [$payloadKodovany, $podpisKodovany] = explode('.', $token, 2);
+        $payload = self::base64UrlDekoduj($payloadKodovany);
+        $podpis = self::base64UrlDekoduj($podpisKodovany);
+        if ($payload === null || $podpis === null) {
+            return null;
+        }
+
+        $ocekavanyPodpis = hash_hmac('sha256', $payload, $secret, true);
+        if (! hash_equals($ocekavanyPodpis, $podpis)) {
+            return null;
+        }
+
+        $casti = explode(self::ODDELOVAC_PAYLOADU, $payload);
+        if (count($casti) !== 3) {
+            return null;
+        }
+        [$email, $expiry, $nonce] = $casti;
+
+        if (! ctype_digit($expiry) || (int) $expiry < time()) {
+            return null;
+        }
+        if ($email === '' || $nonce === '') {
+            return null;
+        }
+
+        return new OvereneSso($email, $nonce);
+    }
+
+    private static function base64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private static function base64UrlDekoduj(string $data): ?string
+    {
+        $dekodovano = base64_decode(strtr($data, '-_', '+/'), true);
+
+        return $dekodovano === false ? null : $dekodovano;
+    }
+}

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřený obsah `?gcsso=` tokenu — výsledek {@see CrossSiteLogin::over}.
+ * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
+ * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
+ * odkaz klikl).
+ */
+final readonly class OvereneSso
+{
+    public function __construct(
+        public string $email,
+        public string $nonce,
+    ) {
+    }
+}

--- a/model/Dev/SsoParovaciCookie.php
+++ b/model/Dev/SsoParovaciCookie.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Spárovací cookie pro magické přihlášení do archivu ({@see CrossSiteLogin}).
+ *
+ * Drží náhodný nonce a je scope `.gamecon.cz`, aby ji prohlížeč automaticky poslal
+ * i na `NNNN.gamecon.cz`. NENÍ to přihlášení — sama o sobě nikoho nepřihlásí; je to
+ * jen „důkaz stejného prohlížeče": archiv přihlásí jen když se nonce z této cookie
+ * shoduje s nonce zapečeným v podepsaném `?gcsso=` tokenu. Sdílená URL v cizím
+ * prohlížeči tuhle cookie nemá → mismatch → nepřihlásí. Produkce ani archiv tuhle
+ * cookie nečtou nikde jinde než v ověření SSO, takže její únik sám o sobě nic nedá.
+ *
+ * Scope `.gamecon.cz` je záměrně širší než host-scoped JWT cookie (viz
+ * nastaveni/jwt-bridge.php) — ale na rozdíl od ní nenese identitu.
+ */
+final class SsoParovaciCookie
+{
+    public const JMENO = 'gc_sso_pair';
+
+    /**
+     * O něco déle než TTL tokenu ({@see CrossSiteLogin::TTL_SEKUND}), aby cookie
+     * přežila proklik přes bránu i případné přesměrování a token nikdy nevypršel
+     * „dřív" než jeho párovací polovina.
+     */
+    public const TTL_SEKUND = 10 * 60;
+
+    /**
+     * Nastaví spárovací cookie s daným nonce. Scope `.gamecon.cz` (aby dorazila i
+     * na archiv), HttpOnly, SameSite=Lax (musí přijít při top-level navigaci na
+     * archiv), Secure jen po HTTPS. Mimo gamecon.cz (lokál, preview na jiném hostu)
+     * spadne na host-only cookie — feature stejně cílí jen na ostré subdomény.
+     */
+    public static function nastav(string $nonce): void
+    {
+        setcookie(self::JMENO, $nonce, [
+            'expires'  => time() + self::TTL_SEKUND,
+            'path'     => '/',
+            'domain'   => self::cookieDomena(),
+            'secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    }
+
+    /**
+     * `.gamecon.cz` na produkčních subdoménách (sdílí se napříč admin/archiv),
+     * jinak prázdno = host-only (prohlížeč jinak širší doménu odmítne).
+     */
+    private static function cookieDomena(): string
+    {
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        // Odřízneme případný port.
+        $host = explode(':', $host, 2)[0];
+
+        return str_ends_with($host, 'gamecon.cz') ? '.gamecon.cz' : '';
+    }
+
+    public static function precti(): ?string
+    {
+        $nonce = $_COOKIE[self::JMENO] ?? null;
+
+        return is_string($nonce) && $nonce !== '' ? $nonce : null;
+    }
+}

--- a/tests/Dev/ArchivSsoPrihlaseniTest.php
+++ b/tests/Dev/ArchivSsoPrihlaseniTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Dev;
+
+use Gamecon\Dev\ArchivSsoPrihlaseni;
+use Gamecon\Dev\CrossSiteLogin;
+use Gamecon\Tests\Db\AbstractUzivatelTestDb;
+use Uzivatel;
+
+/**
+ * Integrační test ověřovací strany magického přihlášení do archivu: nad reálnou DB
+ * a reálným {@see Uzivatel::prihlasId} ověřuje rozhodování {@see ArchivSsoPrihlaseni}.
+ * Logika podpisu tokenu je v {@see CrossSiteLoginTest} (čistý unit).
+ */
+class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
+{
+    private const SECRET = 'integration-secret';
+    private const NONCE = 'parovaci-nonce-integration';
+
+    protected function tearDown(): void
+    {
+        // Session mezi testy nesmí přenášet přihlášení.
+        \Uzivatel::odhlasKlic(\Uzivatel::UZIVATEL);
+        parent::tearDown();
+    }
+
+    public function testPlatnyTokenSeShodnymNoncePrihlasiUzivatele(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
+
+        self::assertNotNull($prihlaseny);
+        self::assertSame($uzivatel->id(), $prihlaseny->id());
+        // Reálné přihlášení do session — zSession ho musí najít.
+        $zeSession = \Uzivatel::zSession();
+        self::assertNotNull($zeSession);
+        self::assertSame($uzivatel->id(), $zeSession->id());
+    }
+
+    public function testNeshodnyNonceNeprihlasi(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        // Token nese self::NONCE, ale cookie přinese jiný → mismatch.
+        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, 'jiny-nonce', null);
+
+        self::assertNull($prihlaseny);
+        self::assertNull(\Uzivatel::zSession());
+    }
+
+    public function testChybejiciCookieNonceNeprihlasi(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, null, null);
+
+        self::assertNull($prihlaseny);
+        self::assertNull(\Uzivatel::zSession());
+    }
+
+    public function testNeznamyEmailNeprihlasi(): void
+    {
+        // Platný token + shodný nonce, ale e-mail v téhle DB neexistuje.
+        $token = CrossSiteLogin::podepis('nikdo-takovy@nikde.cz', self::NONCE, self::SECRET);
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
+
+        self::assertNull($prihlaseny);
+        self::assertNull(\Uzivatel::zSession());
+    }
+
+    public function testPodvrzenyPodpisNeprihlasi(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        // Token podepsaný JINÝM secretem než kterým ho ověřujeme.
+        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, 'utocnikuv-secret');
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
+
+        self::assertNull($prihlaseny);
+        self::assertNull(\Uzivatel::zSession());
+    }
+
+    public function testJizPrihlasenehoNeprepise(): void
+    {
+        $puvodni = self::prihlasenyUzivatel();
+        $jiny = self::prihlasenyUzivatel();
+        // Token by přihlásil $jiny, ale $puvodni už je přihlášený → nepřepisujeme.
+        $token = CrossSiteLogin::podepis($jiny->mail(), self::NONCE, self::SECRET);
+
+        $vysledek = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, $puvodni);
+
+        self::assertSame($puvodni->id(), $vysledek->id());
+        // Token se vůbec nevyhodnocoval, do session nic nepřibylo.
+        self::assertNull(\Uzivatel::zSession());
+    }
+
+    public function testVyprsenyTokenNeprihlasi(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        // Podpis „v minulosti": expiry = TED + TTL je pořád před teď.
+        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET, 1_700_000_000);
+
+        $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
+
+        self::assertNull($prihlaseny);
+        self::assertNull(\Uzivatel::zSession());
+    }
+}

--- a/tests/Dev/CrossSiteLoginTest.php
+++ b/tests/Dev/CrossSiteLoginTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dev;
+
+use Gamecon\Dev\CrossSiteLogin;
+use PHPUnit\Framework\TestCase;
+
+class CrossSiteLoginTest extends TestCase
+{
+    private const SECRET = 'test-secret-do-not-use-in-prod';
+    private const TED = 1_700_000_000;
+
+    public function testPrazdnySecretNepodepisuje(): void
+    {
+        self::assertSame('', CrossSiteLogin::podepis('a@b.cz', 'nonce', '', self::TED));
+    }
+
+    public function testPrazdnySecretNeoveruje(): void
+    {
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        self::assertNull(CrossSiteLogin::over($token, ''));
+    }
+
+    public function testRoundTripVratiStejnyEmailANonce(): void
+    {
+        // Bez explicitního času → expiry = now + TTL, tedy v budoucnosti (over()
+        // odmítá vypršelé tokeny, viz testVyprsenyTokenNeprojde).
+        $token = CrossSiteLogin::podepis('admin@gamecon.cz', 'nonce-123', self::SECRET);
+        $overene = CrossSiteLogin::over($token, self::SECRET);
+
+        self::assertNotNull($overene);
+        self::assertSame('admin@gamecon.cz', $overene->email);
+        self::assertSame('nonce-123', $overene->nonce);
+    }
+
+    public function testTokenMaTvarPayloadTeckaPodpisBezPaddingu(): void
+    {
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+
+        self::assertStringContainsString('.', $token);
+        // base64url: žádné +, /, ani = padding.
+        self::assertDoesNotMatchRegularExpression('~[+/=]~', $token);
+    }
+
+    public function testZmenenyPodpisNeprojde(): void
+    {
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        [$payload, $podpis] = explode('.', $token, 2);
+        // Otočíme první znak podpisu na jiný (stejně dlouhý) řetězec.
+        $rozbity = $payload . '.' . ($podpis[0] === 'A' ? 'B' : 'A') . substr($podpis, 1);
+
+        self::assertNull(CrossSiteLogin::over($rozbity, self::SECRET));
+    }
+
+    public function testZmenenyEmailVPayloaduNeprojde(): void
+    {
+        // Útočník chce přihlášení jako admin@gamecon.cz, ale podpis sedí na evil@x.cz.
+        $token = CrossSiteLogin::podepis('evil@x.cz', 'nonce', self::SECRET, self::TED);
+        [, $podpis] = explode('.', $token, 2);
+        $podvrzenyPayload = rtrim(strtr(base64_encode('admin@gamecon.cz|' . (self::TED + 60) . '|nonce'), '+/', '-_'), '=');
+
+        self::assertNull(CrossSiteLogin::over($podvrzenyPayload . '.' . $podpis, self::SECRET));
+    }
+
+    public function testVyprsenyTokenNeprojde(): void
+    {
+        // Podepíšeme „v minulosti": expiry = TED + TTL je pořád před aktuálním časem.
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        self::assertNull(CrossSiteLogin::over($token, self::SECRET));
+    }
+
+    public function testCerstvyTokenProjde(): void
+    {
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET); // ted() = now
+        self::assertNotNull(CrossSiteLogin::over($token, self::SECRET));
+    }
+
+    public function testJinySecretNeoveri(): void
+    {
+        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', 'secret-a');
+        self::assertNull(CrossSiteLogin::over($token, 'secret-b'));
+    }
+
+    public function testNesmyslnyTvarTokenuVratiNull(): void
+    {
+        self::assertNull(CrossSiteLogin::over('bez-tecky', self::SECRET));
+        self::assertNull(CrossSiteLogin::over('', self::SECRET));
+        self::assertNull(CrossSiteLogin::over('....', self::SECRET));
+    }
+
+    public function testTokenZUrlSeDaOveritZpet(): void
+    {
+        // Mint přesně jako stare-rocniky.php: ?gcsso= připojené k /admin URL,
+        // pak ho consume strana vytáhne z query a ověří.
+        $nonce = 'parovaci-nonce-xyz';
+        $gcsso = CrossSiteLogin::podepis('admin@gamecon.cz', $nonce, self::SECRET);
+        $adminUrl = 'https://2021.gamecon.cz/admin?gcsso=' . $gcsso;
+
+        parse_str((string) parse_url($adminUrl, PHP_URL_QUERY), $params);
+        $overene = CrossSiteLogin::over($params['gcsso'], self::SECRET);
+
+        self::assertNotNull($overene);
+        self::assertSame('admin@gamecon.cz', $overene->email);
+        self::assertSame($nonce, $overene->nonce);
+    }
+
+    public function testEmailSOddelovacemSeNepoplete(): void
+    {
+        // E-mail nesmí obsahovat '|', ale ověřme, že rozparsování je striktní na 3 části:
+        // payload se třemi '|' (4 částmi) musí selhat, ne se tiše ořezat.
+        $payload = rtrim(strtr(base64_encode('a@b.cz|x|' . (time() + 60) . '|nonce'), '+/', '-_'), '=');
+        $podpis = rtrim(strtr(base64_encode(hash_hmac('sha256', base64_decode(strtr($payload, '-_', '+/'), true), self::SECRET, true)), '+/', '-_'), '=');
+
+        self::assertNull(CrossSiteLogin::over($payload . '.' . $podpis, self::SECRET));
+    }
+}


### PR DESCRIPTION
## Proč

Kolegové si stěžovali, že dostat se do adminu archivního ročníku (`NNNN.gamecon.cz/admin`) z rozcestníku `admin.gamecon.cz/web/stare-rocniky` znamená: otevřít archivní web, přihlásit se tam, a pak přes GUI přepnout do adminu — matoucí, protože archivní admin není subdoména, ale cesta `/admin`.

Teď: když přihlášený admin klikne v seznamu na odkaz `/admin` ročníku a **stejný člověk** (dle e-mailu) má v DB toho ročníku účet, **přihlásí se do archivního adminu automaticky**.

## Jak — dvě poloviny, ani jedna sama o sobě nepřihlásí

1. **Podepsaný `?gcsso=` token v odkazu** (`CrossSiteLogin`) nese e-mail admina + nonce, podepsaný `SECRET_CRYPTO_KEY` (bajtově stejný na ostré i ve všech archivních images → archiv ověří, co hlavní admin podepsal, bez nového tajemství). Podpis je to, co dělá přihlášení bez hesla bezpečným — bez něj by si kdokoli vyrobil `?gcsso=admin@gamecon.cz`.
2. **Spárovací cookie `gc_sso_pair`** (`SsoParovaciCookie`, scope `.gamecon.cz`) nese stejný nonce a žije jen v prohlížeči, který na odkaz klikl. **Není to přihlášení** — jen důkaz „stejného prohlížeče". Archiv přihlásí jen když nonce z tokenu sedí s nonce z cookie.

**Důsledky pro zadané podmínky:**
- **Sdílený odkaz nikoho nepřihlásí** — cizí prohlížeč spárovací cookie nemá → mismatch → nic. Odkaz dál prochází jen basic-auth bránou (`?gate=`), jako dřív.
- **Už přihlášený na archivu se nepřepíše** — consume se spustí jen když na archivu nikdo přihlášený není (`Uzivatel::zSession()` prázdné).
- **Tichý fallback** — neplatný / vypršelý token, chybějící cookie, neznámý e-mail: token se z URL odstraní a doběhne běžné přihlašovací okno.

## Bez sdílené PHP knihovny

Archivní admin **není kopie** — každý archiv se staví ze stejného `main`. Consume handler je jednou v `prihlaseni.php` a dorazí do každého archivu při příštím rebuildu image (běžný životní cyklus archivu; zmrazená jsou data, ne admin kód). Sdílená knihovna by byla horší — druhý artefakt k synchronizaci napříč images.

## Závislost: ansible brána

Brána (Caddy) dosud při průchodu `?gate=` přesměrovala na čistou URL a **zahodila celý query string** — `?gcsso=` by u brány umřel. Opraveno v **gamecon-cz/ansible#62** (redirect zachová query kromě `gate`). **Tato feature je end-to-end funkční až po nasazení #62**; do té doby je neškodně spící (param se u brány zahodí, žádná regrese).

## Testy

`tests/Dev/CrossSiteLoginTest.php` (12 testů): round-trip e-mail+nonce, prázdný secret, podvržený podpis, podvržený e-mail v payloadu, vypršení, jiný secret, nesmyslný tvar, token z reálné URL. Vše zelené (`vendor/bin/phpunit tests/Dev/`).
