### PR TITLE
Read GAMECON_SSO_KEY env in archive prod config

### DIFF
--- a/nastaveni/nastaveni-produkce.php
+++ b/nastaveni/nastaveni-produkce.php
@@ -70,3 +70,11 @@ if (!defined('VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB')) define('VAROVAT_O_ZASEKL
 // cross-deploy session continuity.
 if (!defined('SECRET_CRYPTO_KEY')) define('SECRET_CRYPTO_KEY', getenv('SECRET_CRYPTO_KEY')
     ?: 'def0000066cba9ae32fdda839a143276cc0646b3880920c93876ecc1bbaca96ee6ed251559516b1804f4742c2165e4c7eb3ed5c7a5abe857c6db8608e3b5fe97a8cdf15a');
+
+// GAMECON_SSO_KEY — klíč pro ověření magického přihlášení (?gcsso=), odvozený pro
+// tento ročník (HMAC(rok, master)) a vstříknutý deployem přes -e. Tenhle (commitnutý)
+// nastaveni-produkce.php je na archivu reálně načítaný soubor — bake přes
+// skryte-nastaveni-z-env-funkce.php se neprovede, protože tenhle soubor už existuje.
+// Proto se getenv('GAMECON_SSO_KEY') musí číst právě TADY, jinak konstanta zůstane
+// nedefinovaná a SSO se neuplatní. Prázdný fallback = SSO vypnuté.
+if (!defined('GAMECON_SSO_KEY')) define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');


### PR DESCRIPTION
## The actual bug (why magic-login kept failing)

The 2025 container DID receive `-e GAMECON_SSO_KEY=<derived>` correctly (`docker exec ... env` shows it). But **PHP never read it into a constant**, so the consume code got an empty key → every token failed to verify → silent no-login.

Why: on the archive's ostra path, `zavadec-nastaveni.php` calls `vytvorSouborSkrytehoNastaveniPodleEnv('verejne-nastaveni-produkce.php')`, which **only bakes when the hidden file is absent** (`!is_file()`). But `nastaveni/nastaveni-produkce.php` is **committed** in the archive branch → baked into the image → `is_file()` is true → **the bake (which reads getenv) is skipped**. The committed `nastaveni-produkce.php` reads `getenv()` for `DB_*`, `SECRET_CRYPTO_KEY`, … but had **no `GAMECON_SSO_KEY`** line. So the constant stayed undefined; my `defined('GAMECON_SSO_KEY') ? : ''` guard fell to `''`.

(PR #922 added `GAMECON_SSO_KEY` to `skryte-nastaveni-z-env-funkce.php` (the bake fn) and `nastaveni-local-default.php` — but neither runs on the archive's ostra path when the committed hidden file exists. Wrong place.)

## Fix

Add the getenv-read to the file actually loaded on the archive: `nastaveni/nastaveni-produkce.php`, right next to `SECRET_CRYPTO_KEY`:

```php
if (!defined('GAMECON_SSO_KEY')) define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');
```

## After merge

Redeploy the 2025 container so the new committed config is in the image. The `-e GAMECON_SSO_KEY` (already injected) will then actually define the constant → token verifies → login works.

## Applies to other archives too

Same fix needed on every archive branch we port (2017–2024) — they all load the committed `nastaveni-produkce.php`, not the bake.
