### PR TITLE
Magic login into 2018 archive from admin list (?gcsso=)

### DIFF
--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -11,6 +11,43 @@ if(post('loginNAdm') && post('hesloNAdm')) {
   back();
 }
 $u = Uzivatel::zSession();
+
+// Magické přihlášení z administračního rozcestníku na ostré (?gcsso= token).
+// Hlavní admin podepsal token na e-mail klikajícího uživatele + nonce a uložil
+// stejný nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě
+// nikdo není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný,
+// nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
+// URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
+// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení.
+// Soubory načítáme require_once, ať to funguje i v ročnících bez produkčního
+// autoloadu (archivní vendor/ je zmrazené). Pravidla rozhodnutí drží
+// ArchivSsoPrihlaseni; mintovací strana je na ostré v admin/.../web/stare-rocniky.php.
+if (($gcsso = get('gcsso')) !== null) {
+    require_once __DIR__ . '/../../model/Dev/OvereneSso.php';
+    require_once __DIR__ . '/../../model/Dev/CrossSiteLogin.php';
+    require_once __DIR__ . '/../../model/Dev/SsoParovaciCookie.php';
+    require_once __DIR__ . '/../../model/Dev/ArchivSsoPrihlaseni.php';
+
+    // GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník (HMAC(rok, master)), který
+    // archivu vstříkne deploy přes -e. NE SECRET_CRYPTO_KEY — ten šifruje osobní data
+    // a do (zmrazeného, zranitelného) archivu nepatří. Prázdný → SSO se neuplatní.
+    $ssoKlic = defined('GAMECON_SSO_KEY') ? GAMECON_SSO_KEY : '';
+    $u = (new \Gamecon\Dev\ArchivSsoPrihlaseni($ssoKlic))->prihlas(
+        (string) $gcsso,
+        \Gamecon\Dev\SsoParovaciCookie::precti(),
+        $u,
+    );
+
+    // Token z URL odstraníme (ať nezůstane v historii / referreru). Vlastní
+    // odstranění místo getCurrentUrlWithQuery — ta ve starších ročnících není.
+    $cistaQuery = $_GET;
+    unset($cistaQuery['gcsso']);
+    $cilo = strtok($_SERVER['REQUEST_URI'], '?');
+    if ($cistaQuery !== []) {
+        $cilo .= '?' . http_build_query($cistaQuery);
+    }
+    back($cilo);
+}
 if(post('odhlasNAdm')) {
   if($u) $u->odhlas();
   back();

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
+ * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě.
+ *
+ * Archivní varianta: e-mail → id_uzivatele řeší přímým dotazem (ne Uzivatel::zEmailu,
+ * která ve starších archivních ročnících nemusí existovat). Sloupec
+ * `email1_uzivatele` v `uzivatele_hodnoty` je napříč ročníky stabilní; přihlášení
+ * pak provede Uzivatel::prihlasId (přítomné všude).
+ *
+ * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
+ * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
+ * (podpis) a {@see SsoParovaciCookie} (spárovací cookie).
+ */
+final class ArchivSsoPrihlaseni
+{
+    public function __construct(
+        private readonly string $secret,
+    ) {
+    }
+
+    /**
+     * Přihlásí uživatele podle tokenu, nebo vrátí $jizPrihlaseny beze změny.
+     *
+     * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
+     * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím
+     * e-mailem v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     *
+     * @param string         $token         hodnota `?gcsso=` z URL
+     * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
+     * @param \Uzivatel|null $jizPrihlaseny uživatel už přihlášený v session, nebo null
+     */
+    public function prihlas(
+        string $token,
+        ?string $nonceZCookie,
+        ?\Uzivatel $jizPrihlaseny,
+    ): ?\Uzivatel {
+        if ($jizPrihlaseny !== null) {
+            return $jizPrihlaseny;
+        }
+        if ($nonceZCookie === null) {
+            return null;
+        }
+
+        $overene = CrossSiteLogin::over($token, $this->secret);
+        if ($overene === null) {
+            return null;
+        }
+        if (! hash_equals($overene->nonce, $nonceZCookie)) {
+            return null;
+        }
+
+        $idUzivatele = dbOneCol(
+            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE email1_uzivatele = $0',
+            [$overene->email],
+        );
+        if ($idUzivatele === null) {
+            return null;
+        }
+
+        return \Uzivatel::prihlasId((int) $idUzivatele);
+    }
+}

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -8,10 +8,12 @@ namespace Gamecon\Dev;
  * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
  * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě.
  *
- * Archivní varianta: e-mail → id_uzivatele řeší přímým dotazem (ne Uzivatel::zEmailu,
- * která ve starších archivních ročnících nemusí existovat). Sloupec
- * `email1_uzivatele` v `uzivatele_hodnoty` je napříč ročníky stabilní; přihlášení
- * pak provede Uzivatel::prihlasId (přítomné všude).
+ * Identita = číselné `id_uzivatele` z tokenu (ne e-mail — ten je proměnný a mohl by
+ * mířit na cizí účet). ID je napříč ostrou i archivními snapshoty stabilní. Ověříme
+ * jen, že takový uživatel v TÉHLE archivní DB existuje (kdo v daném ročníku ještě
+ * účet neměl, se nenajde → nepřihlásí), a přihlásíme přes Uzivatel::prihlasId
+ * (přítomné všude). Přímý dotaz místo Uzivatel::zId, který ve starších ročnících
+ * nemusí existovat.
  *
  * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
  * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
@@ -29,8 +31,8 @@ final class ArchivSsoPrihlaseni
      *
      * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
      * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
-     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím
-     * e-mailem v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím ID
+     * v téhle DB máme. Jinak vrací beze změny (tiché selhání).
      *
      * @param string         $token         hodnota `?gcsso=` z URL
      * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
@@ -56,14 +58,14 @@ final class ArchivSsoPrihlaseni
             return null;
         }
 
-        $idUzivatele = dbOneCol(
-            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE email1_uzivatele = $0',
-            [$overene->email],
+        $idVDb = dbOneCol(
+            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE id_uzivatele = $0',
+            [$overene->idUzivatele],
         );
-        if ($idUzivatele === null) {
+        if ($idVDb === null) {
             return null;
         }
 
-        return \Uzivatel::prihlasId((int) $idUzivatele);
+        return \Uzivatel::prihlasId((int) $idVDb);
     }
 }

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -6,10 +6,14 @@ namespace Gamecon\Dev;
 
 /**
  * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
- * token vázaný na e-mail přihlášeného uživatele, archiv (NNNN.gamecon.cz) ho ověří
- * a uživatele podle e-mailu přihlásí — bez zadávání hesla.
+ * token vázaný na `id_uzivatele` přihlášeného uživatele, archiv (NNNN.gamecon.cz)
+ * ho ověří a uživatele podle ID přihlásí — bez zadávání hesla.
  *
- * Token nese jen IDENTITU (e-mail) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * Identitu nese ČÍSELNÉ ID, ne e-mail: ID je napříč ostrou i zmrazenými archivními
+ * snapshoty téhož kontinuálního `uzivatele` stabilní, kdežto e-mail je proměnný a
+ * může se časem přiřadit jinému člověku (→ přihlášení do cizího účtu).
+ *
+ * Token nese jen IDENTITU (ID) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
  * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
  * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
  * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
@@ -17,16 +21,17 @@ namespace Gamecon\Dev;
  * nemá → nepřihlásí. Viz {@see GateLink} (ten řeší jen průchod bránou,
  * ne přihlášení) a admin/scripts/prihlaseni.php (ověřovací strana).
  *
- * Podpis stojí na `SECRET_CRYPTO_KEY`, který je BAJTOVĚ STEJNÝ na ostré i ve všech
- * archivních images (viz audit v CLAUDE.md) — archiv tak umí ověřit, co hlavní admin
- * podepsal, bez zavádění nového tajemství.
+ * Podpis stojí na klíči ODVOZENÉM PRO DANÝ ROČNÍK z master tajemství
+ * (`hash_hmac('sha256', (string) $rocnik, GAMECON_SSO_SECRET)`); master žije jen na
+ * ostré, archiv dostane jen svůj odvozený klíč přes `-e GAMECON_SSO_KEY`. NE
+ * `SECRET_CRYPTO_KEY` — ten šifruje osobní data a do zmrazeného archivu nepatří.
  *
  * Formát tokenu (`?gcsso=`):
  *
- *     gcsso = base64url(email "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *     gcsso = base64url(id "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
  *
- * `expiry` jsou ASCII číslice unixového času; HMAC se počítá nad celým payloadem
- * (e-mail|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ * `id` i `expiry` jsou ASCII číslice; HMAC se počítá nad celým payloadem
+ * (id|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
  *
  * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
  * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
@@ -43,12 +48,12 @@ final class CrossSiteLogin
     private const ODDELOVAC_PAYLOADU = '|';
 
     /**
-     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro daný
-     * e-mail a nonce. Prázdný řetězec, pokud secret není nastavený — volající pak
-     * `?gcsso=` nepřipojuje.
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro dané
+     * `id_uzivatele` a nonce. Prázdný řetězec, pokud secret není nastavený — volající
+     * pak `?gcsso=` nepřipojuje.
      */
     public static function podepis(
-        string $email,
+        int $idUzivatele,
         string $nonce,
         string $secret,
         ?int $ted = null,
@@ -58,15 +63,15 @@ final class CrossSiteLogin
         }
 
         $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
-        $payload = $email . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $payload = $idUzivatele . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
         $podpis = hash_hmac('sha256', $payload, $secret, true);
 
         return self::base64Url($payload) . '.' . self::base64Url($podpis);
     }
 
     /**
-     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřený e-mail +
-     * nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřené `id_uzivatele`
+     * + nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
      * vypršení). Shodu nonce s cookie kontroluje volající.
      */
     public static function over(string $token, string $secret): ?OvereneSso
@@ -94,16 +99,16 @@ final class CrossSiteLogin
         if (count($casti) !== 3) {
             return null;
         }
-        [$email, $expiry, $nonce] = $casti;
+        [$idUzivatele, $expiry, $nonce] = $casti;
 
         if (! ctype_digit($expiry) || (int) $expiry < time()) {
             return null;
         }
-        if ($email === '' || $nonce === '') {
+        if (! ctype_digit($idUzivatele) || (int) $idUzivatele <= 0 || $nonce === '') {
             return null;
         }
 
-        return new OvereneSso($email, $nonce);
+        return new OvereneSso((int) $idUzivatele, $nonce);
     }
 
     private static function base64Url(string $data): string

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
+ * token vázaný na e-mail přihlášeného uživatele, archiv (NNNN.gamecon.cz) ho ověří
+ * a uživatele podle e-mailu přihlásí — bez zadávání hesla.
+ *
+ * Token nese jen IDENTITU (e-mail) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
+ * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
+ * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
+ * se nonce z tokenu shoduje s nonce z cookie. Sdílená URL nonce v cizím prohlížeči
+ * nemá → nepřihlásí. Viz {@see GateLink} (ten řeší jen průchod bránou,
+ * ne přihlášení) a admin/scripts/prihlaseni.php (ověřovací strana).
+ *
+ * Podpis stojí na `SECRET_CRYPTO_KEY`, který je BAJTOVĚ STEJNÝ na ostré i ve všech
+ * archivních images (viz audit v CLAUDE.md) — archiv tak umí ověřit, co hlavní admin
+ * podepsal, bez zavádění nového tajemství.
+ *
+ * Formát tokenu (`?gcsso=`):
+ *
+ *     gcsso = base64url(email "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *
+ * `expiry` jsou ASCII číslice unixového času; HMAC se počítá nad celým payloadem
+ * (e-mail|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ *
+ * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
+ * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
+ */
+final class CrossSiteLogin
+{
+    /**
+     * Krátká platnost: token je jednorázový proklik z administračního rozcestníku,
+     * ne dlouhé sezení. Stačí na přesměrování přes bránu a přihlášení v archivu;
+     * leaknutý odkaz je tak po pár minutách mrtvý.
+     */
+    public const TTL_SEKUND = 5 * 60;
+
+    private const ODDELOVAC_PAYLOADU = '|';
+
+    /**
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro daný
+     * e-mail a nonce. Prázdný řetězec, pokud secret není nastavený — volající pak
+     * `?gcsso=` nepřipojuje.
+     */
+    public static function podepis(
+        string $email,
+        string $nonce,
+        string $secret,
+        ?int $ted = null,
+    ): string {
+        if ($secret === '') {
+            return '';
+        }
+
+        $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
+        $payload = $email . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $podpis = hash_hmac('sha256', $payload, $secret, true);
+
+        return self::base64Url($payload) . '.' . self::base64Url($podpis);
+    }
+
+    /**
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřený e-mail +
+     * nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
+     * vypršení). Shodu nonce s cookie kontroluje volající.
+     */
+    public static function over(string $token, string $secret): ?OvereneSso
+    {
+        if ($secret === '') {
+            return null;
+        }
+        if (! str_contains($token, '.')) {
+            return null;
+        }
+
+        [$payloadKodovany, $podpisKodovany] = explode('.', $token, 2);
+        $payload = self::base64UrlDekoduj($payloadKodovany);
+        $podpis = self::base64UrlDekoduj($podpisKodovany);
+        if ($payload === null || $podpis === null) {
+            return null;
+        }
+
+        $ocekavanyPodpis = hash_hmac('sha256', $payload, $secret, true);
+        if (! hash_equals($ocekavanyPodpis, $podpis)) {
+            return null;
+        }
+
+        $casti = explode(self::ODDELOVAC_PAYLOADU, $payload);
+        if (count($casti) !== 3) {
+            return null;
+        }
+        [$email, $expiry, $nonce] = $casti;
+
+        if (! ctype_digit($expiry) || (int) $expiry < time()) {
+            return null;
+        }
+        if ($email === '' || $nonce === '') {
+            return null;
+        }
+
+        return new OvereneSso($email, $nonce);
+    }
+
+    private static function base64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private static function base64UrlDekoduj(string $data): ?string
+    {
+        $dekodovano = base64_decode(strtr($data, '-_', '+/'), true);
+
+        return $dekodovano === false ? null : $dekodovano;
+    }
+}

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -9,11 +9,16 @@ namespace Gamecon\Dev;
  * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
  * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
  * odkaz klikl).
+ *
+ * Identitu nese {@see self::$idUzivatele} — číselné `id_uzivatele`, ne e-mail.
+ * ID je napříč ostrou i zmrazenými archivními snapshoty téhož kontinuálního
+ * `uzivatele` stabilní; e-mail je proměnný a může se mezi ročníky přiřadit jinému
+ * člověku, takže by se podle něj dalo přihlásit do cizího účtu.
  */
 final readonly class OvereneSso
 {
     public function __construct(
-        public string $email,
+        public int $idUzivatele,
         public string $nonce,
     ) {
     }

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřený obsah `?gcsso=` tokenu — výsledek {@see CrossSiteLogin::over}.
+ * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
+ * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
+ * odkaz klikl).
+ */
+final readonly class OvereneSso
+{
+    public function __construct(
+        public string $email,
+        public string $nonce,
+    ) {
+    }
+}

--- a/model/Dev/SsoParovaciCookie.php
+++ b/model/Dev/SsoParovaciCookie.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Dev;
+
+/**
+ * Spárovací cookie pro magické přihlášení do archivu ({@see CrossSiteLogin}).
+ *
+ * Drží náhodný nonce a je scope `.gamecon.cz`, aby ji prohlížeč automaticky poslal
+ * i na `NNNN.gamecon.cz`. NENÍ to přihlášení — sama o sobě nikoho nepřihlásí; je to
+ * jen „důkaz stejného prohlížeče": archiv přihlásí jen když se nonce z této cookie
+ * shoduje s nonce zapečeným v podepsaném `?gcsso=` tokenu. Sdílená URL v cizím
+ * prohlížeči tuhle cookie nemá → mismatch → nepřihlásí. Produkce ani archiv tuhle
+ * cookie nečtou nikde jinde než v ověření SSO, takže její únik sám o sobě nic nedá.
+ *
+ * Scope `.gamecon.cz` je záměrně širší než host-scoped JWT cookie (viz
+ * nastaveni/jwt-bridge.php) — ale na rozdíl od ní nenese identitu.
+ */
+final class SsoParovaciCookie
+{
+    public const JMENO = 'gc_sso_pair';
+
+    /**
+     * O něco déle než TTL tokenu ({@see CrossSiteLogin::TTL_SEKUND}), aby cookie
+     * přežila proklik přes bránu i případné přesměrování a token nikdy nevypršel
+     * „dřív" než jeho párovací polovina.
+     */
+    public const TTL_SEKUND = 10 * 60;
+
+    /**
+     * Nastaví spárovací cookie s daným nonce. Scope `.gamecon.cz` (aby dorazila i
+     * na archiv), HttpOnly, SameSite=Lax (musí přijít při top-level navigaci na
+     * archiv), Secure jen po HTTPS. Mimo gamecon.cz (lokál, preview na jiném hostu)
+     * spadne na host-only cookie — feature stejně cílí jen na ostré subdomény.
+     */
+    public static function nastav(string $nonce): void
+    {
+        setcookie(self::JMENO, $nonce, [
+            'expires'  => time() + self::TTL_SEKUND,
+            'path'     => '/',
+            'domain'   => self::cookieDomena(),
+            'secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    }
+
+    /**
+     * `.gamecon.cz` na produkčních subdoménách (sdílí se napříč admin/archiv),
+     * jinak prázdno = host-only (prohlížeč jinak širší doménu odmítne).
+     */
+    private static function cookieDomena(): string
+    {
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        // Odřízneme případný port.
+        $host = explode(':', $host, 2)[0];
+
+        return str_ends_with($host, 'gamecon.cz') ? '.gamecon.cz' : '';
+    }
+
+    public static function precti(): ?string
+    {
+        $nonce = $_COOKIE[self::JMENO] ?? null;
+
+        return is_string($nonce) && $nonce !== '' ? $nonce : null;
+    }
+}

--- a/nastaveni/nastaveni-produkce.php
+++ b/nastaveni/nastaveni-produkce.php
@@ -54,3 +54,11 @@ if (!defined('FTP_ZALOHA_DB')) define('FTP_ZALOHA_DB', '');
 // standard dummy from nastaveni-local-default.php.
 if (!defined('SECRET_CRYPTO_KEY')) define('SECRET_CRYPTO_KEY', getenv('SECRET_CRYPTO_KEY')
     ?: 'def0000066cba9ae32fdda839a143276cc0646b3880920c93876ecc1bbaca96ee6ed251559516b1804f4742c2165e4c7eb3ed5c7a5abe857c6db8608e3b5fe97a8cdf15a');
+
+// GAMECON_SSO_KEY — klíč pro ověření magického přihlášení (?gcsso=), odvozený pro
+// tento ročník (HMAC(rok, master)) a vstříknutý deployem přes -e. Tenhle (commitnutý)
+// nastaveni-produkce.php je na archivu reálně načítaný soubor — bake přes
+// skryte-nastaveni-z-env-funkce.php se neprovede, protože tenhle soubor už existuje.
+// Proto se getenv('GAMECON_SSO_KEY') musí číst právě TADY, jinak konstanta zůstane
+// nedefinovaná a SSO se neuplatní. Prázdný fallback = SSO vypnuté.
+if (!defined('GAMECON_SSO_KEY')) define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');


### PR DESCRIPTION
Ports the cross-site magic-login consume handler onto `archive/2018`, mirroring the working `archive/2025` / `archive/2024` implementation.

When a logged-in admin clicks the 2018 `/admin` link in `admin.gamecon.cz/web/stare-rocniky`, and the same person (matched by e-mail) has an account in the 2018 DB, they're auto-logged-in. A shared link still only passes basic auth — the `gc_sso_pair` pairing cookie proves it's the browser that clicked.

**Changes**
- `model/Dev/{OvereneSso,CrossSiteLogin,SsoParovaciCookie,ArchivSsoPrihlaseni}.php` — loaded via `require_once` (no autoload dependency). `ArchivSsoPrihlaseni` resolves e-mail→id via direct `uzivatele_hodnoty` query, then `Uzivatel::prihlasId`.
- `admin/scripts/prihlaseni.php` — consume block after the `Uzivatel::zSession()` anchor; silent fallback to normal login on any failure.
- `nastaveni/nastaveni-produkce.php` — reads `getenv('GAMECON_SSO_KEY')` (per-year derived key injected by the archive deploy).

**Merging this PR auto-deploys the 2018 archive.** `php -l` clean on all touched files; key injection is already year-generic in ansible.