### PR TITLE
Import DB ze zálohy ostré i na preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,4 +311,12 @@ Pravdivý stav ke dni auditu (zdroj: `cat /usr/local/sbin/deploy-preview-branch.
 
 **Když přidáváš novou env-driven feature, vrať se k téhle tabulce a doplň řádek.** Pokud rozhodneš, že preview má dostat něco jiného než ostra, **napiš proč** — jinak se z toho stane skrytý drift.
 
+### Import DB ze zálohy ostré na preview (bind-mount, ne env var)
+
+Admin → Nastavení nabízí na betě tlačítka „Zkopírovat databázi z ostré". Na preview z těch tří variant jde **jen import z `.sql.gz` zálohy** (`zalohaForm`):
+
+- **Živý mysqldump z ostré** a **kopie archivního ročníku** na preview NEJDOU: in-app kód běží v kontejneru jako DB účet `gc_preview_<slug>`, který nemá práva na produkční `d16779_gcostra` ani na `gamecon_YYYY`. Proto je `SystemoveNastaveniHtml` na preview skrývá; nabízí jen file-based import.
+- **Mechanismus doručení dumpu = read-only bind-mount, ne env var.** Preview deploy skript (ansible, `roles/preview_deployer/templates/deploy-preview-branch.sh.j2`) mountuje hostový `/srv/ftp/gamecon.cz/www/gamecon.cz/ostra/backup/db` → `/var/www/html/ostra/backup/db:ro`, tj. na stejnou relativní cestu (`../ostra/backup/db`), kterou beta čte z filesystému. App-kód proto netřeba měnit pro cestu — `backupDir()` i allowed-dirs v `KopieOstreDatabaze` už tu cestu pro ne-locale prostředí znají.
+- **Import sanituje dump:** `NastrojeDatabaze::removeDefiners()` + `removeDatabaseSelection()` (odstraní `CREATE DATABASE`/`USE`/`DROP DATABASE`), takže obsah zálohy doteče do aktuální (preview/beta) DB bez ohledu na produkční jméno DB zapečené v dumpu. Mount je `:ro` — preview nikdy nepíše do stromu ostré.
+
 

--- a/model/SystemoveNastaveni/KopieOstreDatabaze.php
+++ b/model/SystemoveNastaveni/KopieOstreDatabaze.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\SystemoveNastaveni;
@@ -17,9 +18,9 @@ readonly class KopieOstreDatabaze
     }
 
     public function __construct(
-        private NastrojeDatabaze   $nastrojeDatabaze,
+        private NastrojeDatabaze $nastrojeDatabaze,
         private SystemoveNastaveni $systemoveNastaveni,
-        private Vyjimkovac         $vyjimkovac,
+        private Vyjimkovac $vyjimkovac,
     ) {
     }
 
@@ -38,20 +39,20 @@ readonly class KopieOstreDatabaze
         }
         $allowedBaseDirs = array_filter($allowedBaseDirs);
 
-        $realFile     = realpath($gzipSouborZalohy);
-        $inAllowedDir = $realFile !== false && (bool)array_filter(
-                $allowedBaseDirs,
-                fn(
-                    $dir,
-                ) => str_starts_with($realFile, $dir . '/'),
-            );
+        $realFile = realpath($gzipSouborZalohy);
+        $inAllowedDir = $realFile !== false && (bool) array_filter(
+            $allowedBaseDirs,
+            fn (
+                $dir,
+            ) => str_starts_with($realFile, $dir . '/'),
+        );
 
-        if (!$inAllowedDir || !preg_match('~^export_.*\.sql\.gz$~', basename($realFile))) {
+        if (! $inAllowedDir || ! preg_match('~^export_.*\.sql\.gz$~', basename($realFile))) {
             throw new \RuntimeException("Nepovolený soubor zálohy: {$gzipSouborZalohy}");
         }
 
         $puvodniPriZalogovaniOdeslatMailem = $this->vyjimkovac->priZalogovaniOdeslatMailem();
-        $puvodniZobrazeniChyb              = $this->vyjimkovac->zobrazeni();
+        $puvodniZobrazeniChyb = $this->vyjimkovac->zobrazeni();
         $this->vyjimkovac->priZalogovaniOdeslatMailem(false);
         $this->vyjimkovac->zobrazeni($this->vyjimkovac::TRACY);
 
@@ -73,7 +74,7 @@ readonly class KopieOstreDatabaze
                     gzclose($gz);
                     throw new \RuntimeException('Nepodařilo se otevřít dočasný soubor pro zápis');
                 }
-                while (!gzeof($gz)) {
+                while (! gzeof($gz)) {
                     fwrite($fp, gzread($gz, 524288)); // 512 KB chunks
                 }
                 gzclose($gz);
@@ -81,6 +82,10 @@ readonly class KopieOstreDatabaze
 
                 // Strip DEFINERs from the plain SQL
                 NastrojeDatabaze::removeDefiners($tempFile);
+                // Zálohy ostré nesou `CREATE DATABASE`/`USE d16779_gcostra`; bez
+                // odstranění by se import přepnul na produkční jméno DB místo
+                // aktuální (preview / beta) databáze.
+                NastrojeDatabaze::removeDatabaseSelection($tempFile);
 
                 // Connect to local (beta) DB
                 [
@@ -125,35 +130,35 @@ readonly class KopieOstreDatabaze
         set_time_limit(120);
 
         $zdrojovaDbName = trim($zdrojovaDbName);
-        $jeTestovaciDb  = defined('DB_TEST_PREFIX') && str_starts_with($zdrojovaDbName, DB_TEST_PREFIX);
-        $jeOstraDb      = $zdrojovaDbName === $this->systemoveNastaveni->prihlasovaciUdajeOstreDatabaze()['DB_NAME'];
-        if (!preg_match('~^gamecon(_\d{4})?$~', $zdrojovaDbName) && !$jeTestovaciDb && !$jeOstraDb) {
+        $jeTestovaciDb = defined('DB_TEST_PREFIX') && str_starts_with($zdrojovaDbName, DB_TEST_PREFIX);
+        $jeOstraDb = $zdrojovaDbName === $this->systemoveNastaveni->prihlasovaciUdajeOstreDatabaze()['DB_NAME'];
+        if (! preg_match('~^gamecon(_\d{4})?$~', $zdrojovaDbName) && ! $jeTestovaciDb && ! $jeOstraDb) {
             throw new \RuntimeException("Nepovolený název databáze: {$zdrojovaDbName}");
         }
 
         $puvodniPriZalogovaniOdeslatMailem = $this->vyjimkovac->priZalogovaniOdeslatMailem();
-        $puvodniZobrazeniChyb              = $this->vyjimkovac->zobrazeni();
+        $puvodniZobrazeniChyb = $this->vyjimkovac->zobrazeni();
 
         $this->vyjimkovac->priZalogovaniOdeslatMailem(false);
         $this->vyjimkovac->zobrazeni($this->vyjimkovac::TRACY);
 
         try {
-            $nastaveniZdroj            = $this->systemoveNastaveni->prihlasovaciUdajeOstreDatabaze();
+            $nastaveniZdroj = $this->systemoveNastaveni->prihlasovaciUdajeOstreDatabaze();
             $nastaveniZdroj['DB_NAME'] = $zdrojovaDbName;
 
             // pro speciální archivy na stejném serveru použijeme lokální DB účet
             if ($zdrojovaDbName === 'gamecon_2024') {
-                $lokalni                    = $this->systemoveNastaveni->prihlasovaciUdajeSoucasneDatabaze();
+                $lokalni = $this->systemoveNastaveni->prihlasovaciUdajeSoucasneDatabaze();
                 $nastaveniZdroj['DBM_USER'] = $lokalni['DBM_USER'];
                 $nastaveniZdroj['DBM_PASS'] = $lokalni['DBM_PASS'];
-                $nastaveniZdroj['DB_SERV']  = $lokalni['DB_SERV'];
-                $nastaveniZdroj['DB_PORT']  = $lokalni['DB_PORT'];
+                $nastaveniZdroj['DB_SERV'] = $lokalni['DB_SERV'];
+                $nastaveniZdroj['DB_PORT'] = $lokalni['DB_PORT'];
             }
 
             if (
                 $nastaveniZdroj['DB_SERV'] === DB_SERV
                 && $nastaveniZdroj['DB_NAME'] === DB_NAME
-                && !$this->systemoveNastaveni->jsmeNaLocale()
+                && ! $this->systemoveNastaveni->jsmeNaLocale()
             ) {
                 throw new \RuntimeException('Kopírovat sebe sama nemá smysl');
             }

--- a/model/SystemoveNastaveni/NastrojeDatabaze.php
+++ b/model/SystemoveNastaveni/NastrojeDatabaze.php
@@ -11,19 +11,21 @@ class NastrojeDatabaze
     public static function vytvorZGlobals()
     {
         global $systemoveNastaveni;
-        if (!$systemoveNastaveni) {
+        if (! $systemoveNastaveni) {
             $systemoveNastaveni = SystemoveNastaveni::zGlobals();
         }
+
         return new self($systemoveNastaveni);
     }
 
     public function __construct(
         private SystemoveNastaveni $systemoveNastaveni,
-    )
-    {
+    ) {
     }
 
-    public function vytvorMysqldumpOstreDatabaze(array $mysqldumpSettings = ['skip-definer' => true]): Mysqldump
+    public function vytvorMysqldumpOstreDatabaze(array $mysqldumpSettings = [
+        'skip-definer' => true,
+    ]): Mysqldump
     {
         $nastaveniOstre = $this->systemoveNastaveni->prihlasovaciUdajeOstreDatabaze();
 
@@ -42,9 +44,10 @@ class NastrojeDatabaze
      */
     public function vytvorMysqldumpDatabaze(
         array $nastaveniDb,
-        array $mysqldumpSettings = ['skip-definer' => true],
-    ): Mysqldump
-    {
+        array $mysqldumpSettings = [
+            'skip-definer' => true,
+        ],
+    ): Mysqldump {
         return $this->vytvorMysqldump(
             $nastaveniDb['DB_SERV'],
             $nastaveniDb['DBM_USER'], // dbm účet kvůli SHOW VIEW
@@ -54,7 +57,9 @@ class NastrojeDatabaze
         );
     }
 
-    public function vytvorMysqldumpHlavniDatabaze(array $mysqldumpSettings = ['skip-definer' => true]): Mysqldump
+    public function vytvorMysqldumpHlavniDatabaze(array $mysqldumpSettings = [
+        'skip-definer' => true,
+    ]): Mysqldump
     {
         return $this->vytvorMysqldump(
             $this->systemoveNastaveni->databazoveNastaveni()->serverHlavniDatabaze(),
@@ -65,7 +70,9 @@ class NastrojeDatabaze
         );
     }
 
-    public function vytvorMysqldumpAnonymniDatabaze(array $mysqldumpSettings = ['skip-definer' => true]): Mysqldump
+    public function vytvorMysqldumpAnonymniDatabaze(array $mysqldumpSettings = [
+        'skip-definer' => true,
+    ]): Mysqldump
     {
         return $this->vytvorMysqldump(
             $this->systemoveNastaveni->databazoveNastaveni()->serverAnonymizovaneDatabase(),
@@ -81,9 +88,8 @@ class NastrojeDatabaze
         string $dbUser,
         string $dbPassword,
         string $dbName,
-        array  $mysqldumpSettings,
-    ): Mysqldump
-    {
+        array $mysqldumpSettings,
+    ): Mysqldump {
         return new Mysqldump(
             $this->vytvorDsn($dbServer, $dbName),
             $dbUser,
@@ -98,6 +104,23 @@ class NastrojeDatabaze
     {
         $file = file_get_contents($filename);
         $file = preg_replace('#DEFINER=`(?:[^`]|``)*`@`(?:[^`]|``)*`#', '', $file);
+        file_put_contents($filename, $file);
+    }
+
+    // Zálohy ostré databáze pořízené Adminerem / mysqldumpem --databases v sobě
+    // nesou hlavičku `CREATE DATABASE d16779_gcostra` + `USE d16779_gcostra`.
+    // Při importu přes MySQLImport, který příkazy pouští tak jak jsou, by se tím
+    // spojení přepnulo na produkční jméno DB (a tabulky by skončily mimo cílovou
+    // DB nebo s chybou práv). Odstraněním těchto příkazů se obsah zálohy nahraje
+    // do databáze, ke které je spojení už připojené (preview / beta DB).
+    public static function removeDatabaseSelection(string $filename): void
+    {
+        $file = file_get_contents($filename);
+        $file = preg_replace(
+            '~^\s*(?:CREATE\s+DATABASE|USE|DROP\s+DATABASE)\b[^;]*;\s*$~im',
+            '',
+            $file,
+        );
         file_put_contents($filename, $file);
     }
 
@@ -116,7 +139,7 @@ class NastrojeDatabaze
         if ($databaze === $this->systemoveNastaveni->databazoveNastaveni()->hlavniDatabaze()
             && $this->systemoveNastaveni->jsmeNaOstre()
         ) {
-            throw new \LogicException("Nemůžeme promazávat databázi na ostré");
+            throw new \LogicException('Nemůžeme promazávat databázi na ostré');
         }
         $this->smazTabulkyAPohledy($databaze, $spojeni);
         $this->smazNaseFunkce($databaze, $spojeni);
@@ -140,17 +163,17 @@ class NastrojeDatabaze
             $showCreateTableResult = mysqli_query(
                 $spojeni,
                 <<<SQL
-                    SHOW CREATE TABLE `$table`
+                    SHOW CREATE TABLE `{$table}`
                 SQL,
             );
-            $showCreateTable       = mysqli_fetch_assoc($showCreateTableResult);
-            $type                  = !empty($showCreateTable['View'])
+            $showCreateTable = mysqli_fetch_assoc($showCreateTableResult);
+            $type = ! empty($showCreateTable['View'])
                 ? 'VIEW'
                 : 'TABLE';
             mysqli_query(
                 $spojeni,
                 <<<SQL
-                    DROP $type `$table`
+                    DROP {$type} `{$table}`
                 SQL,
             );
         }
@@ -169,7 +192,7 @@ class NastrojeDatabaze
             mysqli_query(
                 $spojeni,
                 <<<SQL
-                    DROP FUNCTION `$nazevNasiFunkce`
+                    DROP FUNCTION `{$nazevNasiFunkce}`
                 SQL,
             );
         }
@@ -177,20 +200,20 @@ class NastrojeDatabaze
 
     private function nazvyNasichFunkci(string $databaze, \mysqli $spojeni): array
     {
-        $result                 = mysqli_query(
+        $result = mysqli_query(
             $spojeni,
             <<<SQL
                 SHOW FUNCTION STATUS
             SQL,
         );
-        $functionsStatuses      = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $functionsStatuses = mysqli_fetch_all($result, MYSQLI_ASSOC);
         $localFunctionsStatuses = array_filter($functionsStatuses, static function (array $functionStatus) use ($databaze) {
             return $functionStatus['Db'] === $databaze && $functionStatus['Type'] === 'FUNCTION';
         });
-        if (!$localFunctionsStatuses) {
+        if (! $localFunctionsStatuses) {
             return [];
         }
 
-        return array_map(static fn(array $definition) => $definition['Name'], $localFunctionsStatuses);
+        return array_map(static fn (array $definition) => $definition['Name'], $localFunctionsStatuses);
     }
 }

--- a/model/SystemoveNastaveni/SystemoveNastaveniHtml.php
+++ b/model/SystemoveNastaveni/SystemoveNastaveniHtml.php
@@ -1,23 +1,23 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\SystemoveNastaveni;
 
-use DateTimeInterface;
+use Gamecon\BackgroundProcess\BackgroundProcessService;
 use Gamecon\Cas\DateTimeCz;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveniStruktura as Sql;
 use Gamecon\XTemplate\XTemplate;
 use Granam\RemoveDiacritics\RemoveDiacritics;
-use Gamecon\SystemoveNastaveni\SystemoveNastaveniStruktura as Sql;
-use Gamecon\BackgroundProcess\BackgroundProcessService;
 
 class SystemoveNastaveniHtml
 {
-    public const SYNCHRONNI_POST_KLIC           = 'nastaveni';
-    public const ZKOPIROVAT_OSTROU_KLIC         = 'zkopirovat_ostrou';
-    public const ZKOPIROVAT_ARCHIVNI_KLIC        = 'zkopirovat_archivni';
-    public const ZKOPIROVAT_ZE_ZALOHY_KLIC      = 'zkopirovat_ze_zalohy';
-    public const ZVYRAZNI                       = 'zvyrazni';
-    public const AJAX_STAV_KOPIE_KLIC           = 'stavKopieDatabazeZOstre';
+    public const SYNCHRONNI_POST_KLIC = 'nastaveni';
+    public const ZKOPIROVAT_OSTROU_KLIC = 'zkopirovat_ostrou';
+    public const ZKOPIROVAT_ARCHIVNI_KLIC = 'zkopirovat_archivni';
+    public const ZKOPIROVAT_ZE_ZALOHY_KLIC = 'zkopirovat_ze_zalohy';
+    public const ZVYRAZNI = 'zvyrazni';
+    public const AJAX_STAV_KOPIE_KLIC = 'stavKopieDatabazeZOstre';
 
     /**
      * @var SystemoveNastaveni
@@ -51,18 +51,26 @@ class SystemoveNastaveniHtml
             $this->vypisSkupinu($skupina, $zaznamyJedneSkupiny, $template, $klicKeZvyrazneni);
         }
 
-        if ($this->systemoveNastaveni->jsmeNaBete() || $this->systemoveNastaveni->jsmeNaLocale()) {
+        if (
+            $this->systemoveNastaveni->jsmeNaBete()
+            || $this->systemoveNastaveni->jsmeNaLocale()
+            || $this->systemoveNastaveni->jsmeNaPreview()
+        ) {
             $templateZkopirovaniOstre = new XTemplate(__DIR__ . '/templates/zkopirovat-databazi-z-ostre.xtpl');
             $templateZkopirovaniOstre->assign('synchronniPostKlic', self::SYNCHRONNI_POST_KLIC);
             $templateZkopirovaniOstre->assign('zkopirovatOstrouKlic', self::ZKOPIROVAT_OSTROU_KLIC);
             $templateZkopirovaniOstre->assign('zkopirovatArchivniKlic', self::ZKOPIROVAT_ARCHIVNI_KLIC);
             $templateZkopirovaniOstre->assign('ajaxStavKopieKlic', self::AJAX_STAV_KOPIE_KLIC);
+            $templateZkopirovaniOstre->assign(
+                'nadpisProstredi',
+                ucfirst($this->systemoveNastaveni->prostredi()->label()),
+            );
 
-            $archivniRoky = range(2024, (int)(new \DateTimeImmutable())->format('Y') - 1);
+            $archivniRoky = range(2024, (int) (new \DateTimeImmutable())->format('Y') - 1);
             $archivniRokyOptions = implode(
                 '',
                 array_map(
-                    static fn(int $rok) => "<option value=\"{$rok}\">{$rok}</option>",
+                    static fn (int $rok) => "<option value=\"{$rok}\">{$rok}</option>",
                     $archivniRoky,
                 ),
             );
@@ -74,13 +82,14 @@ class SystemoveNastaveniHtml
                     $basename = basename($soubor);
                     $datum = new DateTimeCz('@' . filemtime($soubor));
                     $popisek = $this->formatujDatumSeStarim($datum);
+
                     return "<option value=\"{$basename}\">{$popisek}</option>";
                 },
                 $souboruZaloh,
             ));
             $templateZkopirovaniOstre->assign('zkopirovatZeZalohyKlic', self::ZKOPIROVAT_ZE_ZALOHY_KLIC);
             $templateZkopirovaniOstre->assign('souboruZalohOptions', $souboruZalohOptions);
-            $templateZkopirovaniOstre->assign('maSouboruZaloh', !empty($souboruZaloh));
+            $templateZkopirovaniOstre->assign('maSouboruZaloh', ! empty($souboruZaloh));
 
             // Zkontroluj, jestli proces běží
             $backgroundProcessService = BackgroundProcessService::vytvorZGlobals();
@@ -101,10 +110,21 @@ class SystemoveNastaveniHtml
                 $templateZkopirovaniOstre->parse('zkopirovatDatabaziZOstre.processBezi');
             } else {
                 $templateZkopirovaniOstre->assign('processRunning', false);
-                if (!empty($souboruZaloh)) {
+                if (! empty($souboruZaloh)) {
                     $templateZkopirovaniOstre->parse('zkopirovatDatabaziZOstre.formular.zalohaForm');
                 }
-                if (!$this->systemoveNastaveni->jsmeNaLocale()) {
+                // Na preview běží admin v Docker kontejneru bez přístupu k ostré
+                // DB (vlastní DB účet gc_preview_<slug> nemá práva na produkční DB
+                // ani na archivní gamecon_YYYY) — živý mysqldump z ostré ani kopie
+                // archivního ročníku tam nejdou. Preview proto nabízí jen import
+                // z namountovaného .sql.gz dumpu ostré (zalohaForm výše).
+                if (! $this->systemoveNastaveni->jsmeNaPreview()) {
+                    $templateZkopirovaniOstre->parse('zkopirovatDatabaziZOstre.formular.ostraForm');
+                }
+                if (
+                    ! $this->systemoveNastaveni->jsmeNaLocale()
+                    && ! $this->systemoveNastaveni->jsmeNaPreview()
+                ) {
                     $templateZkopirovaniOstre->parse('zkopirovatDatabaziZOstre.formular.archivniForm');
                 }
                 $templateZkopirovaniOstre->parse('zkopirovatDatabaziZOstre.formular');
@@ -119,7 +139,7 @@ class SystemoveNastaveniHtml
         $template->out('nastaveni');
     }
 
-    private function formatujDatumSeStarim(DateTimeInterface $datum): string
+    private function formatujDatumSeStarim(\DateTimeInterface $datum): string
     {
         return $datum->format(DateTimeCz::FORMAT_DB) . ' (' . DateTimeCz::createFromInterface($datum)->stari() . ')';
     }
@@ -147,14 +167,14 @@ class SystemoveNastaveniHtml
 
     private function klicKeZvyrazneni(): string
     {
-        return RemoveDiacritics::toConstantLikeName((string)get(self::ZVYRAZNI));
+        return RemoveDiacritics::toConstantLikeName((string) get(self::ZVYRAZNI));
     }
 
     private function vypisSkupinu(
-        string    $skupina,
-        array     $zaznamy,
+        string $skupina,
+        array $zaznamy,
         XTemplate $template,
-        string    $klicKeZvyrazneni,
+        string $klicKeZvyrazneni,
     ) {
         $template->assign('nazevSkupiny', mb_ucfirst($skupina));
         $template->parse('nastaveni.skupina.nazev');
@@ -175,15 +195,15 @@ class SystemoveNastaveniHtml
     private function dejHtmlInputType(string $datovyTyp)
     {
         return match (strtolower(trim($datovyTyp))) {
-            'boolean', 'bool'          => 'checkbox',
+            'boolean', 'bool' => 'checkbox',
             'integer', 'int', 'number' => 'number',
             'date', /* date a datetime vyžadují v Chrome nehezký formát, který nechceme
  https://stackoverflow.com/questions/30798906/the-specified-value-does-not-conform-to-the-required-format-yyyy-mm-dd-
     Navíc jediný benefit z date a datetime-local je nativní datepicker prohlížeče,
     který nechceme aradši použijeme jQuery plugin...
     Takže z toho prostě uděláme text input a nazdar */
-            'datetime', 'string'       => 'text',
-            default                    => 'text',
+            'datetime', 'string' => 'text',
+            default => 'text',
         };
     }
 
@@ -201,13 +221,13 @@ class SystemoveNastaveniHtml
         string $datovyTyp,
     ) {
         return match (strtolower(trim($datovyTyp))) {
-            'date'     => $hodnota
+            'date' => $hodnota
                 ? (new DateTimeCz($hodnota))->formatDatumStandardZarovnaneHtml()
                 : $hodnota,
             'datetime' => $hodnota
                 ? (new DateTimeCz($hodnota))->formatCasStandardZarovnaneHtml()
                 : $hodnota,
-            default    => $hodnota,
+            default => $hodnota,
         };
     }
 
@@ -219,13 +239,13 @@ class SystemoveNastaveniHtml
             'bool', 'boolean' => $hodnota
                 ? 'checked'
                 : '',
-            default           => '',
+            default => '',
         };
     }
 
     public function dejZaznamyNastaveniProHtml(
-        array $pouzeSTemitoKlici = null,
-        bool  $prenacti = false,
+        ?array $pouzeSTemitoKlici = null,
+        bool $prenacti = false,
     ): array {
         $hodnotyNastaveni = $pouzeSTemitoKlici
             ? $this->systemoveNastaveni->dejZaznamyNastaveniPodleKlicu($pouzeSTemitoKlici, $prenacti)
@@ -239,7 +259,7 @@ class SystemoveNastaveniHtml
                 $zaznam['zmenil'] = '<strong>' . ($zaznam[Sql::ZMENA_KDY]
                         ? (\Uzivatel::zId($zaznam[Sql::ID_UZIVATELE]) ?? \Uzivatel::zId(\Uzivatel::SYSTEM))->jmenoNick()
                         : '<i>SQL migrace</i>'
-                    ) . '</strong><br>' . (new DateTimeCz($zaznam[Sql::ZMENA_KDY]))->formatCasStandard();;
+                ) . '</strong><br>' . (new DateTimeCz($zaznam[Sql::ZMENA_KDY]))->formatCasStandard();
                 $zaznam['inputType'] = $this->dejHtmlInputType($zaznam[Sql::DATOVY_TYP]);
                 $zaznam['tagInputType'] = $this->dejHtmlTagInputType($zaznam[Sql::DATOVY_TYP]);
                 $zaznam['inputValue'] = $this->dejHtmlInputValue($zaznam[Sql::HODNOTA], $zaznam[Sql::DATOVY_TYP]);
@@ -258,7 +278,7 @@ class SystemoveNastaveniHtml
                 $zaznam['vychoziHodnotaDisplayClass'] = $zaznam[Sql::VLASTNI]
                     ? 'display-none'
                     : '';
-                $zaznam['hodnotaDisplayClass'] = !$zaznam[Sql::VLASTNI]
+                $zaznam['hodnotaDisplayClass'] = ! $zaznam[Sql::VLASTNI]
                     ? 'display-none'
                     : '';
             },
@@ -270,10 +290,10 @@ class SystemoveNastaveniHtml
     public function zpracujPost(?\Uzivatel $uzivatel): bool
     {
         $pozadavky = post(self::SYNCHRONNI_POST_KLIC);
-        if (!$pozadavky) {
+        if (! $pozadavky) {
             return false;
         }
-        if (!empty($pozadavky[self::ZKOPIROVAT_OSTROU_KLIC])) {
+        if (! empty($pozadavky[self::ZKOPIROVAT_OSTROU_KLIC])) {
             try {
                 $this->zkopirujDatabazi($uzivatel);
                 oznameni('Kopírování databáze bylo spuštěno na pozadí. Proces může trvat několik minut. Sledujte jeho průběh níže.');
@@ -283,8 +303,8 @@ class SystemoveNastaveniHtml
 
             return true;
         }
-        if (!empty($pozadavky[self::ZKOPIROVAT_ARCHIVNI_KLIC])) {
-            $rok = (int)($pozadavky[self::ZKOPIROVAT_ARCHIVNI_KLIC]);
+        if (! empty($pozadavky[self::ZKOPIROVAT_ARCHIVNI_KLIC])) {
+            $rok = (int) $pozadavky[self::ZKOPIROVAT_ARCHIVNI_KLIC];
             $backupFile = $this->systemoveNastaveni->rootAdresarProjektu() . '/../' . $rok . '/backup/db/export_latest.sql.gz';
             try {
                 $this->zkopirujZeSouboruZalohy($uzivatel, $backupFile);
@@ -295,8 +315,8 @@ class SystemoveNastaveniHtml
 
             return true;
         }
-        if (!empty($pozadavky[self::ZKOPIROVAT_ZE_ZALOHY_KLIC])) {
-            $soubor = basename((string)$pozadavky[self::ZKOPIROVAT_ZE_ZALOHY_KLIC]);
+        if (! empty($pozadavky[self::ZKOPIROVAT_ZE_ZALOHY_KLIC])) {
+            $soubor = basename((string) $pozadavky[self::ZKOPIROVAT_ZE_ZALOHY_KLIC]);
             try {
                 $this->zkopirujZeSouboruZalohy($uzivatel, $this->backupDir() . '/' . $soubor);
                 oznameni("Kopírování ze zálohy {$soubor} bylo spuštěno na pozadí. Sledujte průběh níže.");
@@ -306,6 +326,7 @@ class SystemoveNastaveniHtml
 
             return true;
         }
+
         return false;
     }
 
@@ -316,12 +337,16 @@ class SystemoveNastaveniHtml
         if ($backgroundProcessService->isProcessRunning($commandName)) {
             throw new \RuntimeException('Kopírování databáze již běží');
         }
-        $workerScript = $this->systemoveNastaveni->rootAdresarProjektu()  . '/admin/scripts/zvlastni/systemove-nastaveni/workers/_database-copy-worker.php';
+        $workerScript = $this->systemoveNastaveni->rootAdresarProjektu() . '/admin/scripts/zvlastni/systemove-nastaveni/workers/_database-copy-worker.php';
         $backgroundProcessService->startBackgroundProcess(
             $commandName,
             $workerScript,
-            ['backupFile' => $backupFilePath],
-            ['started_by' => $requestedBy->id()],
+            [
+                'backupFile' => $backupFilePath,
+            ],
+            [
+                'started_by' => $requestedBy->id(),
+            ],
         );
     }
 
@@ -330,20 +355,22 @@ class SystemoveNastaveniHtml
         if ($this->systemoveNastaveni->jsmeNaLocale()) {
             return $this->systemoveNastaveni->rootAdresarProjektu() . '/backup/db';
         }
+
         return $this->systemoveNastaveni->rootAdresarProjektu() . '/../ostra/backup/db';
     }
 
     private function dejSouboruZaloh(): array
     {
         $backupDir = $this->backupDir();
-        if (!is_dir($backupDir)) {
+        if (! is_dir($backupDir)) {
             return [];
         }
         $soubory = glob($backupDir . '/export_*.sql.gz');
-        if (!$soubory) {
+        if (! $soubory) {
             return [];
         }
         rsort($soubory); // newest first
+
         return $soubory; // return full paths
     }
 
@@ -363,8 +390,12 @@ class SystemoveNastaveniHtml
         $backgroundProcessService->startBackgroundProcess(
             $commandName,
             $workerScript,
-            $zdrojovaDbName ? ['sourceDb' => $zdrojovaDbName] : [],
-            ['started_by' => $requestedBy->id()],
+            $zdrojovaDbName ? [
+                'sourceDb' => $zdrojovaDbName,
+            ] : [],
+            [
+                'started_by' => $requestedBy->id(),
+            ],
         );
     }
 

--- a/model/SystemoveNastaveni/templates/zkopirovat-databazi-z-ostre.xtpl
+++ b/model/SystemoveNastaveni/templates/zkopirovat-databazi-z-ostre.xtpl
@@ -1,15 +1,17 @@
 <!-- begin:zkopirovatDatabaziZOstre -->
-<h1>Beta</h1>
+<h1>{nadpisProstredi}</h1>
 
 <!-- begin:formular -->
-<form method="post" onsubmit="return confirm('Opravdu přemazat současná data na betě daty z ostré?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
+<!-- begin:ostraForm -->
+<form method="post" onsubmit="return confirm('Opravdu přemazat současná data daty z ostré?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
   <button type="submit" value="1" name="{synchronniPostKlic}[{zkopirovatOstrouKlic}]"
           class="disable-and-show-loading-on-click without-safety-unlock">
     Zkopírovat databázi z ostré
   </button>
 </form>
+<!-- end:ostraForm -->
 <!-- begin:archivniForm -->
-<form method="post" style="margin-top: 8px" onsubmit="return confirm('Opravdu přemazat současná data na betě daty z archivní databáze gamecon_' + this.querySelector('select').value + '?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
+<form method="post" style="margin-top: 8px" onsubmit="return confirm('Opravdu přemazat současná data daty z archivní databáze gamecon_' + this.querySelector('select').value + '?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
   <select name="{synchronniPostKlic}[{zkopirovatArchivniKlic}]" style="margin-right: 6px">
     {archivniRokyOptions}
   </select>
@@ -19,7 +21,7 @@
 </form>
 <!-- end:archivniForm -->
 <!-- begin:zalohaForm -->
-<form method="post" style="margin-top: 8px" onsubmit="return confirm('Opravdu přemazat současná data na betě daty ze souboru zálohy ' + this.querySelector('select').value + '?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
+<form method="post" style="margin-top: 8px" onsubmit="return confirm('Opravdu přemazat současná data daty ze souboru zálohy ' + this.querySelector('select').value + '?') || (unblockAndRemoveLoading(this.querySelector('button')) && false)">
   <select name="{synchronniPostKlic}[{zkopirovatZeZalohyKlic}]" style="margin-right: 6px">
     {souboruZalohOptions}
   </select>

--- a/tests/Model/SystemoveNastaveni/NastrojeDatabazeTest.php
+++ b/tests/Model/SystemoveNastaveni/NastrojeDatabazeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\SystemoveNastaveni;
+
+use Gamecon\SystemoveNastaveni\NastrojeDatabaze;
+use PHPUnit\Framework\TestCase;
+
+class NastrojeDatabazeTest extends TestCase
+{
+    private ?string $tempFile = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== null && is_file($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+        parent::tearDown();
+    }
+
+    public function testRemoveDatabaseSelectionOdstraniHlavickuSVyberemDatabaze(): void
+    {
+        $sql = <<<'SQL'
+            CREATE DATABASE `d16779_gcostra` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;
+            USE `d16779_gcostra`;
+            CREATE TABLE `uzivatele_hodnoty` (`id` INT);
+            INSERT INTO `uzivatele_hodnoty` VALUES (1);
+            SQL;
+
+        $vysledek = $this->spustNadObsahem($sql);
+
+        self::assertStringNotContainsString('CREATE DATABASE', $vysledek);
+        self::assertStringNotContainsString('USE `d16779_gcostra`', $vysledek);
+        // Vlastní obsah zálohy zůstává nedotčen.
+        self::assertStringContainsString('CREATE TABLE `uzivatele_hodnoty`', $vysledek);
+        self::assertStringContainsString('INSERT INTO `uzivatele_hodnoty`', $vysledek);
+    }
+
+    public function testRemoveDatabaseSelectionNechaPoVZkladuJmenoDatabazeVDatech(): void
+    {
+        // Jméno produkční DB jako součást textové hodnoty (ne příkazu) se nesmí
+        // odstranit — pravidlo cílí jen na celé příkazy CREATE/USE/DROP DATABASE.
+        $sql = "INSERT INTO `logy` VALUES ('USE d16779_gcostra zmíněno v textu');\n";
+
+        $vysledek = $this->spustNadObsahem($sql);
+
+        self::assertSame($sql, $vysledek);
+    }
+
+    public function testRemoveDatabaseSelectionOdstraniDropDatabase(): void
+    {
+        $sql = "DROP DATABASE IF EXISTS `d16779_gcostra`;\nSELECT 1;\n";
+
+        $vysledek = $this->spustNadObsahem($sql);
+
+        self::assertStringNotContainsString('DROP DATABASE', $vysledek);
+        self::assertStringContainsString('SELECT 1;', $vysledek);
+    }
+
+    private function spustNadObsahem(string $sql): string
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'nastroje-databaze-test-');
+        file_put_contents($this->tempFile, $sql);
+
+        NastrojeDatabaze::removeDatabaseSelection($this->tempFile);
+
+        return file_get_contents($this->tempFile);
+    }
+}


### PR DESCRIPTION
Na betě jde v adminu **Nastavení** „Zkopírovat databázi z ostré". Na preview to dosud nešlo vůbec — tahle změna tam zpřístupní **import z `.sql.gz` zálohy ostré**.

## Co se mění
- `SystemoveNastaveniHtml` pouští blok kopie DB i na preview (dosud jen beta/locale). Nadpis sekce je podle prostředí (Beta/Preview/Local).
- Na preview se z těch tří variant ukazuje **jen** import ze zálohy. Živý mysqldump z ostré ani kopie archivního ročníku tam nejdou — admin běží v kontejneru jako DB účet `gc_preview_<slug>`, který nemá práva na produkční `d16779_gcostra` ani na `gamecon_YYYY`.
- `NastrojeDatabaze::removeDatabaseSelection()` odstraní z dumpu `CREATE DATABASE`/`USE`/`DROP DATABASE`, aby se obsah zálohy nahrál do aktuální (preview/beta) DB místo přepnutí na produkční jméno DB. Voláno při importu ze zálohy (chrání i betu).

## Doručení dumpu do preview kontejneru
Read-only bind-mount hostového `ostra/backup/db` na stejnou relativní cestu, kterou čte beta. Viz párový PR v ansible repu (`preview-mount-ostra-backup-db`).

## Testy
- Nový `NastrojeDatabazeTest` na `removeDatabaseSelection` (3 případy).
- `KopieOstreDatabazeTest` dál prochází (import + migrace).