### PR TITLE
Zrušit dvojí běh testů na PR (concurrency)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,14 @@ on:
             - reopened
             - ready_for_review
 
+# Feature větve spouští testy přes oba triggery (push i pull_request),
+# takže po otevření PR by stejný commit běžel dvakrát. Skupina klíčovaná
+# na větev (head_ref na PR, jinak ref) je u obou běhů stejná, takže
+# druhý běh ten první zruší a testy proběhnou jen jednou.
+concurrency:
+    group: run-tests-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     run-tests:
         strategy:


### PR DESCRIPTION
Workflow `Run tests` se na feature větvi s otevřeným PR spouštěl **dvakrát** pro stejný commit — jednou z triggeru `push` (testy na každé feature větvi) a jednou z `pull_request` (testy pro PR). Dva identické běhy = zbytečně dvojnásobná spotřeba runnerů.

## Oprava
Přidán top-level `concurrency` blok klíčovaný na větev (`github.head_ref` na PR událostech, jinak `github.ref`). Push i pull_request běh téhož commitu spadnou do stejné skupiny, takže `cancel-in-progress` ten dřívější zruší a testy proběhnou jen jednou.

- Větve **bez** PR si CI na push zachovají (skupina je per-větev, nic se neruší).
- Žádná ztráta pokrytí — jen se eliminuje duplicita.