### PR TITLE
Verify SSO with per-year GAMECON_SSO_KEY

### DIFF
--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -38,7 +38,11 @@ if (($gcsso = get('gcsso')) !== null) {
     require_once __DIR__ . '/../../model/Dev/SsoParovaciCookie.php';
     require_once __DIR__ . '/../../model/Dev/ArchivSsoPrihlaseni.php';
 
-    $u = (new \Gamecon\Dev\ArchivSsoPrihlaseni(SECRET_CRYPTO_KEY))->prihlas(
+    // GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník (HMAC(rok, master)), který
+    // archivu vstříkne deploy přes -e. NE SECRET_CRYPTO_KEY — ten šifruje osobní data
+    // a do (zmrazeného, zranitelného) archivu nepatří. Prázdný → SSO se neuplatní.
+    $ssoKlic = defined('GAMECON_SSO_KEY') ? GAMECON_SSO_KEY : '';
+    $u = (new \Gamecon\Dev\ArchivSsoPrihlaseni($ssoKlic))->prihlas(
         (string) $gcsso,
         \Gamecon\Dev\SsoParovaciCookie::precti(),
         $u,

--- a/model/funkce/skryte-nastaveni-z-env-funkce.php
+++ b/model/funkce/skryte-nastaveni-z-env-funkce.php
@@ -28,6 +28,11 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
         $APP_DEBUG = getenv('APP_DEBUG') ? 'true' : 'false';
         $APP_SECRET = getenv('APP_SECRET');
 
+        // Magické přihlášení do archivu (?gcsso=): klíč ODVOZENÝ pro tento ročník
+        // (HMAC(rok, master)), který archivu vstříkne deploy přes -e. Master sám
+        // do archivu nikdy nejde. Prázdný → archiv žádný token neověří.
+        $GAMECON_SSO_KEY = getenv('GAMECON_SSO_KEY');
+
         $ted = date(DATE_ATOM);
         $nazevTetoFunkce = __FUNCTION__;
 
@@ -66,6 +71,9 @@ function vytvorSouborSkrytehoNastaveniPodleEnv(
             define('APP_ENV', '$APP_ENV');
             define('APP_DEBUG', $APP_DEBUG);
             define('APP_SECRET', '$APP_SECRET');
+
+            // Magické přihlášení do archivu — odvozený klíč ročníku (ne master)
+            define('GAMECON_SSO_KEY', '$GAMECON_SSO_KEY');
             PHP,
         );
     }

--- a/nastaveni/nastaveni-local-default.php
+++ b/nastaveni/nastaveni-local-default.php
@@ -65,4 +65,7 @@ if (!defined('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB')) define('VAROVAT_O_ZASEKL
 if (!defined('APP_SECRET')) define('APP_SECRET', getenv('APP_SECRET')
     ?: 'someRandomStringForAppSecretThatYouShouldChange');
 
+// Magické přihlášení do archivu (?gcsso=) — odvozený klíč ročníku z -e; lokálně prázdné.
+if (!defined('GAMECON_SSO_KEY')) define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');
+
 error_reporting(E_ALL);


### PR DESCRIPTION
## Why

Follow-up to the dedicated-SSO-key redesign. The merged 2025 consume side (#919) verified the `?gcsso=` token with `SECRET_CRYPTO_KEY` — ostra's personal-data encryption key, which must NOT live in a frozen archive. Switch to the per-year derived `GAMECON_SSO_KEY` (injected by the archive deploy via `-e`).

## What

- `admin/scripts/prihlaseni.php`: verify with `GAMECON_SSO_KEY` (guarded `defined() ? : ''`) instead of `SECRET_CRYPTO_KEY`.
- Add the `GAMECON_SSO_KEY` constant (archive-only — no master on archives) to `skryte-nastaveni-z-env-funkce.php` (getenv + bake) and `nastaveni-local-default.php`.

A popped 2025 archive now leaks only 2025's derived key, not ostra's crypto key.

## Depends on

- gamecon main #921 (mint signs with `hash_hmac(2025, master)`).
- ansible #65 (archive deploy derives + injects `GAMECON_SSO_KEY` for 2025).
- Re-deploy the 2025 container after #65 so the new `-e GAMECON_SSO_KEY` lands.

## Verified

`php -l` clean on all three files.
