### PR TITLE
Magic login into 2017 archive (PHP 5.6-safe)

### DIFF
--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -11,6 +11,44 @@ if(post('loginNAdm') && post('hesloNAdm')) {
   back();
 }
 $u = Uzivatel::zSession();
+
+// Magické přihlášení z administračního rozcestníku na ostré (?gcsso= token).
+// Hlavní admin podepsal token na id_uzivatele klikajícího + nonce a uložil stejný
+// nonce do spárovací cookie (.gamecon.cz). Přihlásíme jen když: tady ještě nikdo
+// není přihlášený (cizí sezení na archivu nepřepisujeme), token je platný, nonce
+// z tokenu sedí s nonce z cookie (= jde o prohlížeč, který klikl — sdílená URL
+// nestačí) a uživatele s tím ID máme v téhle DB. Jakékoli selhání je tiché: token
+// z URL odstraníme a necháme doběhnout běžné přihlášení. Pravidla drží
+// ArchivSsoPrihlaseni; mintovací strana je na ostré v admin/.../web/stare-rocniky.php.
+// PHP 5.6-kompatibilní (tenhle ročník běží na starším PHP) — require_once místo
+// autoloadu, žádné str_contains / trailing comma / typehinty.
+if (get('gcsso') !== null) {
+    $gcsso = get('gcsso');
+    require_once __DIR__ . '/../../model/Dev/OvereneSso.php';
+    require_once __DIR__ . '/../../model/Dev/CrossSiteLogin.php';
+    require_once __DIR__ . '/../../model/Dev/SsoParovaciCookie.php';
+    require_once __DIR__ . '/../../model/Dev/ArchivSsoPrihlaseni.php';
+
+    // GAMECON_SSO_KEY = klíč odvozený pro TENTO ročník (HMAC(rok, master)), který
+    // archivu vstříkne deploy přes -e. NE SECRET_CRYPTO_KEY. Prázdný → SSO se neuplatní.
+    $ssoKlic = defined('GAMECON_SSO_KEY') ? GAMECON_SSO_KEY : '';
+    $ssoPrihlaseni = new \Gamecon\Dev\ArchivSsoPrihlaseni($ssoKlic);
+    $u = $ssoPrihlaseni->prihlas(
+        (string) $gcsso,
+        \Gamecon\Dev\SsoParovaciCookie::precti(),
+        $u
+    );
+
+    // Token z URL odstraníme (ať nezůstane v historii / referreru). Vlastní
+    // odstranění místo getCurrentUrlWithQuery — ta ve starších ročnících není.
+    $cistaQuery = $_GET;
+    unset($cistaQuery['gcsso']);
+    $cilo = strtok($_SERVER['REQUEST_URI'], '?');
+    if (!empty($cistaQuery)) {
+        $cilo .= '?' . http_build_query($cistaQuery);
+    }
+    back($cilo);
+}
 if(post('odhlasNAdm')) {
   if($u) $u->odhlas();
   back();

--- a/model/Dev/ArchivSsoPrihlaseni.php
+++ b/model/Dev/ArchivSsoPrihlaseni.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřovací (consume) strana magického přihlášení do archivu — rozhoduje, zda
+ * `?gcsso=` token uživatele přihlásí. Drží pravidla na jednom místě.
+ *
+ * Identita = číselné `id_uzivatele` z tokenu (ne e-mail — ten je proměnný a mohl by
+ * mířit na cizí účet). ID je napříč ostrou i archivními snapshoty stabilní. Ověříme
+ * jen, že takový uživatel v TÉHLE archivní DB existuje (kdo v daném ročníku ještě
+ * účet neměl, se nenajde → nepřihlásí), a přihlásíme přes Uzivatel::prihlasId
+ * (přítomné všude). Přímý dotaz místo Uzivatel::zId, který ve starších ročnících
+ * nemusí existovat.
+ *
+ * Nepracuje s HTTP (žádné $_GET/$_COOKIE/redirect) — token i nonce z cookie dostane
+ * předané; volající si pak řeší odstranění parametru z URL. Viz {@see CrossSiteLogin}
+ * (podpis) a {@see SsoParovaciCookie} (spárovací cookie).
+ *
+ * PHP 5.6-kompatibilní varianta (archivní ročníky 2015-2021 běží na PHP 5.6/7.3):
+ * žádné constructor property promotion, readonly, scalar typehinty ani návratové typy.
+ */
+final class ArchivSsoPrihlaseni
+{
+    /** @var string */
+    private $secret;
+
+    public function __construct($secret)
+    {
+        $this->secret = (string) $secret;
+    }
+
+    /**
+     * Přihlásí uživatele podle tokenu, nebo vrátí $jizPrihlaseny beze změny.
+     *
+     * Přihlásí jen když: nikdo tu ještě není přihlášený (cizí sezení na archivu
+     * nepřepisujeme), token je platný, jeho nonce sedí s nonce ze spárovací cookie
+     * (= jde o prohlížeč, který klikl — sdílená URL nestačí) a uživatele s tím ID
+     * v téhle DB máme. Jinak vrací beze změny (tiché selhání).
+     *
+     * @param string         $token         hodnota `?gcsso=` z URL
+     * @param string|null    $nonceZCookie  nonce ze spárovací cookie ({@see SsoParovaciCookie::precti})
+     * @param \Uzivatel|null $jizPrihlaseny uživatel už přihlášený v session, nebo null
+     * @return \Uzivatel|null
+     */
+    public function prihlas($token, $nonceZCookie, $jizPrihlaseny)
+    {
+        if ($jizPrihlaseny !== null) {
+            return $jizPrihlaseny;
+        }
+        if ($nonceZCookie === null) {
+            return null;
+        }
+
+        $overene = CrossSiteLogin::over($token, $this->secret);
+        if ($overene === null) {
+            return null;
+        }
+        if (! hash_equals($overene->nonce, $nonceZCookie)) {
+            return null;
+        }
+
+        $idVDb = dbOneCol(
+            'SELECT id_uzivatele FROM uzivatele_hodnoty WHERE id_uzivatele = $0',
+            array($overene->idUzivatele)
+        );
+        if ($idVDb === null) {
+            return null;
+        }
+
+        return \Uzivatel::prihlasId((int) $idVDb);
+    }
+}

--- a/model/Dev/CrossSiteLogin.php
+++ b/model/Dev/CrossSiteLogin.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Gamecon\Dev;
+
+/**
+ * Magické přihlášení napříč subdoménami: hlavní admin (admin.gamecon.cz) podepíše
+ * token vázaný na `id_uzivatele` přihlášeného uživatele, archiv (NNNN.gamecon.cz)
+ * ho ověří a uživatele podle ID přihlásí — bez zadávání hesla.
+ *
+ * Identitu nese ČÍSELNÉ ID, ne e-mail: ID je napříč ostrou i zmrazenými archivními
+ * snapshoty stabilní, kdežto e-mail je proměnný a může se časem přiřadit jinému
+ * člověku (→ přihlášení do cizího účtu).
+ *
+ * Token nese jen IDENTITU (ID) a NESMÍ sám o sobě nikoho přihlásit: podepsaný
+ * odkaz se může sdílet jako každý jiný. Proto je k němu při ověření vyžadován ještě
+ * spárovaný „nonce", který zná jen prohlížeč, co na odkaz klikl (cookie `gc_sso_pair`
+ * scope `.gamecon.cz`). Token commituje na konkrétní nonce; archiv přihlásí jen když
+ * se nonce z tokenu shoduje s nonce z cookie. Sdílená URL nonce v cizím prohlížeči
+ * nemá → nepřihlásí.
+ *
+ * Podpis stojí na klíči ODVOZENÉM PRO DANÝ ROČNÍK z master tajemství
+ * (`hash_hmac('sha256', (string) $rocnik, GAMECON_SSO_SECRET)`); master žije jen na
+ * ostré, archiv dostane jen svůj odvozený klíč přes `-e GAMECON_SSO_KEY`. NE
+ * `SECRET_CRYPTO_KEY` — ten šifruje osobní data a do zmrazeného archivu nepatří.
+ *
+ * Formát tokenu (`?gcsso=`):
+ *
+ *     gcsso = base64url(id "|" expiry "|" nonce) "." base64url(HMAC_SHA256(payload, secret))
+ *
+ * `id` i `expiry` jsou ASCII číslice; HMAC se počítá nad celým payloadem
+ * (id|expiry|nonce). base64url = RFC 4648 §5 bez `=`.
+ *
+ * Když secret není nastavený (lokální vývoj), {@see self::podepis} vrátí prázdný
+ * řetězec a volající `?gcsso=` nepřipojí — feature je prostě vypnutá.
+ *
+ * PHP 5.6-kompatibilní varianta (archivní ročníky 2015-2021 běží na PHP 5.6/7.3):
+ * žádné scalar typehinty, návratové typy, `??`, `str_contains`, list-destructuring
+ * v hranatých závorkách ani visibility u konstant.
+ */
+final class CrossSiteLogin
+{
+    /**
+     * Krátká platnost: token je jednorázový proklik z administračního rozcestníku,
+     * ne dlouhé sezení. Stačí na přesměrování přes bránu a přihlášení v archivu;
+     * leaknutý odkaz je tak po pár minutách mrtvý.
+     */
+    const TTL_SEKUND = 300;
+
+    const ODDELOVAC_PAYLOADU = '|';
+
+    /**
+     * Vrátí hodnotu pro `?gcsso=` (samotný token, bez prefixu) podepsanou pro dané
+     * `id_uzivatele` a nonce. Prázdný řetězec, pokud secret není nastavený — volající
+     * pak `?gcsso=` nepřipojuje.
+     *
+     * @param int         $idUzivatele
+     * @param string      $nonce
+     * @param string      $secret
+     * @param int|null    $ted
+     * @return string
+     */
+    public static function podepis($idUzivatele, $nonce, $secret, $ted = null)
+    {
+        if ($secret === '') {
+            return '';
+        }
+
+        $ted = $ted === null ? time() : $ted;
+        $expiry = (string) ($ted + self::TTL_SEKUND);
+        $payload = ((int) $idUzivatele) . self::ODDELOVAC_PAYLOADU . $expiry . self::ODDELOVAC_PAYLOADU . $nonce;
+        $podpis = hash_hmac('sha256', $payload, $secret, true);
+
+        return self::base64Url($payload) . '.' . self::base64Url($podpis);
+    }
+
+    /**
+     * Ověří token: správný podpis a nevypršelá platnost. Vrátí ověřené `id_uzivatele`
+     * + nonce (objekt {@see OvereneSso}), nebo null při jakékoli nesrovnalosti (špatný
+     * formát, neplatný podpis, vypršení). Shodu nonce s cookie kontroluje volající.
+     *
+     * @param string $token
+     * @param string $secret
+     * @return OvereneSso|null
+     */
+    public static function over($token, $secret)
+    {
+        if ($secret === '') {
+            return null;
+        }
+        if (strpos($token, '.') === false) {
+            return null;
+        }
+
+        $casti = explode('.', $token, 2);
+        $payloadKodovany = $casti[0];
+        $podpisKodovany = $casti[1];
+        $payload = self::base64UrlDekoduj($payloadKodovany);
+        $podpis = self::base64UrlDekoduj($podpisKodovany);
+        if ($payload === null || $podpis === null) {
+            return null;
+        }
+
+        $ocekavanyPodpis = hash_hmac('sha256', $payload, $secret, true);
+        if (! hash_equals($ocekavanyPodpis, $podpis)) {
+            return null;
+        }
+
+        $dily = explode(self::ODDELOVAC_PAYLOADU, $payload);
+        if (count($dily) !== 3) {
+            return null;
+        }
+        $idUzivatele = $dily[0];
+        $expiry = $dily[1];
+        $nonce = $dily[2];
+
+        if (! ctype_digit($expiry) || (int) $expiry < time()) {
+            return null;
+        }
+        if (! ctype_digit($idUzivatele) || (int) $idUzivatele <= 0 || $nonce === '') {
+            return null;
+        }
+
+        return new OvereneSso((int) $idUzivatele, $nonce);
+    }
+
+    private static function base64Url($data)
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private static function base64UrlDekoduj($data)
+    {
+        $dekodovano = base64_decode(strtr($data, '-_', '+/'), true);
+
+        return $dekodovano === false ? null : $dekodovano;
+    }
+}

--- a/model/Dev/OvereneSso.php
+++ b/model/Dev/OvereneSso.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gamecon\Dev;
+
+/**
+ * Ověřený obsah `?gcsso=` tokenu — výsledek {@see CrossSiteLogin::over}.
+ * Podpis i platnost už jsou ověřené; shodu {@see self::$nonce} se spárovanou
+ * cookie kontroluje volající (to teprve potvrdí, že jde o prohlížeč, který na
+ * odkaz klikl).
+ *
+ * Identitu nese {@see self::$idUzivatele} — číselné `id_uzivatele`, ne e-mail.
+ * ID je napříč ostrou i zmrazenými archivními snapshoty téhož kontinuálního
+ * `uzivatele` stabilní; e-mail je proměnný a může se mezi ročníky přiřadit jinému
+ * člověku, takže by se podle něj dalo přihlásit do cizího účtu.
+ *
+ * PHP 5.6-kompatibilní varianta (archivní ročníky 2015-2021 běží na PHP 5.6/7.3):
+ * žádné property promotion, readonly, scalar typehinty ani návratové typy.
+ */
+final class OvereneSso
+{
+    /** @var int */
+    public $idUzivatele;
+
+    /** @var string */
+    public $nonce;
+
+    public function __construct($idUzivatele, $nonce)
+    {
+        $this->idUzivatele = (int) $idUzivatele;
+        $this->nonce = (string) $nonce;
+    }
+}

--- a/model/Dev/SsoParovaciCookie.php
+++ b/model/Dev/SsoParovaciCookie.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Gamecon\Dev;
+
+/**
+ * Spárovací cookie pro magické přihlášení do archivu ({@see CrossSiteLogin}).
+ *
+ * Drží náhodný nonce a je scope `.gamecon.cz`, aby ji prohlížeč automaticky poslal
+ * i na `NNNN.gamecon.cz`. NENÍ to přihlášení — sama o sobě nikoho nepřihlásí; je to
+ * jen „důkaz stejného prohlížeče": archiv přihlásí jen když se nonce z této cookie
+ * shoduje s nonce zapečeným v podepsaném `?gcsso=` tokenu. Sdílená URL v cizím
+ * prohlížeči tuhle cookie nemá → mismatch → nepřihlásí.
+ *
+ * PHP 5.6-kompatibilní varianta (archivní ročníky 2015-2021 běží na PHP 5.6/7.3):
+ * setcookie() options-array (PHP 7.3+) tu není, takže používáme poziční formu a
+ * SameSite propašujeme připojením za path (starý trik, který prohlížeče respektují).
+ */
+final class SsoParovaciCookie
+{
+    const JMENO = 'gc_sso_pair';
+
+    /**
+     * O něco déle než TTL tokenu ({@see CrossSiteLogin::TTL_SEKUND}), aby cookie
+     * přežila proklik přes bránu i případné přesměrování a token nikdy nevypršel
+     * „dřív" než jeho párovací polovina.
+     */
+    const TTL_SEKUND = 600;
+
+    /**
+     * Nastaví spárovací cookie s daným nonce. Scope `.gamecon.cz` (aby dorazila i
+     * na archiv), HttpOnly, SameSite=Lax (musí přijít při top-level navigaci na
+     * archiv), Secure jen po HTTPS.
+     *
+     * @param string $nonce
+     * @return void
+     */
+    public static function nastav($nonce)
+    {
+        $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+        // SameSite za path: poziční setcookie() v PHP 5.6 nemá samostatný argument,
+        // ale prohlížeče berou "; SameSite=Lax" připojené k path. Path je vždy '/'.
+        $path = '/; SameSite=Lax';
+
+        setcookie(
+            self::JMENO,
+            $nonce,
+            time() + self::TTL_SEKUND,
+            $path,
+            self::cookieDomena(),
+            $secure,
+            true
+        );
+    }
+
+    /**
+     * `.gamecon.cz` na produkčních subdoménách (sdílí se napříč admin/archiv),
+     * jinak prázdno = host-only (prohlížeč jinak širší doménu odmítne).
+     *
+     * @return string
+     */
+    private static function cookieDomena()
+    {
+        $host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
+        // Odřízneme případný port.
+        $dily = explode(':', $host, 2);
+        $host = $dily[0];
+
+        $pripona = 'gamecon.cz';
+        $delkaPripony = strlen($pripona);
+
+        return substr($host, -$delkaPripony) === $pripona ? '.gamecon.cz' : '';
+    }
+
+    /**
+     * @return string|null
+     */
+    public static function precti()
+    {
+        $nonce = isset($_COOKIE[self::JMENO]) ? $_COOKIE[self::JMENO] : null;
+
+        return is_string($nonce) && $nonce !== '' ? $nonce : null;
+    }
+}

--- a/nastaveni/nastaveni-produkce.php
+++ b/nastaveni/nastaveni-produkce.php
@@ -62,3 +62,16 @@ define('HTTPS_ONLY', true);
 if (!defined('FIO_TOKEN')) define('FIO_TOKEN', '');
 if (!defined('CRON_KEY')) define('CRON_KEY', '');
 if (!defined('MIGRACE_HESLO')) define('MIGRACE_HESLO', '');
+
+// GAMECON_SSO_KEY — klíč pro ověření magického přihlášení (?gcsso=), odvozený pro
+// tento ročník (HMAC(rok, master)) a vstříknutý deployem přes -e. Tenhle (commitnutý)
+// nastaveni-produkce.php je na archivu reálně načítaný soubor — bake přes
+// skryte-nastaveni-z-env-funkce.php se neprovede, protože tenhle soubor už existuje.
+// Proto se getenv('GAMECON_SSO_KEY') musí číst právě TADY, jinak konstanta zůstane
+// nedefinovaná a SSO se neuplatní. Prázdný fallback = SSO vypnuté.
+if (!defined('GAMECON_SSO_KEY')) define('GAMECON_SSO_KEY', getenv('GAMECON_SSO_KEY') ?: '');
+
+// SECRET_CRYPTO_KEY — vyžadované Defuse\Crypto helpery na bootu. Zmrazený
+// archiv může mít stabilní dummy klíč bez bezpečnostního dopadu. Mirror novějších ročníků.
+if (!defined('SECRET_CRYPTO_KEY')) define('SECRET_CRYPTO_KEY', getenv('SECRET_CRYPTO_KEY')
+    ?: 'def0000066cba9ae32fdda839a143276cc0646b3880920c93876ecc1bbaca96ee6ed251559516b1804f4742c2165e4c7eb3ed5c7a5abe857c6db8608e3b5fe97a8cdf15a');


### PR DESCRIPTION
Re-adds the cross-site magic login to `archive/2017` in **PHP 5.6-compatible syntax**. The 2017 container runs PHP 5.6; the earlier 8.x port fatally broke the admin (parse error), since reverted.

The 4 Dev files + consume block avoid all 7.x/8.x-only syntax (no `readonly`, constructor promotion, named args, return/scalar type hints, `str_contains`, `??`, `[$a,$b]` destructuring, `public const`, setcookie options-array). Verified by linting **inside the live 2017 PHP 5.6 container** + (on the 2018 pilot) a runtime mint→verify→reject round-trip and the `dbOneCol` id-lookup on 5.6. Also re-adds the `SECRET_CRYPTO_KEY` define (2017 lacks it).

Token wire format is unchanged → prod (8.2) mints, this archive verifies the same bytes. **Merging auto-deploys 2017.**