### PR TITLE
Sjednotit pořadí kapacit s importem + vrátit nápovědu

### DIFF
--- a/model/Aktivita/templates/editor-aktivity.xtpl
+++ b/model/Aktivita/templates/editor-aktivity.xtpl
@@ -311,9 +311,9 @@
         <td>
             <div id="kapacitaStd">
                 <input id="kapacitaInput" type="text" style="width:25px" name="{fields}[kapacita]" value="{kapacita}"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_f]" value="{kapacita_f}"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_m]" value="{kapacita_m}">
-                <span class="hinted"><div class="hint">Univerzálně / holky / kluky<br/>Kapacita 0/0/0 znamená bez omezení</div></span>
+                <input type="text" style="width:25px" name="{fields}[kapacita_m]" value="{kapacita_m}"> /
+                <input type="text" style="width:25px" name="{fields}[kapacita_f]" value="{kapacita_f}">
+                <div style="font-size:11px;color:#888;margin-top:2px">unisex / muži / ženy &nbsp;(0/0/0 = bez omezení)</div>
             </div>
             <div id="teamVelikost" style="display:none">
                 min: <input type="text" style="width:25px" name="{fields}[team_min]" value="{team_min}">

--- a/model/Aktivita/templates/editor-aktivity.xtpl
+++ b/model/Aktivita/templates/editor-aktivity.xtpl
@@ -310,10 +310,10 @@
         </th>
         <td>
             <div id="kapacitaStd">
-                <input id="kapacitaInput" type="text" style="width:25px" name="{fields}[kapacita]" value="{kapacita}"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_m]" value="{kapacita_m}"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_f]" value="{kapacita_f}">
-                <div style="font-size:11px;color:#888;margin-top:2px">unisex / muži / ženy &nbsp;(0/0/0 = bez omezení)</div>
+                <input id="kapacitaInput" type="text" style="width:25px" name="{fields}[kapacita]" value="{kapacita}" placeholder="U" title="Univerzální (unisex)"> /
+                <input type="text" style="width:25px" name="{fields}[kapacita_m]" value="{kapacita_m}" placeholder="M" title="Muži"> /
+                <input type="text" style="width:25px" name="{fields}[kapacita_f]" value="{kapacita_f}" placeholder="Ž" title="Ženy">
+                <div style="font-size:11px;color:#888;margin-top:2px">U = unisex / M = muži / Ž = ženy &nbsp;(0/0/0 = bez omezení)</div>
             </div>
             <div id="teamVelikost" style="display:none">
                 min: <input type="text" style="width:25px" name="{fields}[team_min]" value="{team_min}">

--- a/model/Aktivita/templates/editor-aktivity.xtpl
+++ b/model/Aktivita/templates/editor-aktivity.xtpl
@@ -310,10 +310,10 @@
         </th>
         <td>
             <div id="kapacitaStd">
-                <input id="kapacitaInput" type="text" style="width:25px" name="{fields}[kapacita]" value="{kapacita}" placeholder="U" title="Univerzální (unisex)"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_m]" value="{kapacita_m}" placeholder="M" title="Muži"> /
-                <input type="text" style="width:25px" name="{fields}[kapacita_f]" value="{kapacita_f}" placeholder="Ž" title="Ženy">
-                <div style="font-size:11px;color:#888;margin-top:2px">U = unisex / M = muži / Ž = ženy &nbsp;(0/0/0 = bez omezení)</div>
+                <input id="kapacitaInput" type="text" style="width:30px" name="{fields}[kapacita]" value="{kapacita}" placeholder="⚧" title="Univerzální (unisex)"> /
+                <input type="text" style="width:30px" name="{fields}[kapacita_m]" value="{kapacita_m}" placeholder="♂" title="Muži"> /
+                <input type="text" style="width:30px" name="{fields}[kapacita_f]" value="{kapacita_f}" placeholder="♀" title="Ženy">
+                <div style="font-size:11px;color:#888;margin-top:2px">⚧ unisex / ♂ muži / ♀ ženy &nbsp;(0/0/0 = bez omezení)</div>
             </div>
             <div id="teamVelikost" style="display:none">
                 min: <input type="text" style="width:25px" name="{fields}[team_min]" value="{team_min}">


### PR DESCRIPTION
Řeší stížnost vypravěčky, která si špatně zadala kapacity, protože předpokládala, že pořadí políček muži/ženy v adminu je stejné jako v importu.

## Problém
- **Pořadí bylo opravdu prohozené.** Import/export sloupce jsou `unisex / muži / ženy`, ale GUI mělo `univerzál / holky(f) / kluci(m)` — 2. a 3. políčko obráceně.
- **Nápověda nezmizela z kódu**, ale visela jako hover-only tooltip na prázdném `<span class="hinted">` (není na co najet myší). Na mobilu hover neexistuje → nápověda byla zcela nedosažitelná.

## Oprava (`model/Aktivita/templates/editor-aktivity.xtpl`)
1. Sjednoceno vizuální pořadí políček s importem/exportem: **unisex / muži / ženy** (`kapacita / kapacita_m / kapacita_f`). Binding je podle `name`, žádný JS ani test nezávisí na vizuálním pořadí → data se mapují korektně.
2. Nápověda je nyní **trvale viditelná** pod políčky: `unisex / muži / ženy (0/0/0 = bez omezení)` — funguje na desktopu i mobilu, bez hoveru.

## Pozn.
- Mění zavedené GUI pořadí (kdo měl svalovou paměť, uvidí 2./3. políčko prohozené), ale nový popisek to jasně označuje.
- Data v DB se nemění, mění se jen pořadí inputů ve formuláři.