### PR TITLE
Build 2017/2018 archives on PHP 7.3 (code needs 7.0+)

### DIFF
--- a/.github/workflows/deploy-year-archive.yml
+++ b/.github/workflows/deploy-year-archive.yml
@@ -108,8 +108,8 @@ jobs:
                         2014) base_image="php:5.6-apache" ;;
                         2015) base_image="php:5.6-apache" ;;
                         2016) base_image="php:5.6-apache" ;;
-                        2017) base_image="php:5.6-apache" ;;
-                        2018) base_image="php:5.6-apache" ;;
+                        2017) base_image="php:7.3-apache" ;;
+                        2018) base_image="php:7.3-apache" ;;
                         2019) base_image="php:7.3-apache" ;;
                         2020) base_image="php:7.3-apache" ;;
                         2021) base_image="php:7.3-apache" ;;


### PR DESCRIPTION
The 2017 and 2018 archive code uses PHP 7.0+ syntax (`??` null-coalescing in `admin/scripts/modules/uvod.php`, `chyby.php`, `model/uzivatel-slucovani.php`), but the deploy `BASE_IMAGE` map assigned them `php:5.6-apache`. Result: those files **fatally parse-error**, so any logged-in admin page 500s.

This was invisible until the archive magic-login started actually logging admins in (you can't reach those pages from the login screen). Verified: 2017 and 2018 code lints **100% clean under PHP 7.3** (0 non-vendor failures), and they already use `mysqli` (not the 5.6-only `mysql_*`), so 7.3 is safe.

Bumps 2017 + 2018 → `php:7.3-apache` (matching 2019-2021). `php_exts` left as `mysqli` (unchanged — what ran on 5.6). **Merging auto-deploys both years** on the corrected base.