### PR TITLE
Fix fatal: SSO nonce exceeded randHex 32-char cap

### DIFF
--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -40,7 +40,10 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GA
 $ssoNonce = null;
 $ssoEmail = $u->mail() ?? '';
 if ($ssoEmail !== '' && SECRET_CRYPTO_KEY !== '') {
-    $ssoNonce = randHex(40);
+    // Kryptograficky náhodný nonce (128 bitů). Ne randHex() — ta stropuje na 32
+    // znaků a stojí na substr(md5(mt_rand())), což má slabou entropii; tady jde
+    // o bezpečnostní párovací token, tak chceme random_bytes.
+    $ssoNonce = bin2hex(random_bytes(16));
     SsoParovaciCookie::nastav($ssoNonce);
 }
 $adminUrlSeSso = static function (string $adminUrl) use ($ssoNonce, $ssoEmail, $gateUrl): string {


### PR DESCRIPTION
Hotfix — `admin.gamecon.cz/web/stare-rocniky` throws a fatal on load.

## Příčina

Mintovací strana magického přihlášení (PR #918) generovala párovací nonce přes `randHex(40)`. `randHex` ale stropuje na 32 znacích (`$chars <= 32`) a nad limit hází `Exception("maximum characters is 32 so far.")` — takže rozcestník archivů spadne hned při načtení.

## Oprava

`bin2hex(random_bytes(16))` — 128bitový kryptograficky náhodný nonce (32 hex znaků). Navíc lepší než `randHex` i věcně: ta stojí na `substr(md5(mt_rand()), 0, $chars)` (slabá entropie + truncated hash, což global rules zakazují); pro bezpečnostní párovací token chceme `random_bytes`.

## Ověřeno

`php -l` čisté. Smoke: `bin2hex(random_bytes(16))` → 32-znakový hex nonce, projde sign→verify v `CrossSiteLogin` (mint→consume kontrakt). Logika SSO jinak beze změny.