### PR TITLE
Povolit přepnutí na uživatele i na locale

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,12 +1,14 @@
 <?php
 
-use Gamecon\XTemplate\XTemplate;
+declare(strict_types=1);
+
+use Gamecon\Cas\DateTimeCz;
+use Gamecon\Pravo;
+use Gamecon\Role\Role;
+use Gamecon\Uzivatel\Platby;
 use Gamecon\Web\Info;
 use Gamecon\Web\VerzeSouboru;
-use Gamecon\Role\Role;
-use Gamecon\Pravo;
-use Gamecon\Uzivatel\Platby;
-use Gamecon\Cas\DateTimeCz;
+use Gamecon\XTemplate\XTemplate;
 
 require __DIR__ . '/../nastaveni/zavadec.php';
 
@@ -19,7 +21,7 @@ if (HTTPS_ONLY) {
 
 // nastaví uživatele $u a $uPracovni
 require __DIR__ . '/scripts/prihlaseni.php';
-/**
+/*
  * @var Uzivatel|void|null $u
  * @var Uzivatel|void|null $uPracovni
  */
@@ -29,7 +31,7 @@ require __DIR__ . '/scripts/prihlaseni.php';
 include __DIR__ . '/_symfony.php';
 
 // nastavení stránky, prázdná url => přesměrování na úvod
-if (!$stranka) {
+if (! $stranka) {
     if ($u) {
         if ($u->jeOrganizator() && $u->maPravo(Pravo::ADMINISTRACE_INFOPULT)) {
             back(URL_ADMIN . '/' . basename(__DIR__ . '/scripts/modules/uzivatel.php', '.php'));
@@ -44,7 +46,7 @@ if (!$stranka) {
     }
 }
 
-if ($stranka == "api") {
+if ($stranka === 'api') {
     $apiDir = __DIR__ . '/scripts/api';
     chdir($apiDir);
     if (is_file($apiDir . '/' . $podstranka . '.php')) {
@@ -69,17 +71,19 @@ $xtpl->assign([
     'cssVersions'             => new VerzeSouboru(__DIR__ . '/files/design', 'css'),
     'jsVersions'              => new VerzeSouboru(__DIR__ . '/files', 'js'),
     'urlSPracovnimUzivatelem' => $uPracovni
-        ? getCurrentUrlWithQuery(['pracovni_uzivatel' => $uPracovni->id()])
+        ? getCurrentUrlWithQuery([
+            'pracovni_uzivatel' => $uPracovni->id(),
+        ])
         : '',
 ]);
 
 // kontrola přihlášení při ajaxovém volání (kvůli elektronickým prezenčkám)
-if (!$u && get('ajax')) {
+if (! $u && get('ajax')) {
     http_response_code(403);
 }
 
 // zobrazení stránky
-if (!$u && !in_array($stranka, ['last-minute-tabule', 'program-obecny'])) {
+if (! $u && ! in_array($stranka, ['last-minute-tabule', 'program-obecny'], true)) {
     require __DIR__ . '/login.php';
     profilInfo();
 
@@ -110,9 +114,9 @@ if (VAROVAT_O_ZASEKLE_SYNCHRONIZACI_PLATEB && $u && $u->jeOrganizator() && empty
     ) {
         varovani(
             'Platby z Fio byly naposledy aktualizovány ' . (
-            $platbyNaposledyAktualizovanyKdy === null
-                ? '"nikdy"'
-                : DateTimeCz::createFromInterface($platbyNaposledyAktualizovanyKdy)->relativni()
+                $platbyNaposledyAktualizovanyKdy === null
+                    ? '"nikdy"'
+                    : DateTimeCz::createFromInterface($platbyNaposledyAktualizovanyKdy)->relativni()
             ),
             false,
         );
@@ -127,7 +131,7 @@ $menu = $menuObject->pole();
 // načtení submenu
 $submenu = [];
 $submenuObject = null;
-if (!empty($menu[$stranka]['submenu'])) {
+if (! empty($menu[$stranka]['submenu'])) {
     $submenuObject = new AdminMenu(__DIR__ . '/scripts/modules/' . $stranka . '/', true);
     $submenu = $submenuObject->pole();
 }
@@ -173,7 +177,7 @@ if ($strankaExistuje && $uzivatelMaPristup) {
     if ($BEZ_DEKORACE) {
         return;
     }
-} elseif ($strankaExistuje && !$uzivatelMaPristup) {
+} elseif ($strankaExistuje && ! $uzivatelMaPristup) {
     http_response_code(403);
     if ($u) {
         $xtpl->assign('a', $u->koncovkaDlePohlavi());
@@ -193,9 +197,9 @@ if ($strankaExistuje && $uzivatelMaPristup) {
 // operátor - info & odhlašování
 $xtpl->assign('a', $u->koncovkaDlePohlavi());
 $xtpl->assign('operator', $u->jmenoNick());
-if ($u && ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || $u->jeInfopultak())) {
+if ($u && ($u->muzePrepnoutNaJinehoUzivatele() || $u->jeInfopultak())) {
     $dataOmnibox = [];
-    if ($u->jeInfopultak() && !$u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE)) {
+    if ($u->jeInfopultak() && ! $u->muzePrepnoutNaJinehoUzivatele()) {
         $dataOmnibox['jenSRolemi'] = [Role::LETOSNI_VYPRAVEC, Role::LETOSNI_PARTNER];
     }
     $xtpl->assign('dataOmniboxJson', htmlspecialchars(json_encode($dataOmnibox, JSON_FORCE_OBJECT)));
@@ -211,7 +215,7 @@ if ($u && $u->maPravo(Pravo::ADMINISTRACE_INFOPULT)) {
         $xtpl->parse('all.uzivatel.omnibox');
     }
     $historiePredchozich = $_SESSION['pracovni_uzivatel_predchozi'] ?? [];
-    if (!is_array($historiePredchozich)) {
+    if (! is_array($historiePredchozich)) {
         $historiePredchozich = $historiePredchozich ? [$historiePredchozich] : [];
     }
     $idPracovnihoUzivatele = $uPracovni ? $uPracovni->id() : null;
@@ -239,7 +243,7 @@ foreach ($menu as $url => $polozka) {
     if ($u->maPravo($polozka['pravo'])) {
         $xtpl->assign('url', $url);
         $xtpl->assign('nazev', $polozka['nazev']);
-        $xtpl->assign('aktivni', $stranka == $url
+        $xtpl->assign('aktivni', $stranka === $url
             ? 'class="active"'
             : '');
         $xtpl->parse('all.menuPolozka');
@@ -252,9 +256,9 @@ uasort($submenu, function (
     $b,
 ) {
     $diff = $a['group'] - $b['group'];
-    if ($diff == 0) {
+    if ($diff === 0) {
         $diff = $a['order'] - $b['order'];
-        if ($diff == 0) {
+        if ($diff === 0) {
             return 0;
         }
     }
@@ -266,7 +270,7 @@ uasort($submenu, function (
 $allHidden = true;
 foreach ($submenu as $url => $polozka) {
     if ($u && $u->maPravo($polozka['pravo'])) {
-        $xtpl->assign('url', $url == $stranka
+        $xtpl->assign('url', $url === $stranka
             ? $url
             : $stranka . '/' . $url);
         $xtpl->assign('nazev', $polozka['nazev']);
@@ -274,14 +278,14 @@ foreach ($submenu as $url => $polozka) {
         if ($polozka['link_in_blank']) {
             $addAttributes[] = 'target="_blank"';
         }
-        if (($podstranka != '' && $podstranka == $url) || ($podstranka == '' && $stranka == $url)) {
+        if (($podstranka !== '' && $podstranka === $url) || ($podstranka === '' && $stranka === $url)) {
             $addAttributes[] = 'class="activeSubmenuLink"';
             $info->nazev($polozka['nazev']);
         }
         $xtpl->assign('add_attributes', implode(' ', $addAttributes));
 
         $displayPolozka = '';
-        if (!empty($polozka['hidden'])) {
+        if (! empty($polozka['hidden'])) {
             $displayPolozka = 'none';
         } else {
             $allHidden = false;
@@ -289,7 +293,7 @@ foreach ($submenu as $url => $polozka) {
         $xtpl->assign('displayPolozka', $displayPolozka);
 
         $itemBreak = '';
-        if ($polozka['order'] == 1 && $polozka['group'] > 1) {
+        if ($polozka['order'] === 1 && $polozka['group'] > 1) {
             $itemBreak = '</ul></li><li><ul class="adm_submenu_group">';
         }
         $xtpl->assign('break', $itemBreak);
@@ -319,7 +323,7 @@ $info->nazev($info->nazev() ?? '', 'Administrace');
 $xtpl->assign('protip', $protipy[array_rand($protipy)]);
 $xtpl->parse('all.paticka');
 $xtpl->assign('chyba', chyba::vyzvedniHtml());
-$xtpl->assign('jsVyjimkovac', \Gamecon\Vyjimkovac\Vyjimkovac::js(URL_WEBU));
+$xtpl->assign('jsVyjimkovac', Gamecon\Vyjimkovac\Vyjimkovac::js(URL_WEBU));
 $xtpl->assign('headerPageInfo', $info->html());
 $xtpl->parse('all');
 $xtpl->out('all');

--- a/admin/scripts/prihlaseni.php
+++ b/admin/scripts/prihlaseni.php
@@ -6,7 +6,6 @@ use Gamecon\Dev\ArchivSsoPrihlaseni;
 use Gamecon\Dev\SsoParovaciCookie;
 use Gamecon\Exceptions\UzivatelNenalezen;
 use Gamecon\Login\Login;
-use Gamecon\Pravo;
 
 /*
  * Kód starající o přihlášení uživatele a výběr uživatele pro práci
@@ -115,9 +114,9 @@ if (post('zrusitUzivateleProPraci')) {
 
 if (post('prihlasitSeJakoUzivatel')) {
     try {
-        if ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || $u->jeInfopultak()) {
+        if ($u->muzePrepnoutNaJinehoUzivatele() || $u->jeInfopultak()) {
             $potencialniUzivatel = Uzivatel::zIdUrcite(post('id'));
-            if ($u->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || $potencialniUzivatel->jeVypravec() || $potencialniUzivatel->jePartner()) {
+            if ($u->muzePrepnoutNaJinehoUzivatele() || $potencialniUzivatel->jeVypravec() || $potencialniUzivatel->jePartner()) {
                 $u = Uzivatel::prihlasId(post('id'));
                 back($u->jeVypravec() || $u->jePartner()
                     ? $u->mojeAktivityAdminUrl()

--- a/docs/generated/prepnuti-na-uzivatele.md
+++ b/docs/generated/prepnuti-na-uzivatele.md
@@ -6,7 +6,7 @@ TL;DR: Schopnost přihlásit se v adminu jako libovolný uživatel ("přepnout s
 - Právo: `Gamecon\Pravo::PREPNUTI_NA_UZIVATELE` (= 114), `model/Pravo.php`.
 - Role (ročníková): `Gamecon\Role\Role::LETOSNI_PREPINANI_UZIVATELE()`, base id `ROLE_PREPINANI_UZIVATELE_ID_ZAKLAD = 30`, význam `VYZNAM_PREPINANI_UZIVATELE`.
 - Konstanta `ROLE_PREPINANI_UZIVATELE`: `nastaveni/nastaveni-role.php`.
-- Vynucení práva: `admin/scripts/prihlaseni.php` (větev `prihlasitSeJakoUzivatel`) a `admin/index.php` (zobrazení omniboxu „přepnutí uživatele“).
+- Vynucení práva: `admin/scripts/prihlaseni.php` (větev `prihlasitSeJakoUzivatel`) a `admin/index.php` (zobrazení omniboxu „přepnutí uživatele“). Obě místa volají `Uzivatel::muzePrepnoutNaJinehoUzivatele()` (= drží právo **nebo** `jsmeNaLocale()`).
 - Auto-zakládání role pro nový ročník: `migrace/9999_01-letosni-role-krome-ucasti-endless.php` (iteruje `Role::vsechnyRocnikoveRole`).
 - První zavedení: `migrace/2026-05-24-111857_prepnuti-na-uzivatele-pravo.php`.
 
@@ -15,6 +15,7 @@ TL;DR: Schopnost přihlásit se v adminu jako libovolný uživatel ("přepnout s
 - **(záměr)** **Uděluje rada** (`CLEN_RADY`), ne kdokoli: role má `kategorie_role = KATEGORIE_OMEZENA (0)`, takže `Uzivatel::maPravoNaPrirazeniRole()` ji pustí přidělit jen členu rady. Viz `Role::kategoriePodleVyznamu(VYZNAM_PREPINANI_UZIVATELE) => KATEGORIE_OMEZENA`.
 - **(záměr)** Držení `CLEN_RADY` samo o sobě **nedává** přepínání — člen rady ji musí dostat přiřazenou jako každý jiný. Rada tedy právo *spravuje*, ale automaticky *nemá*.
 - **(záměr)** Pro rok 2026 není přiřazen **nikdo** — rada přiřadí ručně přes `/admin/prava`. Do té doby nemůže přepínat nikdo.
+- **(záměr)** **Na locale (`jsmeNaLocale()`) smí přepínat každý admin i bez přiřazené role.** Lokální vývoj jede na čerstvě naseedované DB, kde nikomu není přiřazená letošní ročníková role pro přepínání — bez tohoto pravidla by se vývojář na svém stroji nemohl přepnout vůbec. Na preview řeší tentýž problém deploy příkazem `app:grant-switch-user-role-to-devs` (uděluje roli Dev uživatelům po restore ostré DB); na locale to řeší přímo `muzePrepnoutNaJinehoUzivatele()`. Není to bezpečnostní díra — locale je vývojářův vlastní stroj.
 - Infopulťák (`jeInfopultak`) má i nadále vlastní *omezené* přepínání (jen na vypravěče/partnery) nezávisle na tomto právu — viz druhá větev v `admin/index.php` / `prihlaseni.php`.
 
 ## Gotchas

--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -24,13 +24,13 @@ use Gamecon\Uzivatel\Exceptions\DuplicitniLogin;
 use Gamecon\Uzivatel\Finance;
 use Gamecon\Uzivatel\Medailonek;
 use Gamecon\Uzivatel\Pohlavi;
-use Gamecon\Uzivatel\ZpusobZobrazeniNaWebu;
 use Gamecon\Uzivatel\SqlStruktura\PlatneRoleUzivateluSqlStruktura;
 use Gamecon\Uzivatel\SqlStruktura\PravaRoleSqlStruktura;
 use Gamecon\Uzivatel\SqlStruktura\UzivateleHodnotySqlStruktura as Sql;
 use Gamecon\Uzivatel\UserController;
 use Gamecon\Uzivatel\UserRepository;
 use Gamecon\Uzivatel\UzivatelSlucovani;
+use Gamecon\Uzivatel\ZpusobZobrazeniNaWebu;
 
 /**
  * Třída popisující uživatele a jeho vlastnosti
@@ -128,7 +128,7 @@ class Uzivatel extends DbObject
      */
     public function odeberZamceneUdajePoKontrole(array $udaje): array
     {
-        if (!$this->maZkontrolovaneUdaje()) {
+        if (! $this->maZkontrolovaneUdaje()) {
             return $udaje;
         }
 
@@ -223,10 +223,10 @@ SQL, [Pravo::PORADANI_AKTIVIT],
     public function nechceUbytovani(?bool $nechceUbytovani = null): bool
     {
         if ($nechceUbytovani !== null) {
-            $this->r[Sql::NECHCE_UBYTOVANI] = (int)$nechceUbytovani;
+            $this->r[Sql::NECHCE_UBYTOVANI] = (int) $nechceUbytovani;
         }
 
-        return (bool)($this->r[Sql::NECHCE_UBYTOVANI] ?? false);
+        return (bool) ($this->r[Sql::NECHCE_UBYTOVANI] ?? false);
     }
 
     /**
@@ -775,17 +775,10 @@ SQL,
 
     public function zkontrolujGcPrihlasen(
         bool $hlaskyVeTretiOsobe = false,
-        ?DataSourcesCollector $dataSourcesCollector = null) {
-        if (!$this->gcPrihlasen($dataSourcesCollector)) {
-            throw new \Chyba(
-                ($hlaskyVeTretiOsobe
-                    ? 'Uživatel ' . $this->jmenoVolitelnyNick() . ' '
-                    : ''
-                ) .
-                hlaska($hlaskyVeTretiOsobe
-                    ? 'neniPrihlasenNaGc'
-                    : 'nejsiPrihlasenNaGc'),
-            );
+        ?DataSourcesCollector $dataSourcesCollector = null)
+    {
+        if (! $this->gcPrihlasen($dataSourcesCollector)) {
+            throw new Chyba(($hlaskyVeTretiOsobe ? 'Uživatel ' . $this->jmenoVolitelnyNick() . ' ' : '') . hlaska($hlaskyVeTretiOsobe ? 'neniPrihlasenNaGc' : 'nejsiPrihlasenNaGc'));
         }
     }
 
@@ -965,16 +958,16 @@ SQL,
 
     public static function jmenoNaWebuZjisti(array $r): string
     {
-        $jmeno     = trim((string) ($r[Sql::JMENO_UZIVATELE] ?? ''));
-        $prijmeni  = trim((string) ($r[Sql::PRIJMENI_UZIVATELE] ?? ''));
-        $login     = trim((string) ($r[Sql::LOGIN_UZIVATELE] ?? ''));
-        $nick      = str_contains($login, '@') ? '' : $login;
+        $jmeno = trim((string) ($r[Sql::JMENO_UZIVATELE] ?? ''));
+        $prijmeni = trim((string) ($r[Sql::PRIJMENI_UZIVATELE] ?? ''));
+        $login = trim((string) ($r[Sql::LOGIN_UZIVATELE] ?? ''));
+        $nick = str_contains($login, '@') ? '' : $login;
         $celeJmeno = trim($jmeno . ' ' . $prijmeni);
 
         $zpusob = ZpusobZobrazeniNaWebu::zHodnoty($r[Sql::ZPUSOB_ZOBRAZENI_NA_WEBU] ?? null);
 
         $zvolene = match ($zpusob) {
-            ZpusobZobrazeniNaWebu::JMENO_A_PRIJMENI => $celeJmeno,
+            ZpusobZobrazeniNaWebu::JMENO_A_PRIJMENI              => $celeJmeno,
             ZpusobZobrazeniNaWebu::JMENO_S_PREZDIVKOU_A_PRIJMENI => $nick === ''
                 ? ''
                 : trim(implode(' ', array_filter(
@@ -1188,6 +1181,20 @@ SQL,
         return $this->maRoli(Role::LETOSNI_INFOPULT);
     }
 
+    /**
+     * Smí se v adminu přihlásit jako libovolný uživatel ("přepnout se na").
+     *
+     * Drží-li právo PREPNUTI_NA_UZIVATELE, nebo běžíme na locale: lokální vývoj
+     * jede na čerstvě naseedované DB, kde nikomu není přiřazená ročníková role
+     * pro přepínání (stejný problém jako na preview, kde ji deploy uděluje
+     * příkazem app:grant-switch-user-role-to-devs). Na vlastním stroji vývojáře
+     * je plné přepínání bez bezpečnostního rizika, tak ho povolíme rovnou.
+     */
+    public function muzePrepnoutNaJinehoUzivatele(): bool
+    {
+        return $this->maPravo(Pravo::PREPNUTI_NA_UZIVATELE) || jsmeNaLocale();
+    }
+
     public function jeHerman(): bool
     {
         return $this->maRoli(Role::LETOSNI_HERMAN);
@@ -1202,9 +1209,10 @@ SQL,
         ?Aktivita $ignorovanaAktivita = null,
         bool $jenPritomen = false,
     ): ?Aktivita {
-        if (!$aktivita->zacatek() || !$aktivita->konec()) {
+        if (! $aktivita->zacatek() || ! $aktivita->konec()) {
             return null;
         }
+
         return $this->maKoliziSJinouAktivitouVCase($aktivita->zacatek(), $aktivita->konec(), $ignorovanaAktivita, $jenPritomen);
     }
 
@@ -1965,9 +1973,9 @@ SQL,
                 '^(' . implode('|', ZpusobZobrazeniNaWebu::platneHodnoty()) . ')$',
                 'vyber prosím způsob zobrazení na webu',
             ],
-            Sql::POHLAVI                  => ['^(m|f)$', 'vyber prosím pohlaví'],
-            'heslo'                       => $validaceHesla,
-            'heslo_kontrola'              => $validaceHesla,
+            Sql::POHLAVI     => ['^(m|f)$', 'vyber prosím pohlaví'],
+            'heslo'          => $validaceHesla,
+            'heslo_kontrola' => $validaceHesla,
         ];
 
         // provedení validací
@@ -2071,7 +2079,7 @@ SQL,
      * pole "vypraveci" v aktivity.json, pokud je uživatel vypravěčem.
      */
     public static function zmeniloSeJmenoNaWebu(
-        self  $stavajici,
+        self $stavajici,
         array $noveHodnoty,
     ): bool {
         $sledovanaPole = [
@@ -2100,14 +2108,14 @@ SQL,
     public static function invalidujProgramCacheJeLiVypravecem(int $idUzivatele): void
     {
         $systemoveNastaveni = SystemoveNastaveni::zGlobals();
-        $jeVypravec         = (bool) dbOneCol(
+        $jeVypravec = (bool) dbOneCol(
             'SELECT 1 FROM akce_organizatori
                 JOIN akce_seznam ON akce_seznam.id_akce = akce_organizatori.id_akce
                 WHERE akce_organizatori.id_uzivatele = $1 AND akce_seznam.rok = $2
                 LIMIT 1',
             [$idUzivatele, $systemoveNastaveni->rocnik()],
         );
-        if (!$jeVypravec) {
+        if (! $jeVypravec) {
             return;
         }
         (new ProgramStaticFileGenerator($systemoveNastaveni))
@@ -2948,38 +2956,39 @@ SQL;
     /**
      * Vrací anonymní objekt pro api
      */
-    public function apiUzivatel() {
+    public function apiUzivatel()
+    {
         $res = [];
 
-        $res["id"] = $this->id();
-        $res["pohlavi"] = $this->pohlavi();
+        $res['id'] = $this->id();
+        $res['pohlavi'] = $this->pohlavi();
 
-        $res["gcStav"] = "nepřihlášen";
+        $res['gcStav'] = 'nepřihlášen';
 
         if ($this->gcPrihlasen()) {
-            $res["gcStav"] = "přihlášen";
+            $res['gcStav'] = 'přihlášen';
         }
         if ($this->gcPritomen()) {
-            $res["gcStav"] = "přítomen";
+            $res['gcStav'] = 'přítomen';
         }
         if ($this->gcOdjel()) {
-            $res["gcStav"] = "odjel";
+            $res['gcStav'] = 'odjel';
         }
 
         $role = [];
 
         if ($this->jeOrganizator()) {
-            $role["organizator"] = true;
+            $role['organizator'] = true;
         }
         if ($this->jeBrigadnik()) {
-            $role["brigadnik"] = true;
+            $role['brigadnik'] = true;
         }
         if ($this->maRoli(Role::SEF_INFOPULTU)) {
-            $role["sefInfa"] = true;
+            $role['sefInfa'] = true;
         }
 
-        if (!empty($role)){
-            $res["role"] = $role;
+        if (! empty($role)) {
+            $res['role'] = $role;
         }
 
         return $res;
@@ -2987,10 +2996,9 @@ SQL;
 
     /**
      * Používá fetchPřihlášenýUživatel.
-     *
-     * @param bool $ucastnikJeOperator používá se když chceme ignorovat uPraconi
      */
-    public static function apiPrihlasenyUzivatel() {
+    public static function apiPrihlasenyUzivatel()
+    {
         /** @var Uzivatel $u */
         global $u;
         /** @var Uzivatel $uPracovni */
@@ -3000,8 +3008,8 @@ SQL;
         $ucastnik = $uPracovni ? $uPracovni : $u;
 
         return [
-            "ucastnik" => $ucastnik?->apiUzivatel(),
-            "operator" => $operator?->apiUzivatel(),
+            'ucastnik' => $ucastnik?->apiUzivatel(),
+            'operator' => $operator?->apiUzivatel(),
         ];
     }
 }

--- a/tests/Uzivatel/PrepnutiNaUzivateleTest.php
+++ b/tests/Uzivatel/PrepnutiNaUzivateleTest.php
@@ -97,4 +97,38 @@ SQL,
             'Uživatel bez práva na přepnutí nesmí přepnout na uživatele',
         );
     }
+
+    /**
+     * Lokální vývoj jede na čerstvě naseedované DB, kde nikomu není přiřazená
+     * ročníková role pro přepínání — bez tohoto pravidla by se vývojář nemohl
+     * přepnout na jiného uživatele vůbec. Testy běží na locale (ENV=local),
+     * takže ho rovnou ověřujeme v reálném locale prostředí.
+     */
+    public function testNaLocaleSmiPrepnoutIBezPrava(): void
+    {
+        self::assertTrue(jsmeNaLocale(), 'Předpoklad testu: testy běží na locale');
+
+        $uzivatel = $this->vytvorUzivatele('locale_bez_prava');
+        $uzivatel = $this->pridelPravo($uzivatel, Pravo::ADMINISTRACE_INFOPULT);
+        self::assertFalse(
+            $uzivatel->maPravo(Pravo::PREPNUTI_NA_UZIVATELE),
+            'Předpoklad testu: uživatel nemá právo na přepnutí',
+        );
+
+        self::assertTrue(
+            $uzivatel->muzePrepnoutNaJinehoUzivatele(),
+            'Na locale smí přepnout na uživatele i bez přiděleného práva',
+        );
+    }
+
+    public function testSPravemSmiPrepnout(): void
+    {
+        $uzivatel = $this->vytvorUzivatele('s_pravem_muze_prepnout');
+        $uzivatel = $this->pridelPravo($uzivatel, Pravo::PREPNUTI_NA_UZIVATELE);
+
+        self::assertTrue(
+            $uzivatel->muzePrepnoutNaJinehoUzivatele(),
+            'Uživatel s přiděleným právem smí přepnout na uživatele',
+        );
+    }
 }


### PR DESCRIPTION
V adminu jde „přihlásit se jako libovolný uživatel" (omnibox „přepnutí uživatele" v hlavičce). Dosud to viselo jen na ročníkovém právu `PREPNUTI_NA_UZIVATELE`.

## Problém
Lokální vývoj jede na čerstvě naseedované DB, kde letošní ročníkovou roli pro přepínání nikdo nemá → vývojář se na svém stroji nemohl přepnout vůbec. Na preview tentýž problém řeší deploy příkazem `app:grant-switch-user-role-to-devs` (uděluje roli Dev uživatelům po restore ostré DB).

## Řešení
Nová metoda `Uzivatel::muzePrepnoutNaJinehoUzivatele()` = drží právo **nebo** `jsmeNaLocale()`. Použitá v obou místech, kde se přepínání vynucuje:
- `admin/index.php` — zobrazení omniboxu (vč. správného `jenSRolemi` omezení pro infopulťáka bez plného práva),
- `admin/scripts/prihlaseni.php` — POST handler `prihlasitSeJakoUzivatel`.

Není to bezpečnostní díra — locale je vývojářův vlastní stroj. Beta/preview/ostrá se nemění (tam stále rozhoduje právo).

## Testy
`PrepnutiNaUzivateleTest` rozšířen: na locale (kde testy běží) smí přepnout i uživatel bez práva; uživatel s právem smí přepnout. Vše prochází.