### PR TITLE
Sign archive SSO token with user ID, not email

### DIFF
--- a/admin/scripts/modules/web/stare-rocniky.php
+++ b/admin/scripts/modules/web/stare-rocniky.php
@@ -43,20 +43,23 @@ $gateUrl = static fn (string $url): string => GateLink::podepis($url, ARCHIVE_GA
 // do toho jednoho ročníku, ne do ostatních a hlavně NE k SECRET_CRYPTO_KEY (ten šifruje
 // osobní data na ostré a do archivů nepatří). Odvození je shodné s bash stranou v
 // deploy-year-archive.sh (openssl dgst -sha256 -hmac).
+// Token nese ČÍSELNÉ id_uzivatele, ne e-mail: ID je napříč ostrou i zmrazenými
+// archivními snapshoty stabilní, kdežto e-mail je proměnný a mohl by se časem
+// přiřadit jinému člověku (→ přihlášení do cizího účtu).
 $ssoMaster = defined('GAMECON_SSO_SECRET') ? GAMECON_SSO_SECRET : '';
 $ssoNonce = null;
-$ssoEmail = $u->mail() ?? '';
-if ($ssoEmail !== '' && $ssoMaster !== '') {
+$ssoIdUzivatele = $u->id() ?? 0;
+if ($ssoIdUzivatele > 0 && $ssoMaster !== '') {
     // Kryptograficky náhodný nonce (128 bitů). Ne randHex() — ta stropuje na 32
     // znaků a stojí na substr(md5(mt_rand())), což má slabou entropii; tady jde
     // o bezpečnostní párovací token, tak chceme random_bytes.
     $ssoNonce = bin2hex(random_bytes(16));
     SsoParovaciCookie::nastav($ssoNonce);
 }
-$adminUrlSeSso = static function (string $adminUrl, int $rocnik) use ($ssoNonce, $ssoEmail, $ssoMaster, $gateUrl): string {
+$adminUrlSeSso = static function (string $adminUrl, int $rocnik) use ($ssoNonce, $ssoIdUzivatele, $ssoMaster, $gateUrl): string {
     if ($ssoNonce !== null) {
         $klicRocniku = hash_hmac('sha256', (string) $rocnik, $ssoMaster);
-        $gcsso = CrossSiteLogin::podepis($ssoEmail, $ssoNonce, $klicRocniku);
+        $gcsso = CrossSiteLogin::podepis($ssoIdUzivatele, $ssoNonce, $klicRocniku);
         if ($gcsso !== '') {
             $oddelovac = str_contains($adminUrl, '?') ? '&' : '?';
             $adminUrl .= $oddelovac . 'gcsso=' . $gcsso;

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -6,8 +6,14 @@ namespace Gamecon\Dev;
 
 /**
  * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
- * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě, aby je
- * sdílel procedurální admin/scripts/prihlaseni.php i test.
+ * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě.
+ *
+ * Identita = číselné `id_uzivatele` z tokenu (ne e-mail — ten je proměnný a mohl by
+ * mířit na cizí účet). ID je napříč ostrou i archivními snapshoty stabilní. Ověříme
+ * jen, že takový uživatel v TÉHLE archivní DB existuje (kdo v daném ročníku ještě
+ * účet neměl, se nenajde → nepřihlásí), a přihlásíme přes Uzivatel::prihlasId
+ * (přítomné všude). Přímý dotaz místo Uzivatel::zId, který ve starších ročnících
+ * nemusí existovat.
  *
  * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
  * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
@@ -25,8 +31,8 @@ final class ArchivSsoPrihlaseni
      *
      * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
      * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
-     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím
-     * e-mailem v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím ID
+     * v téhle DB máme. Jinak vrací beze změny (tiché selhání).
      *
      * @param string         $token         hodnota `?gcsso=` z URL
      * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
@@ -52,11 +58,14 @@ final class ArchivSsoPrihlaseni
             return null;
         }
 
-        $uzivatel = \Uzivatel::zEmailu($overene->email);
-        if ($uzivatel === null) {
+        $idVDb = dbOneCol(
+            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE id_uzivatele = $0',
+            [$overene->idUzivatele],
+        );
+        if ($idVDb === null) {
             return null;
         }
 
-        return \Uzivatel::prihlasId($uzivatel->id());
+        return \Uzivatel::prihlasId((int) $idVDb);
     }
 }

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -6,10 +6,14 @@ namespace Gamecon\Dev;
 
 /**
  * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
- * token vázaný na e-mail přihlášeného uživatele, archiv (NNNN.gamecon.cz) ho ověří
- * a uživatele podle e-mailu přihlásí — bez zadávání hesla.
+ * token vázaný na `id_uzivatele` přihlášeného uživatele, archiv (NNNN.gamecon.cz)
+ * ho ověří a uživatele podle ID přihlásí — bez zadávání hesla.
  *
- * Token nese jen IDENTITU (e-mail) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * Identitu nese ČÍSELNÉ ID, ne e-mail: ID je napříč ostrou i zmrazenými archivními
+ * snapshoty téhož kontinuálního `uzivatele` stabilní, kdežto e-mail je proměnný a
+ * může se časem přiřadit jinému člověku (→ přihlášení do cizího účtu).
+ *
+ * Token nese jen IDENTITU (ID) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
  * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
  * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
  * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
@@ -17,16 +21,17 @@ namespace Gamecon\Dev;
  * nemá → nepřihlásí. Viz {@see GateLink} (ten řeší jen průchod bránou,
  * ne přihlášení) a admin/scripts/prihlaseni.php (ověřovací strana).
  *
- * Podpis stojí na `SECRET_CRYPTO_KEY`, který je BAJTOVĚ STEJNÝ na ostré i ve všech
- * archivních images (viz audit v CLAUDE.md) — archiv tak umí ověřit, co hlavní admin
- * podepsal, bez zavádění nového tajemství.
+ * Podpis stojí na klíči ODVOZENÉM PRO DANÝ ROČNÍK z master tajemství
+ * (`hash_hmac('sha256', (string) $rocnik, GAMECON_SSO_SECRET)`); master žije jen na
+ * ostré, archiv dostane jen svůj odvozený klíč přes `-e GAMECON_SSO_KEY`. NE
+ * `SECRET_CRYPTO_KEY` — ten šifruje osobní data a do zmrazeného archivu nepatří.
  *
  * Formát tokenu (`?gcsso=`):
  *
- *     gcsso = base64url(email "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *     gcsso = base64url(id "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
  *
- * `expiry` jsou ASCII číslice unixového času; HMAC se počítá nad celým payloadem
- * (e-mail|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ * `id` i `expiry` jsou ASCII číslice; HMAC se počítá nad celým payloadem
+ * (id|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
  *
  * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
  * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
@@ -43,12 +48,12 @@ final class CrossSiteLogin
     private const ODDELOVAC_PAYLOADU = '|';
 
     /**
-     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro daný
-     * e-mail a nonce. Prázdný řetězec, pokud secret není nastavený — volající pak
-     * `?gcsso=` nepřipojuje.
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro dané
+     * `id_uzivatele` a nonce. Prázdný řetězec, pokud secret není nastavený — volající
+     * pak `?gcsso=` nepřipojuje.
      */
     public static function podepis(
-        string $email,
+        int $idUzivatele,
         string $nonce,
         string $secret,
         ?int $ted = null,
@@ -58,15 +63,15 @@ final class CrossSiteLogin
         }
 
         $expiry = (string) (($ted ?? time()) + self::TTL_SEKUND);
-        $payload = $email . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $payload = $idUzivatele . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
         $podpis = hash_hmac('sha256', $payload, $secret, true);
 
         return self::base64Url($payload) . '.' . self::base64Url($podpis);
     }
 
     /**
-     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřený e-mail +
-     * nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřené `id_uzivatele`
+     * + nonce, nebo null při jakékoli nesrovnalosti (špatný formát, neplatný podpis,
      * vypršení). Shodu nonce s cookie kontroluje volající.
      */
     public static function over(string $token, string $secret): ?OvereneSso
@@ -94,16 +99,16 @@ final class CrossSiteLogin
         if (count($casti) !== 3) {
             return null;
         }
-        [$email, $expiry, $nonce] = $casti;
+        [$idUzivatele, $expiry, $nonce] = $casti;
 
         if (! ctype_digit($expiry) || (int) $expiry < time()) {
             return null;
         }
-        if ($email === '' || $nonce === '') {
+        if (! ctype_digit($idUzivatele) || (int) $idUzivatele <= 0 || $nonce === '') {
             return null;
         }
 
-        return new OvereneSso($email, $nonce);
+        return new OvereneSso((int) $idUzivatele, $nonce);
     }
 
     private static function base64Url(string $data): string

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -9,11 +9,16 @@ namespace Gamecon\Dev;
  * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
  * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
  * odkaz klikl).
+ *
+ * Identitu nese {@see self::$idUzivatele} — číselné `id_uzivatele`, ne e-mail.
+ * ID je napříč ostrou i zmrazenými archivními snapshoty téhož kontinuálního
+ * `uzivatele` stabilní; e-mail je proměnný a může se mezi ročníky přiřadit jinému
+ * člověku, takže by se podle něj dalo přihlásit do cizího účtu.
  */
 final readonly class OvereneSso
 {
     public function __construct(
-        public string $email,
+        public int $idUzivatele,
         public string $nonce,
     ) {
     }

--- a/tests/Dev/ArchivSsoPrihlaseniTest.php
+++ b/tests/Dev/ArchivSsoPrihlaseniTest.php
@@ -29,7 +29,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
     public function testPlatnyTokenSeShodnymNoncePrihlasiUzivatele(): void
     {
         $uzivatel = self::prihlasenyUzivatel();
-        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+        $token = CrossSiteLogin::podepis($uzivatel->id(), self::NONCE, self::SECRET);
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
 
@@ -45,7 +45,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
     {
         $uzivatel = self::prihlasenyUzivatel();
         // Token nese self::NONCE, ale cookie přinese jiný → mismatch.
-        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+        $token = CrossSiteLogin::podepis($uzivatel->id(), self::NONCE, self::SECRET);
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, 'jiny-nonce', null);
 
@@ -56,7 +56,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
     public function testChybejiciCookieNonceNeprihlasi(): void
     {
         $uzivatel = self::prihlasenyUzivatel();
-        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET);
+        $token = CrossSiteLogin::podepis($uzivatel->id(), self::NONCE, self::SECRET);
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, null, null);
 
@@ -64,10 +64,11 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
         self::assertNull(\Uzivatel::zSession());
     }
 
-    public function testNeznamyEmailNeprihlasi(): void
+    public function testNeznameIdNeprihlasi(): void
     {
-        // Platný token + shodný nonce, ale e-mail v téhle DB neexistuje.
-        $token = CrossSiteLogin::podepis('nikdo-takovy@nikde.cz', self::NONCE, self::SECRET);
+        // Platný token + shodný nonce, ale uživatel s tím ID v téhle DB neexistuje
+        // (např. v daném ročníku ještě účet neměl). 2_000_000_000 je mimo rozsah.
+        $token = CrossSiteLogin::podepis(2_000_000_000, self::NONCE, self::SECRET);
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
 
@@ -79,7 +80,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
     {
         $uzivatel = self::prihlasenyUzivatel();
         // Token podepsaný JINÝM secretem než kterým ho ověřujeme.
-        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, 'utocnikuv-secret');
+        $token = CrossSiteLogin::podepis($uzivatel->id(), self::NONCE, 'utocnikuv-secret');
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
 
@@ -92,7 +93,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
         $puvodni = self::prihlasenyUzivatel();
         $jiny = self::prihlasenyUzivatel();
         // Token by přihlásil $jiny, ale $puvodni už je přihlášený → nepřepisujeme.
-        $token = CrossSiteLogin::podepis($jiny->mail(), self::NONCE, self::SECRET);
+        $token = CrossSiteLogin::podepis($jiny->id(), self::NONCE, self::SECRET);
 
         $vysledek = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, $puvodni);
 
@@ -105,7 +106,7 @@ class ArchivSsoPrihlaseniTest extends AbstractUzivatelTestDb
     {
         $uzivatel = self::prihlasenyUzivatel();
         // Podpis „v minulosti": expiry = TED + TTL je pořád před teď.
-        $token = CrossSiteLogin::podepis($uzivatel->mail(), self::NONCE, self::SECRET, 1_700_000_000);
+        $token = CrossSiteLogin::podepis($uzivatel->id(), self::NONCE, self::SECRET, 1_700_000_000);
 
         $prihlaseny = (new ArchivSsoPrihlaseni(self::SECRET))->prihlas($token, self::NONCE, null);
 

--- a/tests/Dev/CrossSiteLoginTest.php
+++ b/tests/Dev/CrossSiteLoginTest.php
@@ -11,33 +11,34 @@ class CrossSiteLoginTest extends TestCase
 {
     private const SECRET = 'test-secret-do-not-use-in-prod';
     private const TED = 1_700_000_000;
+    private const ID = 12345;
 
     public function testPrazdnySecretNepodepisuje(): void
     {
-        self::assertSame('', CrossSiteLogin::podepis('a@b.cz', 'nonce', '', self::TED));
+        self::assertSame('', CrossSiteLogin::podepis(self::ID, 'nonce', '', self::TED));
     }
 
     public function testPrazdnySecretNeoveruje(): void
     {
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', self::SECRET, self::TED);
         self::assertNull(CrossSiteLogin::over($token, ''));
     }
 
-    public function testRoundTripVratiStejnyEmailANonce(): void
+    public function testRoundTripVratiStejneIdANonce(): void
     {
         // Bez explicitního času → expiry = now + TTL, tedy v budoucnosti (over()
         // odmítá vypršelé tokeny, viz testVyprsenyTokenNeprojde).
-        $token = CrossSiteLogin::podepis('admin@gamecon.cz', 'nonce-123', self::SECRET);
+        $token = CrossSiteLogin::podepis(777, 'nonce-123', self::SECRET);
         $overene = CrossSiteLogin::over($token, self::SECRET);
 
         self::assertNotNull($overene);
-        self::assertSame('admin@gamecon.cz', $overene->email);
+        self::assertSame(777, $overene->idUzivatele);
         self::assertSame('nonce-123', $overene->nonce);
     }
 
     public function testTokenMaTvarPayloadTeckaPodpisBezPaddingu(): void
     {
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', self::SECRET, self::TED);
 
         self::assertStringContainsString('.', $token);
         // base64url: žádné +, /, ani = padding.
@@ -46,7 +47,7 @@ class CrossSiteLoginTest extends TestCase
 
     public function testZmenenyPodpisNeprojde(): void
     {
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', self::SECRET, self::TED);
         [$payload, $podpis] = explode('.', $token, 2);
         // Otočíme první znak podpisu na jiný (stejně dlouhý) řetězec.
         $rozbity = $payload . '.' . ($podpis[0] === 'A' ? 'B' : 'A') . substr($podpis, 1);
@@ -54,12 +55,12 @@ class CrossSiteLoginTest extends TestCase
         self::assertNull(CrossSiteLogin::over($rozbity, self::SECRET));
     }
 
-    public function testZmenenyEmailVPayloaduNeprojde(): void
+    public function testZmeneneIdVPayloaduNeprojde(): void
     {
-        // Útočník chce přihlášení jako admin@gamecon.cz, ale podpis sedí na evil@x.cz.
-        $token = CrossSiteLogin::podepis('evil@x.cz', 'nonce', self::SECRET, self::TED);
+        // Útočník chce přihlášení jako uživatel 1 (admin), ale podpis sedí na ID 9999.
+        $token = CrossSiteLogin::podepis(9999, 'nonce', self::SECRET, self::TED);
         [, $podpis] = explode('.', $token, 2);
-        $podvrzenyPayload = rtrim(strtr(base64_encode('admin@gamecon.cz|' . (self::TED + 60) . '|nonce'), '+/', '-_'), '=');
+        $podvrzenyPayload = rtrim(strtr(base64_encode('1|' . (self::TED + 60) . '|nonce'), '+/', '-_'), '=');
 
         self::assertNull(CrossSiteLogin::over($podvrzenyPayload . '.' . $podpis, self::SECRET));
     }
@@ -67,19 +68,19 @@ class CrossSiteLoginTest extends TestCase
     public function testVyprsenyTokenNeprojde(): void
     {
         // Podepíšeme „v minulosti": expiry = TED + TTL je pořád před aktuálním časem.
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET, self::TED);
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', self::SECRET, self::TED);
         self::assertNull(CrossSiteLogin::over($token, self::SECRET));
     }
 
     public function testCerstvyTokenProjde(): void
     {
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', self::SECRET); // ted() = now
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', self::SECRET); // ted() = now
         self::assertNotNull(CrossSiteLogin::over($token, self::SECRET));
     }
 
     public function testJinySecretNeoveri(): void
     {
-        $token = CrossSiteLogin::podepis('a@b.cz', 'nonce', 'secret-a');
+        $token = CrossSiteLogin::podepis(self::ID, 'nonce', 'secret-a');
         self::assertNull(CrossSiteLogin::over($token, 'secret-b'));
     }
 
@@ -92,7 +93,7 @@ class CrossSiteLoginTest extends TestCase
         $klic2025 = hash_hmac('sha256', '2025', $master);
         $klic2024 = hash_hmac('sha256', '2024', $master);
 
-        $token2025 = CrossSiteLogin::podepis('admin@gamecon.cz', 'nonce', $klic2025);
+        $token2025 = CrossSiteLogin::podepis(self::ID, 'nonce', $klic2025);
 
         self::assertNotNull(CrossSiteLogin::over($token2025, $klic2025), 'vlastní ročník projde');
         self::assertNull(CrossSiteLogin::over($token2025, $klic2024), 'cizí ročník neprojde');
@@ -105,29 +106,41 @@ class CrossSiteLoginTest extends TestCase
         self::assertNull(CrossSiteLogin::over('....', self::SECRET));
     }
 
+    public function testNeciselneIdVPayloaduNeprojde(): void
+    {
+        // payload musí nést ID jako číslice; podvržené ne-číselné ID (i s platným
+        // podpisem) over() odmítne.
+        $payload = 'neni-cislo|' . (time() + 60) . '|nonce';
+        $payloadKodovany = rtrim(strtr(base64_encode($payload), '+/', '-_'), '=');
+        $podpis = rtrim(strtr(base64_encode(hash_hmac('sha256', $payload, self::SECRET, true)), '+/', '-_'), '=');
+
+        self::assertNull(CrossSiteLogin::over($payloadKodovany . '.' . $podpis, self::SECRET));
+    }
+
     public function testTokenZUrlSeDaOveritZpet(): void
     {
         // Mint přesně jako stare-rocniky.php: ?gcsso= připojené k /admin URL,
         // pak ho consume strana vytáhne z query a ověří.
         $nonce = 'parovaci-nonce-xyz';
-        $gcsso = CrossSiteLogin::podepis('admin@gamecon.cz', $nonce, self::SECRET);
+        $gcsso = CrossSiteLogin::podepis(42, $nonce, self::SECRET);
         $adminUrl = 'https://2021.gamecon.cz/admin?gcsso=' . $gcsso;
 
         parse_str((string) parse_url($adminUrl, PHP_URL_QUERY), $params);
         $overene = CrossSiteLogin::over($params['gcsso'], self::SECRET);
 
         self::assertNotNull($overene);
-        self::assertSame('admin@gamecon.cz', $overene->email);
+        self::assertSame(42, $overene->idUzivatele);
         self::assertSame($nonce, $overene->nonce);
     }
 
-    public function testEmailSOddelovacemSeNepoplete(): void
+    public function testPayloadSeCtyrmiCastmiNeprojde(): void
     {
-        // E-mail nesmí obsahovat '|', ale ověřme, že rozparsování je striktní na 3 části:
-        // payload se třemi '|' (4 částmi) musí selhat, ne se tiše ořezat.
-        $payload = rtrim(strtr(base64_encode('a@b.cz|x|' . (time() + 60) . '|nonce'), '+/', '-_'), '=');
-        $podpis = rtrim(strtr(base64_encode(hash_hmac('sha256', base64_decode(strtr($payload, '-_', '+/'), true), self::SECRET, true)), '+/', '-_'), '=');
+        // Rozparsování je striktní na 3 části: payload se čtyřmi částmi musí selhat,
+        // ne se tiše ořezat.
+        $payload = '42|x|' . (time() + 60) . '|nonce';
+        $payloadKodovany = rtrim(strtr(base64_encode($payload), '+/', '-_'), '=');
+        $podpis = rtrim(strtr(base64_encode(hash_hmac('sha256', $payload, self::SECRET, true)), '+/', '-_'), '=');
 
-        self::assertNull(CrossSiteLogin::over($payload . '.' . $podpis, self::SECRET));
+        self::assertNull(CrossSiteLogin::over($payloadKodovany . '.' . $podpis, self::SECRET));
     }
 }


### PR DESCRIPTION
The cross-site magic-login token (`?gcsso=`) carried the user's **email**, and the archive resolved email→`id_uzivatele` to log them in. Email is mutable and can be reassigned to a different person between years, so a stale/reused address could log the clicker into the wrong account.

Switches the token to carry the **numeric `id_uzivatele`** instead — stable across prod and every frozen archive snapshot of the one continuous `uzivatele` table.

**Changes**
- `model/Dev/CrossSiteLogin.php` — `podepis(int $idUzivatele, …)`; `over()` parses/validates a digit ID and returns it.
- `model/Dev/OvereneSso.php` — `$email` → `int $idUzivatele`.
- `model/Dev/ArchivSsoPrihlaseni.php` — verifies the ID exists in this archive's DB (`WHERE id_uzivatele = …`; a user who had no account that year simply isn't found) then `Uzivatel::prihlasId`. No email lookup.
- `admin/scripts/modules/web/stare-rocniky.php` (mint) — signs `$u->id()` instead of `$u->mail()`.
- Tests updated to ID-based; **21 tests / 59 assertions green** (14 unit + 7 integration).

The 9 archive-port PRs (#925-#932 + 2015/2016) will be updated to match before merge.