### PR TITLE
Add magic-login /admin link to previews list

### DIFF
--- a/admin/scripts/modules/web/previews.php
+++ b/admin/scripts/modules/web/previews.php
@@ -1,7 +1,9 @@
 <?php
 
+use Gamecon\Dev\CrossSiteLogin;
 use Gamecon\Dev\DeploymentsReader;
 use Gamecon\Dev\GateLink;
+use Gamecon\Dev\SsoParovaciCookie;
 
 /**
  * Seznam aktivních preview prostředí.
@@ -21,6 +23,40 @@ $previews = $unavailableReason === null ? $reader->readPreviews() : [];
 // není nastavený, brána spadne na basic auth — proto údaje ukazujeme jako
 // kopírovatelný text. Viz GateLink + ansible role gate_validator.
 $gateUrl = static fn (string $url): string => GateLink::podepis($url, PREVIEW_GATE_SECRET);
+
+// Magické přihlášení do preview adminu: k odkazu na /admin připojíme podepsaný
+// ?gcsso= token vázaný na id_uzivatele přihlášeného admina + náhodný nonce, který
+// zároveň uložíme do spárovací cookie (.gamecon.cz). Preview pak admina přihlásí
+// podle ID — ale jen když nonce z tokenu sedí s nonce z cookie, takže pouhé sdílení
+// odkazu nikoho nepřihlásí (cizí prohlížeč cookie nemá). Bez masteru / ID se token
+// nepřipojí a zůstane jen basic-auth brána.
+//
+// Na rozdíl od archivů (ty ověřují klíčem ODVOZENÝM pro daný ročník) preview
+// podepisuje i ověřuje přímo MASTEREM GAMECON_SSO_SECRET: preview není ročník v
+// rámci fan-outu, je to jedno samostatné prostředí, které přihlašuje samo sebe —
+// žádné odvození per-prostředí netřeba. Master se do preview dostává přes
+// deploy-preview-branch.sh (-e GAMECON_SSO_SECRET); ověřovací stranu viz
+// admin/scripts/prihlaseni.php (větev jsmeNaPreview()).
+$ssoMaster = defined('GAMECON_SSO_SECRET') ? GAMECON_SSO_SECRET : '';
+$ssoNonce = null;
+$ssoIdUzivatele = $u->id() ?? 0;
+if ($ssoIdUzivatele > 0 && $ssoMaster !== '') {
+    // Kryptograficky náhodný nonce (128 bitů) — bezpečnostní párovací token.
+    $ssoNonce = bin2hex(random_bytes(16));
+    SsoParovaciCookie::nastav($ssoNonce);
+}
+$adminUrlSeSso = static function (string $previewUrl) use ($ssoNonce, $ssoIdUzivatele, $ssoMaster, $gateUrl): string {
+    $adminUrl = rtrim($previewUrl, '/') . '/admin';
+    if ($ssoNonce !== null) {
+        $gcsso = CrossSiteLogin::podepis($ssoIdUzivatele, $ssoNonce, $ssoMaster);
+        if ($gcsso !== '') {
+            $oddelovac = str_contains($adminUrl, '?') ? '&' : '?';
+            $adminUrl .= $oddelovac . 'gcsso=' . $gcsso;
+        }
+    }
+
+    return $gateUrl($adminUrl);
+};
 
 $mailpitUrl = $gateUrl('https://webmail.preview.gamecon.cz/');
 
@@ -60,6 +96,7 @@ $prListUrl = static fn (string $ref): string => 'https://github.com/gamecon-cz/g
         <thead>
             <tr>
                 <th>URL</th>
+                <th>Admin</th>
                 <th>PR</th>
                 <th>Deployed</th>
             </tr>
@@ -71,6 +108,9 @@ $prListUrl = static fn (string $ref): string => 'https://github.com/gamecon-cz/g
                     <a href="<?php echo htmlspecialchars($gateUrl($preview->url)); ?>" target="_blank" rel="noopener">
                         <?php echo htmlspecialchars(preg_replace('/^https?:\/\/|\/$/', '', $preview->url)); ?>
                     </a>
+                </td>
+                <td>
+                    <a href="<?php echo htmlspecialchars($adminUrlSeSso($preview->url)); ?>" target="_blank" rel="noopener">/admin</a>
                 </td>
                 <td>
                     <?php $prRef = $preview->branch ?? $preview->slug; ?>

--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 use Gamecon\Dev\ArchivSsoPrihlaseni;
 use Gamecon\Dev\SsoParovaciCookie;
-use Gamecon\Login\Login;
 use Gamecon\Exceptions\UzivatelNenalezen;
+use Gamecon\Login\Login;
 use Gamecon\Pravo;
 
-/**
+/*
  * Kód starající o přihlášení uživatele a výběr uživatele pro práci
  */
-if (!empty($_GET['update_code'])) {
+if (! empty($_GET['update_code'])) {
     exec('git pull 2>&1', $output, $returnValue);
     print_r($output);
     exit($returnValue);
@@ -18,27 +20,37 @@ if (!empty($_GET['update_code'])) {
 $u = null;
 if (post(Login::LOGIN_INPUT_NAME) && post(Login::PASSWORD_INPUT_NAME)) {
     $pravePrihlaseny = Uzivatel::prihlas(post(Login::LOGIN_INPUT_NAME), post(Login::PASSWORD_INPUT_NAME));
-    if (!$pravePrihlaseny) {
-        chyba("Chybné přihlašovací jméno nebo heslo");
+    if (! $pravePrihlaseny) {
+        chyba('Chybné přihlašovací jméno nebo heslo');
     }
     back();
 }
 $u = Uzivatel::zSession();
 
-// Magické přihlášení z administračního rozcestníku na ostré (?gcsso= token).
-// Hlavní admin podepsal token na e-mail klikajícího uživatele + nonce a uložil
-// stejný nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě
-// nikdo není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný,
-// nonce z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená
-// URL nestačí) a uživatele s tím e-mailem máme v téhle DB. Jakékoli selhání je
-// tiché: token z URL odstraníme a necháme doběhnout běžné přihlášení. Pravidla
-// rozhodnutí drží ArchivSsoPrihlaseni (sdílí je s testem). Ověřujeme klíčem
-// GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník (HMAC(rok, master)), který archivu
-// vstříkne deploy přes -e. Na ostré je prázdný (master se k odvození nepoužívá pro
-// vlastní login), takže se tu SSO nikdy neuplatní — což je správně.
-// Viz ArchivSsoPrihlaseni + SsoParovaciCookie + admin/scripts/modules/web/stare-rocniky.php.
+// Magické přihlášení z administračního rozcestníku (?gcsso= token).
+// Rozcestník podepsal token na id_uzivatele klikajícího + nonce a uložil stejný
+// nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě nikdo
+// není přihlášený (cizí sezení nepřepisujeme), token je platný, nonce z tokenu
+// sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená URL nestačí) a
+// uživatele s tím ID v téhle DB máme. Jakékoli selhání je tiché: token z URL
+// odstraníme a necháme doběhnout běžné přihlášení. Pravidla drží ArchivSsoPrihlaseni
+// (sdílí je s testem).
+//
+// Volba ověřovacího klíče podle prostředí:
+//   - Archiv ročníku: GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník
+//     (HMAC(rok, master)), vstříknutý deployem přes -e. Master tu není.
+//   - Preview: GAMECON_SSO_KEY prázdný, ale preview má rovnou master
+//     GAMECON_SSO_SECRET (viz deploy-preview-branch.sh) — preview podepisuje i
+//     ověřuje sám sebe, takže ověřujeme přímo masterem.
+//   - Ostrá: master sice má (kvůli mintování odkazů do archivů/preview), ale
+//     NENÍ preview → master k ověření tady nepoužijeme, takže se na ostré SSO
+//     login nikdy neuplatní (jsi tu už přihlášený) — což je správně.
+// Viz ArchivSsoPrihlaseni + SsoParovaciCookie + admin/scripts/modules/web/{stare-rocniky,previews}.php.
 if (($gcsso = get('gcsso')) !== null) {
     $ssoKlic = defined('GAMECON_SSO_KEY') ? GAMECON_SSO_KEY : '';
+    if ($ssoKlic === '' && jsmeNaPreview() && defined('GAMECON_SSO_SECRET')) {
+        $ssoKlic = GAMECON_SSO_SECRET;
+    }
     $u = (new ArchivSsoPrihlaseni($ssoKlic))->prihlas(
         (string) $gcsso,
         SsoParovaciCookie::precti(),
@@ -61,7 +73,7 @@ $uPracovni = null;
 
 $ulozPredchozihoUzivatele = function (int $id) {
     $historie = $_SESSION['pracovni_uzivatel_predchozi'] ?? [];
-    if (!is_array($historie)) {
+    if (! is_array($historie)) {
         $historie = $historie ? [$historie] : [];
     }
     if (($historie[0] ?? null) !== $id) {
@@ -72,7 +84,7 @@ $ulozPredchozihoUzivatele = function (int $id) {
 
 if (post('vybratUzivateleProPraci')) {
     $idAktualniho = $_SESSION[Uzivatel::UZIVATEL_PRACOVNI]['id_uzivatele'] ?? null;
-    if ($idAktualniho && $idAktualniho != (int)post('id')) {
+    if ($idAktualniho && $idAktualniho !== (int) post('id')) {
         $ulozPredchozihoUzivatele($idAktualniho);
     }
     $uPracovni = Uzivatel::prihlasId(post('id'), Uzivatel::UZIVATEL_PRACOVNI);
@@ -80,13 +92,15 @@ if (post('vybratUzivateleProPraci')) {
 }
 
 if ($idPracovnihoUzivatele = get('pracovni_uzivatel')) {
-    if (!$uPracovni || $uPracovni->id() != $idPracovnihoUzivatele) {
+    if (! $uPracovni || $uPracovni->id() !== $idPracovnihoUzivatele) {
         $idAktualniho = $_SESSION[Uzivatel::UZIVATEL_PRACOVNI]['id_uzivatele'] ?? null;
-        if ($idAktualniho && $idAktualniho != (int)$idPracovnihoUzivatele) {
+        if ($idAktualniho && $idAktualniho !== (int) $idPracovnihoUzivatele) {
             $ulozPredchozihoUzivatele($idAktualniho);
         }
         $uPracovni = Uzivatel::prihlasId($idPracovnihoUzivatele, Uzivatel::UZIVATEL_PRACOVNI);
-        back(getCurrentUrlWithQuery(['pracovni_uzivatel' => null]));
+        back(getCurrentUrlWithQuery([
+            'pracovni_uzivatel' => null,
+        ]));
     }
 }
 
@@ -101,7 +115,7 @@ if (post('zrusitUzivateleProPraci')) {
 
 if (post('prihlasitSeJakoUzivatel')) {
     try {
-        if ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || ($u->jeInfopultak())) {
+        if ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || $u->jeInfopultak()) {
             $potencialniUzivatel = Uzivatel::zIdUrcite(post('id'));
             if ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || $potencialniUzivatel->jeVypravec() || $potencialniUzivatel->jePartner()) {
                 $u = Uzivatel::prihlasId(post('id'));


### PR DESCRIPTION
Extends the cross-site magic login (already on the Staré ročníky archive list) to the **Previews** list (`admin/.../web/previews.php`).

Each preview now gets an **Admin** column whose `/admin` link carries a signed `?gcsso=` token + `gc_sso_pair` cookie, so an admin clicking it is auto-logged-in to that preview (matched by stable `id_uzivatele`). Same anti-share guarantee as archives: a shared link without the pairing cookie logs nobody in.

**Key model (differs from archives):** a preview signs AND verifies with the **master `GAMECON_SSO_SECRET`** directly — no per-environment derivation, because a preview is a single self-contained env, not a fan-out of years. Previews receive the master via `docker run -e` (ansible #68).

- **Mint** (`previews.php`): nonce + pairing cookie + `CrossSiteLogin::podepis($u->id(), nonce, master)`, Admin column.
- **Consume** (`prihlaseni.php`): when `GAMECON_SSO_KEY` (the archive's derived key) is empty AND `jsmeNaPreview()`, verify with `GAMECON_SSO_SECRET`. Prod isn't a preview → never auto-logs-in there (correct).

`php -l` + ECS clean. This branch's own preview can verify it end-to-end.