### PR TITLE
Seřadit přihlášené dle pořadí přihlášení, přidat sledující

### DIFF
--- a/admin/scripts/modules/aktivity/prihlaseni.php
+++ b/admin/scripts/modules/aktivity/prihlaseni.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Stránka pro přehled všech přihlášených na aktivity
  *
@@ -9,19 +11,20 @@
  * submenu_order: 1
  */
 
+use Gamecon\Aktivita\StavPrihlaseni;
 use Gamecon\Cas\DateTimeCz;
 use Gamecon\XTemplate\XTemplate;
 
 $xtpl2 = new XTemplate(__DIR__ . '/prihlaseni.xtpl');
 
 $naDateTimeCz = static function (?string $datum): ?DateTimeCz {
-    if (!$datum || str_starts_with($datum, '0000-00-00')) {
+    if (! $datum || str_starts_with($datum, '0000-00-00')) {
         return null;
     }
 
     try {
         return new DateTimeCz($datum);
-    } catch (\Throwable) {
+    } catch (Throwable) {
         return null;
     }
 };
@@ -51,14 +54,14 @@ $formatVek = static function (?string $datumNarozeni, ?DateTimeCz $datumAktivity
 
     return $vek >= 18
         ? '18+'
-        : (string)$vek;
+        : (string) $vek;
 };
 
 $formatDatumPrihlaseni = static function (?string $datumPrihlaseni) use ($naDateTimeCz): string {
     $prihlasen = $naDateTimeCz($datumPrihlaseni);
 
     return $prihlasen
-        ? $prihlasen->format('j.n. H:i')
+        ? $prihlasen->format('j. n. H:i:s')
         : '';
 };
 
@@ -68,12 +71,18 @@ while ($r = mysqli_fetch_assoc($o)) {
     $xtpl2->parse('prihlaseni.vyber');
 }
 
-if (!get('typ')) {
+if (! get('typ')) {
     $xtpl2->parse('prihlaseni');
     $xtpl2->out('prihlaseni');
+
     return;
 }
 
+// Přihlášení (akce_prihlaseni) i sledující (akce_prihlaseni_spec, stav SLEDUJICI)
+// sjednotíme do jednoho seznamu. Sledující řadíme na konec aktivity (je_sledujici),
+// uvnitř každé skupiny pak od nejdříve přihlášeného (datum_prihlaseni) – stejně
+// jako v online prezenci.
+$sledujici = StavPrihlaseni::SLEDUJICI;
 $odpoved = dbQuery(<<<SQL
 SELECT  akce_seznam.nazev_akce AS nazevAktivity, akce_seznam.id_akce AS id,
         (akce_seznam.kapacita + akce_seznam.kapacita_m + akce_seznam.kapacita_f) AS kapacita,
@@ -81,6 +90,7 @@ SELECT  akce_seznam.nazev_akce AS nazevAktivity, akce_seznam.id_akce AS id,
         ucastnik.login_uzivatele AS nick, ucastnik.jmeno_uzivatele AS jmeno, ucastnik.id_uzivatele,
         ucastnik.prijmeni_uzivatele AS prijmeni, ucastnik.email1_uzivatele AS mail, ucastnik.telefon_uzivatele AS telefon,
         ucastnik.datum_narozeni,
+        prihlaseni.je_sledujici,
         (SELECT GROUP_CONCAT(organizator.login_uzivatele SEPARATOR ', ')
             FROM akce_organizatori
             JOIN uzivatele_hodnoty AS organizator ON organizator.id_uzivatele = akce_organizatori.id_uzivatele
@@ -97,51 +107,70 @@ SELECT  akce_seznam.nazev_akce AS nazevAktivity, akce_seznam.id_akce AS id,
         ) AS mistnost,
         MAX(log.kdy) AS datum_prihlaseni
 FROM akce_seznam
-LEFT JOIN akce_prihlaseni ON akce_seznam.id_akce = akce_prihlaseni.id_akce
-LEFT JOIN uzivatele_hodnoty AS ucastnik ON akce_prihlaseni.id_uzivatele = ucastnik.id_uzivatele
+LEFT JOIN (
+        SELECT id_akce, id_uzivatele, 0 AS je_sledujici FROM akce_prihlaseni
+        UNION ALL
+        SELECT id_akce, id_uzivatele, 1 AS je_sledujici FROM akce_prihlaseni_spec WHERE id_stavu_prihlaseni = $2
+    ) AS prihlaseni ON akce_seznam.id_akce = prihlaseni.id_akce
+LEFT JOIN uzivatele_hodnoty AS ucastnik ON prihlaseni.id_uzivatele = ucastnik.id_uzivatele
 LEFT JOIN akce_prihlaseni_log AS log ON log.id_akce = akce_seznam.id_akce AND log.id_uzivatele = ucastnik.id_uzivatele
 WHERE akce_seznam.rok = $0
     AND akce_seznam.zacatek
     AND akce_seznam.typ = $1
-GROUP BY ucastnik.id_uzivatele, akce_seznam.id_akce, akce_seznam.nazev_akce, akce_seznam.zacatek
-ORDER BY akce_seznam.zacatek, akce_seznam.nazev_akce, akce_seznam.id_akce, ucastnik.id_uzivatele
+GROUP BY ucastnik.id_uzivatele, prihlaseni.je_sledujici, akce_seznam.id_akce, akce_seznam.nazev_akce, akce_seznam.zacatek
+ORDER BY akce_seznam.zacatek, akce_seznam.nazev_akce, akce_seznam.id_akce,
+         prihlaseni.je_sledujici, MAX(log.kdy), ucastnik.id_uzivatele
 SQL,
-    [0 => ROCNIK, 1 => get('typ')]
+    [
+        0 => ROCNIK,
+        1 => get('typ'),
+        2 => $sledujici,
+    ]
 );
 
-$totoPrihlaseni  = mysqli_fetch_assoc($odpoved) ?: [];
+$totoPrihlaseni = mysqli_fetch_assoc($odpoved) ?: [];
 $dalsiPrihlaseni = mysqli_fetch_assoc($odpoved) ?: [];
-$obsazenost      = 0;
-$odd             = 0;
-$maily           = [];
+$obsazenost = 0;
+$pocetSledujicich = 0;
+$odd = 0;
+$maily = [];
 while ($totoPrihlaseni) {
+    $jeSledujici = (bool) ($totoPrihlaseni['je_sledujici'] ?? false);
     $xtpl2->assign($totoPrihlaseni);
     $xtpl2->assign('datum_prihlaseni', '');
+    $xtpl2->assign('sledujiciTrida', $jeSledujici ? 'sledujici' : '');
+    $xtpl2->assign('sledujiciStitek', $jeSledujici ? ' (sledující)' : '');
     if ($totoPrihlaseni['id_uzivatele']) {
         $datumAktivity = $naDateTimeCz($totoPrihlaseni['zacatek'] ?? null);
         $xtpl2->assign('vek', $formatVek($totoPrihlaseni['datum_narozeni'] ?? null, $datumAktivity));
         $xtpl2->assign('datum_prihlaseni', $formatDatumPrihlaseni($totoPrihlaseni['datum_prihlaseni'] ?? null));
         $xtpl2->assign('odd', $odd ? $odd = '' : $odd = 'odd');
         $xtpl2->parse('prihlaseni.aktivita.lide.clovek');
-        $maily[] = $totoPrihlaseni['mail'];
-        $obsazenost++;
+        if ($jeSledujici) {
+            ++$pocetSledujicich;
+        } else {
+            $maily[] = $totoPrihlaseni['mail'];
+            ++$obsazenost;
+        }
     }
-    if (($totoPrihlaseni['id'] ?? null) != ($dalsiPrihlaseni['id'] ?? null)) {
+    if (($totoPrihlaseni['id'] ?? null) !== ($dalsiPrihlaseni['id'] ?? null)) {
         $xtpl2->assign('maily', implode('; ', $maily));
         $xtpl2->assign('cas', $formatCasAktivity($totoPrihlaseni));
         $xtpl2->assign('orgove', $totoPrihlaseni['orgove']);
         $xtpl2->assign('obsazenost', $obsazenost .
-            ($totoPrihlaseni['kapacita'] ? '/' . $totoPrihlaseni['kapacita'] : ''));
+            ($totoPrihlaseni['kapacita'] ? '/' . $totoPrihlaseni['kapacita'] : '') .
+            ($pocetSledujicich ? " + {$pocetSledujicich} sledujících" : ''));
         $xtpl2->assign('druzina', '');
-        if ($obsazenost) {
+        if ($obsazenost || $pocetSledujicich) {
             $xtpl2->parse('prihlaseni.aktivita.lide');
         }
         $xtpl2->parse('prihlaseni.aktivita');
         $obsazenost = 0;
-        $odd        = 0;
-        $maily      = [];
+        $pocetSledujicich = 0;
+        $odd = 0;
+        $maily = [];
     }
-    $totoPrihlaseni  = $dalsiPrihlaseni;
+    $totoPrihlaseni = $dalsiPrihlaseni;
     $dalsiPrihlaseni = mysqli_fetch_assoc($odpoved);
 }
 

--- a/admin/scripts/modules/aktivity/prihlaseni.xtpl
+++ b/admin/scripts/modules/aktivity/prihlaseni.xtpl
@@ -1,5 +1,9 @@
 <!-- begin:prihlaseni -->
 
+<style>
+.vypis tr.sledujici { color: #888; font-style: italic; }
+</style>
+
 <ul class="aktivityPrihlaseni_seznam_menu">
 <!-- begin:vyber -->
   <li><a href="aktivity/prihlaseni?typ={id_typu}">{typ_1pmn}</a></li>
@@ -33,8 +37,8 @@ function tgl(id)
     <th style="min-width: 125px">Datum</th>
   </tr>
   <!-- begin:clovek -->
-  <tr class="{odd}">
-    <td>{nick}</td>
+  <tr class="{odd} {sledujiciTrida}">
+    <td>{nick}{sledujiciStitek}</td>
     <td>{jmeno} {prijmeni}</td>
     <td>{mail}</td>
     <td>{vek}</td>


### PR DESCRIPTION
Seznam přihlášených (`admin/aktivity/prihlaseni`) nově řadí účastníky **od nejdříve přihlášeného k pozdějšímu** – stejně jako online prezence – místo dosavadního řazení podle ID uživatele.

## Změny

- **Přihlášení účastníci** se řadí podle času přihlášení (`MAX(akce_prihlaseni_log.kdy)` vzestupně), ne podle `id_uzivatele`.
- **Sledující** (`akce_prihlaseni_spec`, stav `SLEDUJICI`), které tato stránka dosud vůbec nezobrazovala, jsou nově zařazeni **na konec každé aktivity** a mezi sebou rovněž seřazeni podle času přihlášení.
- Sledující se **nepočítají do obsazenosti** ani do seznamu mailů („e-mail všem“); místo toho má aktivita zvlášť uvedený počet `+ N sledujících`.
- Řádek sledujícího je vizuálně odlišen štítkem `(sleduje)` a tlumeným stylem.

Výsledné řazení: `zacatek, nazev_akce, id_akce, je_sledujici, MAX(log.kdy), id_uzivatele`.

## Ověření

- SQL dotaz spuštěn přímo proti dev DB – přihlášení vychází od nejdříve přihlášeného, sledující na konci.
- Vyrenderování celé stránky s `typ=2`: 51 řádků sledujících označeno `(sleduje)`, 35 aktivit s `+ N sledujících`, bez chyb.
- `ecs --fix` na změněném PHP.