### PR TITLE
Umožnit sledování i u gender-plné aktivity

### DIFF
--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -8,6 +8,7 @@ Pravidla **kdy** konzultovat / vytvořit dokument jsou v kořenovém `CLAUDE.md`
 
 <!-- Formát: `- [nazev-souboru](nazev-souboru.md) — jedna věta o čem to je` -->
 
+- [sledovani-aktivit](sledovani-aktivit.md) — watchlist aktivity (mail při uvolnění místa); kde se zobrazuje „sledovat/zrušit", jediný trigger mailu v `odhlas()` při `volno()==='x'`; tři chyby u genderově rozdělených aktivit (volno jen pro opačné pohlaví → nejde sledovat ani odhlásit ze sledování, maily se neposílají)
 - [prepnuti-na-uzivatele](prepnuti-na-uzivatele.md) — přihlášení v adminu jako libovolný uživatel; dřív hardcoded „superadmin“, nově dočasné ročníkové právo udělované radou
 - [archiv-rekonstrukce-z-wayback](archiv-rekonstrukce-z-wayback.md) — postavení `NNNN.gamecon.cz` jako statického archivu z Internet Archive pro ročníky bez DB/kódu (≤2011, hotovo 2005–2011); kde hledat zdroj (2006–2008 = `gamecon.altar.cz`, 2005− = path `altar.cz/gamecon/`, jiný CMS, ISO-8859-2), tři year-guardy, landmines (logo, absolutní odkazy, 403, jiný CMS, `[R]` redirect, CDX okno přeteče do dalšího roku, chybějící charset → mojibake), operační sekvence
 

--- a/docs/generated/sledovani-aktivit.md
+++ b/docs/generated/sledovani-aktivit.md
@@ -1,0 +1,56 @@
+# sledovani-aktivit
+
+TL;DR: „Sledování" (watchlist) aktivity = uživatel si nechá poslat mail, až se na plné aktivitě uvolní místo. Dokument popisuje, kde se zobrazuje tlačítko „sledovat / zrušit sledování", kdy a komu se posílá mail, a tři reálné chyby u **genderově rozdělených** aktivit (volno jen pro opačné pohlaví) nahlášené testerem 2026-06.
+
+## Datový model
+
+- Stav sledování je řádek v `akce_prihlaseni_spec` se `id_stavu_prihlaseni = StavPrihlaseni::SLEDUJICI` (= 5).
+- `StavPrihlaseni::SLEDUJICI` v `model/Aktivita/StavPrihlaseni.php`.
+- Struktura tabulky: `model/Aktivita/SqlStruktura/AkcePrihlaseniSpecSqlStruktura.php` (`id_akce`, `id_uzivatele`, `id_stavu_prihlaseni`).
+
+## Vstupní body v kódu
+
+- `Aktivita::prihlasovatko()` — `model/Aktivita/Aktivita.php` (cca ř. 3122) — renderuje přihlašovátko vč. „sledovat" / „zrušit sledování".
+- `Aktivita::volno()` — tamtéž (cca ř. 3677) — vrací typ volného místa: `'u'` volno / `'x'` plno / `'f'` zbývají jen ženská místa / `'m'` zbývají jen mužská místa.
+- `Aktivita::prihlasovatelnaProSledujici()` — `return !$this->tymova() && !$this->jeSoucastiTurnaje();` — sledovat lze jen netýmové aktivity mimo turnaj.
+- `Aktivita::prihlasSledujiciho()` / `odhlasSledujiciho()` — zápis/smazání řádku v `akce_prihlaseni_spec`.
+- `Aktivita::poslatMailSledujicim()` — `model/Aktivita/Aktivita.php` (cca ř. 2375) — odešle mail (`hlaskaMail('uvolneneMisto', …)`).
+- **Jediný spouštěč mailu**: `Aktivita::odhlas()` (cca ř. 2039): `if ($this->volno() === "x" && !($params & NEPOSILAT_MAILY_SLEDUJICIM))`. Žádný cron, žádný jiný trigger, žádná fronta/retry — posílá se synchronně v requestu odhlášení.
+- Mail šablona `uvolneneMisto` v `nastaveni/hlasky/nastaveni-hlasky-subst.php`.
+
+## Jak se rozhoduje zobrazení (přihlašovátko)
+
+Řetěz `if/elseif` v `prihlasovatko()`. Po opravě (2026-06) větve `'f'`/`'m'` přidávají k textu i odkaz na sledování přes `prihlasovatkoSledovani()`:
+```
+$volno = $this->volno();
+if ($volno === 'u' || $volno == $u->pohlavi()) { ... "přihlásit" ... }
+elseif ($volno === 'f') { $out = 'pouze ženská místa' . $this->prihlasovatkoSledovani($u, ' | '); }
+elseif ($volno === 'm') { $out = 'pouze mužská místa' . $this->prihlasovatkoSledovani($u, ' | '); }
+else { $out = $this->prihlasovatkoSledovani($u); }   // 'x' = úplně plno
+```
+`prihlasovatkoSledovani()` vrátí „sledovat" / „zrušit sledování" (dle `prihlasenJakoSledujici`), nebo prázdný řetězec když aktivitu nelze sledovat (`!prihlasovatelnaProSledujici()` → týmová / turnaj).
+
+## Tři chyby u genderově rozdělených aktivit (nález 2026-06, tester)
+
+Příčina chyb 1+2: stav `'f'`/`'m'` z `volno()` (volno jen pro opačné pohlaví) je z pohledu dotčeného uživatele *plno*, ale starý kód ho neřešil jako plno — větve `'f'`/`'m'` vracely jen statický text a `elseif` řetěz tím končil, takže větev se sledováním byla nedosažitelná.
+
+1. **(OPRAVENO 2026-06) Nešlo začít sledovat.** Screenshot: `A.R.C.H.A. ♀ 3/5 ♂ 3/3 pouze ženská místa` (bez „sledovat"). Nyní se vedle textu zobrazí i „sledovat".
+
+2. **(OPRAVENO 2026-06) Nešlo zrušit sledování.** Když uživatel sledoval aktivitu (kdysi `'x'`) a ta se odemkla na `'f'`/`'m'`, zůstal ve sledování bez možnosti se odhlásit. Screenshot: `Temná ulička ♀ 3/4 ♂ 5/5 pouze ženská místa`. Nyní se vedle textu zobrazí „zrušit sledování".
+
+   Test: `tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php`.
+
+3. **(NEOPRAVENO) Maily sledujícím „celkově nefungují".** (nejisté — odvozeno z kódu, neověřeno z provozu) Dva slabé body:
+   - Podmínka odeslání je `volno() === "x"` *před* odhlášením. Genderově rozdělená aktivita se ale snáz dostane do `'f'`/`'m'` než do `'x'`. Když se uvolní místo na aktivitě, která byla `'f'` (nebo `'m'`), `volno()` před odhlášením **nebylo `'x'`** → **mail se neodešle**, přestože se reálně uvolnilo místo, které sledující správného pohlaví může chtít.
+   - `poslatMailSledujicim()` nefiltruje podle pohlaví — pošle **všem** sledujícím. U gender-aktivity tak může dostat „uvolnilo se místo" i sledující, pro jehož pohlaví se nic neuvolnilo.
+   - Žádný retry: selhání SMTP v requestu = ztracený mail.
+
+## Stav oprav
+
+- **Zobrazení (bug 1+2)** — HOTOVO 2026-06. `prihlasovatkoSledovani()` přidá odkaz na sledování i ve větvích `'f'`/`'m'`. Text „pouze X místa" je správný jen pro uživatele opačného pohlaví; uživateli, pro jehož pohlaví je volno, vrátí `volno() == $u->pohlavi()` „přihlásit" už dřív — do `'f'`/`'m'` větve tedy spadne jen ten, pro koho je reálně plno, takže nabídka sledování dává smysl.
+- **Maily (bug 3)** — NEOPRAVENO. Větší zásah do logiky obsazenosti: spouštět `poslatMailSledujicim()` i při přechodu z `'f'`/`'m'` na volno pro dané pohlaví (ne jen z `'x'`), a ideálně filtrovat příjemce dle pohlaví, pro které se místo uvolnilo. Před implementací ověřit reálné chování z logů.
+
+## Gotchas
+
+- `prihlasovatelnaProSledujici()` vylučuje týmové aktivity a aktivity v turnaji — sledování u nich neexistuje záměrně.
+- `NEPOSILAT_MAILY_SLEDUJICIM` flag se používá při hromadných operacích (mazání uživatele `model/uzivatel.php`, prezence `AktivitaPrezence.php`), aby se neposílaly maily — ne bug, záměr.

--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -3171,23 +3171,12 @@ HTML
                         '<a href="#" onclick="this.parentNode.submit(); return false">přihlásit</a>' .
                         '</form>';
                 } elseif ($volno === 'f') {
-                    $out = 'pouze ženská místa';
+                    // volno už je jen pro ženy → pro tohoto uživatele (muže) je plno, smí proto sledovat
+                    $out = 'pouze ženská místa' . $this->prihlasovatkoSledovani($u, ' | ');
                 } elseif ($volno === 'm') {
-                    $out = 'pouze mužská místa';
-                } elseif ($this->prihlasovatelnaProSledujici()) {
-                    if ($u->prihlasenJakoSledujici($this)) {
-                        $out =
-                            '<form method="post" style="display:inline">' .
-                            '<input type="hidden" name="odhlasSledujiciho" value="' . $this->id() . '">' .
-                            '<a href="#" onclick="this.parentNode.submit(); return false">zrušit sledování</a>' .
-                            '</form>';
-                    } else {
-                        $out =
-                            '<form method="post" style="display:inline">' .
-                            '<input type="hidden" name="prihlasSledujiciho" value="' . $this->id() . '">' .
-                            '<a href="#" onclick="this.parentNode.submit(); return false">sledovat</a>' .
-                            '</form>';
-                    }
+                    $out = 'pouze mužská místa' . $this->prihlasovatkoSledovani($u, ' | ');
+                } else {
+                    $out = $this->prihlasovatkoSledovani($u);
                 }
             }
         }
@@ -3196,6 +3185,33 @@ HTML
         }
 
         return $out;
+    }
+
+    /**
+     * Odkaz „sledovat" / „zrušit sledování" pro uživatele, pro kterého je aktivita plná.
+     * Vrátí prázdný řetězec, pokud aktivitu nelze sledovat (týmová, součást turnaje).
+     * $prefix se vloží před odkaz jen když nějaký odkaz vznikne (oddělovač od textu „pouze … místa").
+     */
+    private function prihlasovatkoSledovani(Uzivatel $u, string $prefix = ''): string
+    {
+        if (!$this->prihlasovatelnaProSledujici()) {
+            return '';
+        }
+        if ($u->prihlasenJakoSledujici($this)) {
+            $formular =
+                '<form method="post" style="display:inline">' .
+                '<input type="hidden" name="odhlasSledujiciho" value="' . $this->id() . '">' .
+                '<a href="#" onclick="this.parentNode.submit(); return false">zrušit sledování</a>' .
+                '</form>';
+        } else {
+            $formular =
+                '<form method="post" style="display:inline">' .
+                '<input type="hidden" name="prihlasSledujiciho" value="' . $this->id() . '">' .
+                '<a href="#" onclick="this.parentNode.submit(); return false">sledovat</a>' .
+                '</form>';
+        }
+
+        return $prefix . $formular;
     }
 
     public function formatujDuvodProTesting(string $duvod): string

--- a/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
+++ b/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Aktivity;
+
+use App\Structure\Sql\UserRoleSqlStructure as UserRoleSql;
+use App\Structure\Sql\UserSqlStructure as UserSql;
+use Gamecon\Aktivita\Aktivita;
+use Gamecon\Aktivita\SqlStruktura\AkceSeznamSqlStruktura as AktivitaSql;
+use Gamecon\Aktivita\StavAktivity;
+use Gamecon\Aktivita\TypAktivity;
+use Gamecon\Role\Role;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Gamecon\Tests\Db\AbstractTestDb;
+use Gamecon\Uzivatel\Pohlavi;
+
+/**
+ * Genderově rozdělená aktivita, kde zbývají volná místa jen pro opačné pohlaví
+ * (volno() === 'f' / 'm'), musí přesto nabídnout sledování — z pohledu uživatele,
+ * pro jehož pohlaví už je plno, je aktivita plná a sledovat ji dává smysl.
+ */
+class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
+{
+    use ProbihaRegistraceAktivitTrait;
+
+    protected static bool $disableStrictTransTables = true;
+
+    private SystemoveNastaveni $systemoveNastaveni;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->systemoveNastaveni = self::vytvorSystemoveNastaveni();
+    }
+
+    public function testKdyzMuziVyzraliMistaNabidneSeMuziSledovani(): void
+    {
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 2, kapacitaZen: 2);
+        $this->zaplnMuzskaMista($aktivita, 2);
+
+        // muž, pro kterého je aktivita plná (zbývají jen ženská místa)
+        $muz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+
+        $out = $aktivita->prihlasovatko($muz, 0);
+
+        self::assertStringContainsString('pouze ženská místa', $out);
+        self::assertStringContainsString('sledovat', $out);
+        self::assertStringContainsString('prihlasSledujiciho', $out);
+    }
+
+    public function testZeSledovaniSeLzeOdhlasitIKdyzZbyvajiMistaOpacnehoPohlavi(): void
+    {
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 2, kapacitaZen: 2);
+        $this->zaplnMuzskaMista($aktivita, 2);
+
+        $muz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlasSledujiciho($muz, $muz);
+        self::assertTrue($aktivita->prihlasenJakoSledujici($muz));
+
+        $out = $aktivita->prihlasovatko($muz, 0);
+
+        self::assertStringContainsString('pouze ženská místa', $out);
+        self::assertStringContainsString('zrušit sledování', $out);
+        self::assertStringContainsString('odhlasSledujiciho', $out);
+    }
+
+    public function testUplnePlnaAktivitaNabidneSledovaniBeztextu(): void
+    {
+        // regrese: u úplně plné aktivity (volno() === 'x') zůstává jen odkaz na sledování, bez textu „pouze … místa"
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 0);
+        $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        self::assertSame('x', $aktivita->volno());
+
+        $dalsiMuz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $out = $aktivita->prihlasovatko($dalsiMuz, 0);
+
+        self::assertStringNotContainsString('pouze', $out);
+        self::assertStringContainsString('sledovat', $out);
+    }
+
+    private function genderoveRozdelenaAktivita(int $kapacitaMuzu, int $kapacitaZen): Aktivita
+    {
+        dbInsert(AktivitaSql::AKCE_SEZNAM_TABULKA, [
+            AktivitaSql::NAZEV_AKCE => 'Genderově rozdělená aktivita',
+            AktivitaSql::TYP        => TypAktivity::LARP,
+            AktivitaSql::ROK        => ROCNIK,
+            AktivitaSql::STAV       => StavAktivity::AKTIVOVANA,
+            AktivitaSql::ZACATEK    => ROCNIK . '-07-16 10:00:00',
+            AktivitaSql::KONEC      => ROCNIK . '-07-16 13:00:00',
+            AktivitaSql::KAPACITA   => 0,
+            AktivitaSql::KAPACITA_M => $kapacitaMuzu,
+            AktivitaSql::KAPACITA_F => $kapacitaZen,
+            AktivitaSql::CENA       => 0,
+            AktivitaSql::TEAMOVA    => 0,
+        ]);
+
+        return Aktivita::zId((int) dbInsertId(), false, $this->systemoveNastaveni);
+    }
+
+    private function zaplnMuzskaMista(Aktivita $aktivita, int $pocet): void
+    {
+        for ($i = 0; $i < $pocet; ++$i) {
+            $muz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+            $aktivita->prihlas($muz, $muz, Aktivita::UKAZAT_DETAILY_CHYBY);
+        }
+        self::assertSame('f', $aktivita->volno(), 'Muži měli vyžrat všechna mužská místa');
+    }
+
+    private function prihlasenyUzivatelNaGc(string $pohlavi): \Uzivatel
+    {
+        $cislo = self::unikatniCislo();
+        dbInsert(UserSql::_table, [
+            UserSql::login_uzivatele  => 'test_' . $cislo,
+            UserSql::email1_uzivatele => 'godric.cz+gc_test_' . $cislo . '@gmail.com',
+            UserSql::pohlavi          => $pohlavi,
+        ]);
+        $idUzivatele = dbInsertId();
+        dbInsert(UserRoleSql::_table, [
+            UserRoleSql::id_uzivatele => $idUzivatele,
+            UserRoleSql::id_role      => Role::PRIHLASEN_NA_LETOSNI_GC,
+        ]);
+        $uzivatel = \Uzivatel::zId($idUzivatele);
+        self::assertNotNull($uzivatel);
+        self::assertTrue($uzivatel->gcPrihlasen());
+
+        return $uzivatel;
+    }
+
+    private static function unikatniCislo(): int
+    {
+        static $pocitadlo = 100000;
+
+        return ++$pocitadlo;
+    }
+}


### PR DESCRIPTION
## Problém

U genderově rozdělené aktivity, kde zbývají volná místa **jen pro opačné pohlaví** (`Aktivita::volno()` vrací `'f'` / `'m'`), je z pohledu dotčeného uživatele aktivita plná — ale staré větvení v `prihlasovatko()` zobrazilo pouze statický text „pouze ženská/mužská místa" a `elseif` řetěz tím skončil. Větev se sledováním byla nedosažitelná, takže:

1. **nešlo začít sledovat** — chyběl odkaz „sledovat" (např. `A.R.C.H.A. ♀ 3/5 ♂ 3/3 pouze ženská místa`),
2. **nešlo se ze sledování odhlásit** — chyběl odkaz „zrušit sledování" (např. `Temná ulička ♀ 3/4 ♂ 5/5 pouze ženská místa`).

Nahlásil tester; logicky sledovat jít má.

## Oprava

- Logika „sledovat / zrušit sledování" vytažena do privátní metody `prihlasovatkoSledovani($u, $prefix)`.
- Ve větvích `'f'` / `'m'` se k textu „pouze … místa" připojí i odkaz na sledování (oddělený `|`).
- Chování úplně plné aktivity (`volno() === 'x'`) i týmových / turnajových aktivit zůstává beze změny (metoda vrátí prázdný řetězec, když aktivitu nelze sledovat).

## Testy

Nový `tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php` (test-first — nejdřív selhal, odhalil chybu):

- muž u aktivity s volnými jen ženskými místy vidí „sledovat",
- ve stejné situaci jde „zrušit sledování",
- regrese: úplně plná aktivita nadále nabízí jen „sledovat", bez textu „pouze…".

Související sada `tests/Aktivity` zelená.

## Mimo rozsah

Odesílání mailů sledujícím (tester píše, že „sledování celkově moc nefunguje, co se mailů týče") je samostatný, větší zásah do logiky obsazenosti — řešeno zvlášť (Trello). Popsáno v `docs/generated/sledovani-aktivit.md`.
