### PR TITLE
Magic login into archive (consume side)

### DIFF
--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -21,6 +21,40 @@ if (post(Login::LOGIN_INPUT_NAME) && post(Login::PASSWORD_INPUT_NAME)) {
     back();
 }
 $u = Uzivatel::zSession();
+
+// Magické přihlášení z administračního rozcestníku na ostré (?gcsso= token).
+// Hlavní admin podepsal token na e-mail klikajícího uživatele + nonce a uložil
+// stejný nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě
+// nikdo není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný,
+// nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
+// URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
+// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení.
+// Soubory načítáme require_once, ať to funguje i v ročnících bez produkčního
+// autoloadu (archivní vendor/ je zmrazené). Pravidla rozhodnutí drží
+// ArchivSsoPrihlaseni; mintovací strana je na ostré v admin/.../web/stare-rocniky.php.
+if (($gcsso = get('gcsso')) !== null) {
+    require_once __DIR__ . '/../../model/Dev/OvereneSso.php';
+    require_once __DIR__ . '/../../model/Dev/CrossSiteLogin.php';
+    require_once __DIR__ . '/../../model/Dev/SsoParovaciCookie.php';
+    require_once __DIR__ . '/../../model/Dev/ArchivSsoPrihlaseni.php';
+
+    $u = (new \Gamecon\Dev\ArchivSsoPrihlaseni(SECRET_CRYPTO_KEY))->prihlas(
+        (string) $gcsso,
+        \Gamecon\Dev\SsoParovaciCookie::precti(),
+        $u,
+    );
+
+    // Token z URL odstraníme (ať nezůstane v historii / referreru). Vlastní
+    // odstranění místo getCurrentUrlWithQuery — ta ve starších ročnících není.
+    $cistaQuery = $_GET;
+    unset($cistaQuery['gcsso']);
+    $cilo = strtok($_SERVER['REQUEST_URI'], '?');
+    if ($cistaQuery !== []) {
+        $cilo .= '?' . http_build_query($cistaQuery);
+    }
+    back($cilo);
+}
+
 if (post('odhlasNAdm')) {
     if ($u) {
         $u->odhlas(false);

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
+ * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě.
+ *
+ * Archivní varianta: e-mail → id_uzivatele řeší přímým dotazem (ne Uzivatel::zEmailu,
+ * která ve starších archivních ročnících nemusí existovat). Sloupec
+ * `email1_uzivatele` v `uzivatele_hodnoty` je napříč ročníky stabilní; přihlášení
+ * pak provede Uzivatel::prihlasId (přítomné všude).
+ *
+ * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
+ * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
+ * (podpis) a {@see SsoParovaciCookie} (spárovací cookie).
+ */
+final class ArchivSsoPrihlaseni
+{
+    public function __construct(
+        private readonly string $secret,
+    ) {
+    }
+
+    /**
+     * Přihlásí uživatele podle tokenu, nebo vrátí $jizPrihlaseny beze změny.
+     *
+     * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
+     * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím
+     * e-mailem v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     *
+     * @param string         $token         hodnota `?gcsso=` z URL
+     * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
+     * @param \Uzivatel|null $jizPrihlaseny uživatel už přihlášený v session, nebo null
+     */
+    public function prihlas(
+        string $token,
+        ?string $nonceZCookie,
+        ?\Uzivatel $jizPrihlaseny,
+    ): ?\Uzivatel {
+        if ($jizPrihlaseny !== null) {
+            return $jizPrihlaseny;
+        }
+        if ($nonceZCookie === null) {
+            return null;
+        }
+
+        $overene = CrossSiteLogin::over($token, $this->secret);
+        if ($overene === null) {
+            return null;
+        }
+        if (! hash_equals($overene->nonce, $nonceZCookie)) {
+            return null;
+        }
+
+        $idUzivatele = dbOneCol(
+            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE email1_uzivatele = $0',
+            [$overene->email],
+        );
+        if ($idUzivatele === null) {
+            return null;
+        }
+
+        return \Uzivatel::prihlasId((int) $idUzivatele);
+    }
+}

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
+ * token vázaný na e-mail přihlášeného uživatele, archiv (NNNN.gamecon.cz) ho ověří
+ * a uživatele podle e-mailu přihlásí — bez zadávání hesla.
+ *
+ * Token nese jen IDENTITU (e-mail) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
+ * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
+ * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
+ * se nonce z tokenu shoduje s nonce z cookie. Sdílená URL nonce v cizím prohlížeči
+ * nemá → nepřihlásí. Viz {@see GateLink} (ten řeší jen průchod bránou,
+ * ne přihlášení) a admin/scripts/prihlaseni.php (ověřovací strana).
+ *
+ * Podpis stojí na `SECRET_CRYPTO_KEY`, který je BAJTOVĚ STEJNÝ na ostré i ve všech
+ * archivních images (viz audit v CLAUDE.md) — archiv tak umí ověřit, co hlavní admin
+ * podepsal, bez zavádění nového tajemství.
+ *
+ * Formát tokenu (`?gcsso=`):
+ *
+ *     gcsso = base64url(email "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *
+ * `expiry` jsou ASCII číslice unixového času; HMAC se počítá nad celým payloadem
+ * (e-mail|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ *
+ * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
+ * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
+ */
+final class CrossSiteLogin
+{
+    /**
+     * Krátká platnost: token je jednorázový proklik z administračního rozcestníku,
+     * ne dlouhé sezení. Stačí na přesměrování přes bránu a přihlášení v archivu;
+     * leaknutý odkaz je tak po pár minutách mrtvý.
+     */
+    public const TTL_SEKUND = 5 * 60;
+
+    private const ODDELOVAC_PAYLOADU = '|';
+
+    /**
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro daný
+     * e-mail a nonce. Prázdný řetězec, pokud secret není nastavený — volající pak
+     * `?gcsso=` nepřipojuje.
+     */
+    public static function podepis(
+        string $email,
+        string $nonce,
+        string $secret,
+        ?int $ted = null,
+    ): string {
+        if ($secret === '') {
+            return '';
+        }
+
+        $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
+        $payload = $email . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $podpis = hash_hmac('sha256', $payload, $secret, true);
+
+        return self::base64Url($payload) . '.' . self::base64Url($podpis);
+    }
+
+    /**
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřený e-mail +
+     * nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
+     * vypršení). Shodu nonce s cookie kontroluje volající.
+     */
+    public static function over(string $token, string $secret): ?OvereneSso
+    {
+        if ($secret === '') {
+            return null;
+        }
+        if (! str_contains($token, '.')) {
+            return null;
+        }
+
+        [$payloadKodovany, $podpisKodovany] = explode('.', $token, 2);
+        $payload = self::base64UrlDekoduj($payloadKodovany);
+        $podpis = self::base64UrlDekoduj($podpisKodovany);
+        if ($payload === null || $podpis === null) {
+            return null;
+        }
+
+        $ocekavanyPodpis = hash_hmac('sha256', $payload, $secret, true);
+        if (! hash_equals($ocekavanyPodpis, $podpis)) {
+            return null;
+        }
+
+        $casti = explode(self::ODDELOVAC_PAYLOADU, $payload);
+        if (count($casti) !== 3) {
+            return null;
+        }
+        [$email, $expiry, $nonce] = $casti;
+
+        if (! ctype_digit($expiry) || (int) $expiry < time()) {
+            return null;
+        }
+        if ($email === '' || $nonce === '') {
+            return null;
+        }
+
+        return new OvereneSso($email, $nonce);
+    }
+
+    private static function base64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private static function base64UrlDekoduj(string $data): ?string
+    {
+        $dekodovano = base64_decode(strtr($data, '-_', '+/'), true);
+
+        return $dekodovano === false ? null : $dekodovano;
+    }
+}

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřený obsah `?gcsso=` tokenu — výsledek {@see CrossSiteLogin::over}.
+ * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
+ * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
+ * odkaz klikl).
+ */
+final readonly class OvereneSso
+{
+    public function __construct(
+        public string $email,
+        public string $nonce,
+    ) {
+    }
+}

--- a/model/Dev/SsoParovaciCookie.php
+++ b/model/Dev/SsoParovaciCookie.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Spárovací cookie pro magické přihlášení do archivu ({@see CrossSiteLogin}).
+ *
+ * Drží náhodný nonce a je scope `.gamecon.cz`, aby ji prohlížeč automaticky poslal
+ * i na `NNNN.gamecon.cz`. NENÍ to přihlášení — sama o sobě nikoho nepřihlásí; je to
+ * jen „důkaz stejného prohlížeče": archiv přihlásí jen když se nonce z této cookie
+ * shoduje s nonce zapečeným v podepsaném `?gcsso=` tokenu. Sdílená URL v cizím
+ * prohlížeči tuhle cookie nemá → mismatch → nepřihlásí. Produkce ani archiv tuhle
+ * cookie nečtou nikde jinde než v ověření SSO, takže její únik sám o sobě nic nedá.
+ *
+ * Scope `.gamecon.cz` je záměrně širší než host-scoped JWT cookie (viz
+ * nastaveni/jwt-bridge.php) — ale na rozdíl od ní nenese identitu.
+ */
+final class SsoParovaciCookie
+{
+    public const JMENO = 'gc_sso_pair';
+
+    /**
+     * O něco déle než TTL tokenu ({@see CrossSiteLogin::TTL_SEKUND}), aby cookie
+     * přežila proklik přes bránu i případné přesměrování a token nikdy nevypršel
+     * „dřív" než jeho párovací polovina.
+     */
+    public const TTL_SEKUND = 10 * 60;
+
+    /**
+     * Nastaví spárovací cookie s daným nonce. Scope `.gamecon.cz` (aby dorazila i
+     * na archiv), HttpOnly, SameSite=Lax (musí přijít při top-level navigaci na
+     * archiv), Secure jen po HTTPS. Mimo gamecon.cz (lokál, preview na jiném hostu)
+     * spadne na host-only cookie — feature stejně cílí jen na ostré subdomény.
+     */
+    public static function nastav(string $nonce): void
+    {
+        setcookie(self::JMENO, $nonce, [
+            'expires'  => time() + self::TTL_SEKUND,
+            'path'     => '/',
+            'domain'   => self::cookieDomena(),
+            'secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    }
+
+    /**
+     * `.gamecon.cz` na produkčních subdoménách (sdílí se napříč admin/archiv),
+     * jinak prázdno = host-only (prohlížeč jinak širší doménu odmítne).
+     */
+    private static function cookieDomena(): string
+    {
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        // Odřízneme případný port.
+        $host = explode(':', $host, 2)[0];
+
+        return str_ends_with($host, 'gamecon.cz') ? '.gamecon.cz' : '';
+    }
+
+    public static function precti(): ?string
+    {
+        $nonce = $_COOKIE[self::JMENO] ?? null;
+
+        return is_string($nonce) && $nonce !== '' ? $nonce : null;
+    }
+}


### PR DESCRIPTION
## Proč

Port magického přihlášení do archivu na ročník **2025**. Na ostré (`admin.gamecon.cz/web/stare-rocniky`) přidává odkaz `/admin` u každého ročníku `?gcsso=` token; tato strana ho na archivu ověří a admina podle e-mailu přihlásí — bez ručního loginu na archivním webu. (Mintovací strana je na `main`, PR #918.)

## Co

Jen **consume strana** (archiv nikoho nemintuje):
- `model/Dev/CrossSiteLogin.php`, `OvereneSso.php`, `SsoParovaciCookie.php` — podpis/ověření tokenu + spárovací cookie.
- `model/Dev/ArchivSsoPrihlaseni.php` — rozhodovací logika. Archivní varianta: e-mail→id řeší přímým dotazem na `uzivatele_hodnoty` (ne `Uzivatel::zEmailu`, ať je soubor identický napříč ročníky), pak `Uzivatel::prihlasId`.
- `admin/scripts/prihlaseni.php` — po `$u = Uzivatel::zSession();` přidán blok: když přijde `?gcsso=` a nikdo není přihlášený, ověří token + shodu nonce se spárovací cookií a přihlásí. Soubory `require_once` (ať to jede i v ročnících bez produkčního autoloadu). Token z URL se pak odstraní.

## Bezpečnost (stejná pravidla jako na ostré)

- **Sdílený odkaz nikoho nepřihlásí** — cizí prohlížeč nemá spárovací cookii `gc_sso_pair` → nonce mismatch → nic. Brána dál chrání basic-auth (`?gate=`).
- **Už přihlášený na archivu se nepřepíše.**
- Podpis přes `SECRET_CRYPTO_KEY` (bajtově stejný napříč ostrá/archiv) → neforgeable e-mail.

## Závislost

Funguje end-to-end až po nasazení **ansible #62** (brána jinak `?gcsso=` zahodí). Do té doby neškodně spící (token se u brány ztratí, padá na běžný login).

## Ověření

`php -l` čisté na všech 5 souborech. Logika otestovaná unit+integračními testy na `main` (PR #918). Po nasazení: proklik z ostrého rozcestníku na 2025/admin → přihlášení; stejná URL v čistém prohlížeči → bez přihlášení.
