### PR TITLE
Sign archive SSO with per-year derived key

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -74,3 +74,5 @@ jobs:
                     # Gate-token signing secrets (viz deploy-ostra.yml).
                     PREVIEW_GATE_SECRET: ${{ secrets.PREVIEW_GATE_SECRET }}
                     ARCHIVE_GATE_SECRET: ${{ secrets.ARCHIVE_GATE_SECRET }}
+                    # Master pro magické přihlášení do archivu (viz deploy-ostra.yml).
+                    GAMECON_SSO_SECRET: ${{ secrets.GAMECON_SSO_SECRET }}

--- a/.github/workflows/deploy-ostra.yml
+++ b/.github/workflows/deploy-ostra.yml
@@ -84,3 +84,7 @@ jobs:
                     # v ansible secrets.yaml.
                     PREVIEW_GATE_SECRET: ${{ secrets.PREVIEW_GATE_SECRET }}
                     ARCHIVE_GATE_SECRET: ${{ secrets.ARCHIVE_GATE_SECRET }}
+                    # Master tajemství pro magické přihlášení do archivu (?gcsso=).
+                    # JEN ostrá — z něj odvozuje klíč pro daný ročník. Archivy dostanou
+                    # jen odvozený klíč (ne tohle), takže popadený archiv master neunese.
+                    GAMECON_SSO_SECRET: ${{ secrets.GAMECON_SSO_SECRET }}

--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -37,18 +37,26 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GA
 // nikoho nepřihlásí (cizí prohlížeč cookie nemá). Bez secretu / e-mailu se token
 // nepřipojí a chování zůstává jako dřív (jen basic-auth brána). Viz CrossSiteLogin
 // + SsoParovaciCookie + admin/scripts/prihlaseni.php (ověřovací strana).
+// Magické přihlášení podepisujeme klíčem ODVOZENÝM PRO DANÝ ROČNÍK z master tajemství
+// GAMECON_SSO_SECRET (master žije jen na ostré). Archiv dostane jen svůj odvozený klíč
+// (HMAC(rok, master)) — když ho někdo z archivu vytáhne, umí podvrhnout přihlášení jen
+// do toho jednoho ročníku, ne do ostatních a hlavně NE k SECRET_CRYPTO_KEY (ten šifruje
+// osobní data na ostré a do archivů nepatří). Odvození je shodné s bash stranou v
+// deploy-year-archive.sh (openssl dgst -sha256 -hmac).
+$ssoMaster = defined('GAMECON_SSO_SECRET') ? GAMECON_SSO_SECRET : '';
 $ssoNonce = null;
 $ssoEmail = $u->mail() ?? '';
-if ($ssoEmail !== '' && SECRET_CRYPTO_KEY !== '') {
+if ($ssoEmail !== '' && $ssoMaster !== '') {
     // Kryptograficky náhodný nonce (128 bitů). Ne randHex() — ta stropuje na 32
     // znaků a stojí na substr(md5(mt_rand())), což má slabou entropii; tady jde
     // o bezpečnostní párovací token, tak chceme random_bytes.
     $ssoNonce = bin2hex(random_bytes(16));
     SsoParovaciCookie::nastav($ssoNonce);
 }
-$adminUrlSeSso = static function (string $adminUrl) use ($ssoNonce, $ssoEmail, $gateUrl): string {
+$adminUrlSeSso = static function (string $adminUrl, int $rocnik) use ($ssoNonce, $ssoEmail, $ssoMaster, $gateUrl): string {
     if ($ssoNonce !== null) {
-        $gcsso = CrossSiteLogin::podepis($ssoEmail, $ssoNonce, SECRET_CRYPTO_KEY);
+        $klicRocniku = hash_hmac('sha256', (string) $rocnik, $ssoMaster);
+        $gcsso = CrossSiteLogin::podepis($ssoEmail, $ssoNonce, $klicRocniku);
         if ($gcsso !== '') {
             $oddelovac = str_contains($adminUrl, '?') ? '&' : '?';
             $adminUrl .= $oddelovac . 'gcsso=' . $gcsso;
@@ -130,7 +138,7 @@ $nadpisEpochy = [
                     if ($epocha === 'ziva') {
                         $adminUrl = rtrim($archive->url, '/') . '/admin';
                         ?>
-                        <a href="<?php echo htmlspecialchars($adminUrlSeSso($adminUrl)); ?>" target="_blank" rel="noopener">/admin</a>
+                        <a href="<?php echo htmlspecialchars($adminUrlSeSso($adminUrl, $archive->year)); ?>" target="_blank" rel="noopener">/admin</a>
                     <?php } else { ?>
                         —
                     <?php } ?>

--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -32,10 +32,14 @@ $u = Uzivatel::zSession();
 // nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
 // URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
 // tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení. Pravidla
-// rozhodnutí drží ArchivSsoPrihlaseni (sdílí je s testem).
+// rozhodnutí drží ArchivSsoPrihlaseni (sdílí je s testem). Ověřujeme klíčem
+// GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník (HMAC(rok, master)), který archivu
+// vstříkne deploy přes -e. Na ostré je prázdný (master se k odvození nepoužívá pro
+// vlastní login), takže se tu SSO nikdy neuplatní — což je správně.
 // Viz ArchivSsoPrihlaseni + SsoParovaciCookie + admin/scripts/modules/web/stare-rocniky.php.
 if (($gcsso = get('gcsso')) !== null) {
-    $u = (new ArchivSsoPrihlaseni(SECRET_CRYPTO_KEY))->prihlas(
+    $ssoKlic = defined('GAMECON_SSO_KEY') ? GAMECON_SSO_KEY : '';
+    $u = (new ArchivSsoPrihlaseni($ssoKlic))->prihlas(
         (string) $gcsso,
         SsoParovaciCookie::precti(),
         $u,

--- a/model/funkce/skryte-nastaveni-z-env-funkce.php
+++ b/model/funkce/skryte-nastaveni-z-env-funkce.php
@@ -46,6 +46,15 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
         $PREVIEW_GATE_SECRET = getenv('PREVIEW_GATE_SECRET');
         $ARCHIVE_GATE_SECRET = getenv('ARCHIVE_GATE_SECRET');
 
+        // Magické přihlášení do archivního adminu (?gcsso=). GAMECON_SSO_SECRET je
+        // master — žije JEN na ostré, kde z něj odvozujeme klíč pro daný ročník.
+        // GAMECON_SSO_KEY je ten ODVOZENÝ klíč (HMAC(rok, master)), který dostane jen
+        // konkrétní archiv (vstříkne deploy přes -e). Tím archiv ověří token, ale když
+        // ho někdo z archivu vytáhne, podvrhne login jen do toho ročníku — ne k masteru
+        // ani k SECRET_CRYPTO_KEY. Viz CrossSiteLogin + stare-rocniky.php / prihlaseni.php.
+        $GAMECON_SSO_SECRET = getenv('GAMECON_SSO_SECRET');
+        $GAMECON_SSO_KEY = getenv('GAMECON_SSO_KEY');
+
         $ted = date(DATE_ATOM);
         $nazevTetoFunkce = __FUNCTION__;
 
@@ -94,6 +103,10 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
             // Tajemství pro podpis gate tokenu (one-click přístup přes bránu)
             define('PREVIEW_GATE_SECRET', '{$PREVIEW_GATE_SECRET}');
             define('ARCHIVE_GATE_SECRET', '{$ARCHIVE_GATE_SECRET}');
+
+            // Magické přihlášení do archivu: master jen na ostré, odvozený klíč jen v archivu
+            define('GAMECON_SSO_SECRET', '{$GAMECON_SSO_SECRET}');
+            define('GAMECON_SSO_KEY', '{$GAMECON_SSO_KEY}');
             PHP,
         );
     }

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -155,4 +155,13 @@ if (! defined('ARCHIVE_GATE_SECRET')) {
     define('ARCHIVE_GATE_SECRET', getenv('ARCHIVE_GATE_SECRET') ?: '');
 }
 
+// Magické přihlášení do archivu (?gcsso=). Lokálně prázdné — feature se nepřipojí.
+// GAMECON_SSO_SECRET = master (ostrá), GAMECON_SSO_KEY = odvozený klíč ročníku (archiv).
+if (! defined('GAMECON_SSO_SECRET')) {
+    define('GAMECON_SSO_SECRET', getenv('GAMECON_SSO_SECRET') ?: '');
+}
+if (! defined('GAMECON_SSO_KEY')) {
+    define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');
+}
+
 error_reporting(E_ALL);

--- a/tests/Dev/CrossSiteLoginTest.php
+++ b/tests/Dev/CrossSiteLoginTest.php
@@ -83,6 +83,21 @@ class CrossSiteLoginTest extends TestCase
         self::assertNull(CrossSiteLogin::over($token, 'secret-b'));
     }
 
+    public function testKlicOdvozenyProRocnikNeoveriTokenJinehoRocniku(): void
+    {
+        // Izolace ročníků: ostrá podepisuje klíčem HMAC(rok, master); archiv ověřuje
+        // jen svým odvozeným klíčem. Token pro 2025 NESMÍ projít klíčem 2024 —
+        // popadený archiv 2025 tak neumí podvrhnout login do 2024.
+        $master = 'master-sso-secret';
+        $klic2025 = hash_hmac('sha256', '2025', $master);
+        $klic2024 = hash_hmac('sha256', '2024', $master);
+
+        $token2025 = CrossSiteLogin::podepis('admin@gamecon.cz', 'nonce', $klic2025);
+
+        self::assertNotNull(CrossSiteLogin::over($token2025, $klic2025), 'vlastní ročník projde');
+        self::assertNull(CrossSiteLogin::over($token2025, $klic2024), 'cizí ročník neprojde');
+    }
+
     public function testNesmyslnyTvarTokenuVratiNull(): void
     {
         self::assertNull(CrossSiteLogin::over('bez-tecky', self::SECRET));


### PR DESCRIPTION
## Proč

Magické přihlášení do archivu podepisovalo `?gcsso=` token klíčem **`SECRET_CRYPTO_KEY`** — ostrý Defuse\Crypto klíč, který šifruje osobní data (číslo OP) na produkci. Aby archiv token ověřil, musel by ten klíč dostat — jenže archivy jsou **zmrazený starý kód se známými dírami**. Popadený archiv = únik produkčního klíče k osobním datům. (Zavrženo, ansible PR #64 zavřen.)

## Co

Vyhrazený SSO klíč, **odvozený pro každý ročník**:

- **`GAMECON_SSO_SECRET`** (master) — žije **jen na ostré** (+ ansible vault). Do žádného archivu nejde.
- Klíč ročníku = `hash_hmac('sha256', (string)$rok, GAMECON_SSO_SECRET)`.
  - **Ostrá (mint)** ho odvodí pro každý řádek archivu (zná `$archive->year`) a tím podepíše token.
  - **Archiv (verify)** dostane jen svůj odvozený klíč jako **`GAMECON_SSO_KEY`** přes `docker run -e` (deploy zná rok). Master nikdy nevidí, jiné ročníky odvodit neumí.

Popadený archiv 2019 → unikne jen klíč 2019 (podvrhne login jen do 2019), ne master, ne ostatní ročníky, **ne `SECRET_CRYPTO_KEY`**.

`CrossSiteLogin` bere klíč parametrem, takže se mění jen co volající předají:
- `stare-rocniky.php` (mint): odvodí `hash_hmac(rok, GAMECON_SSO_SECRET)`, podepíše. Guard na `GAMECON_SSO_SECRET`.
- `prihlaseni.php` (consume): ověří `GAMECON_SSO_KEY` (na ostré prázdné → SSO se tu neuplatní, správně).

Nové env konstanty doplněny dle checklistu "Mirror Ostra": `skryte-nastaveni-z-env-funkce.php`, `nastaveni-local-default.php`, `deploy-ostra.yml` + `deploy-beta.yml` (jen master, jen ostrá/beta). **Žádný bake do Dockerfile** — master se do image nepatří, odvozený klíč je per-deployment (`-e`, jako DB creds).

## Test

`CrossSiteLoginTest::testKlicOdvozenyProRocnikNeoveriTokenJinehoRocniku` — token podepsaný klíčem 2025 NEprojde klíčem 2024 (izolace ročníků). Interop PHP `hash_hmac` == bash `openssl dgst -sha256 -hmac` ověřen (deploy odvozuje stejně). 34 Dev testů zelených.

## Návaznosti (samostatné PR)

- ansible: templated `deploy-year-archive.sh.j2` odvodí + vstříkne per-year `GAMECON_SSO_KEY`.
- `archive/2025` follow-up: consume přepnout z `SECRET_CRYPTO_KEY` na `GAMECON_SSO_KEY`.
- Provisioning: `GAMECON_SSO_SECRET` do GitHub secrets + ansible vault.
- Preview zatím magické přihlášení nedostává (žádný master ani odvozený klíč) — dokumentováno.
