### PR TITLE
Opravit závod deploye a teardownu preview (zombie preview)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,13 +34,22 @@ permissions:
 # clean up (the teardown workflow only fires on `pull_request: closed`,
 # which has already fired).
 #
-# Keying on head_ref (PRs) / ref_name (push, workflow_dispatch) matches
-# the slug derivation below — runs for the same branch queue, runs for
-# different branches stay parallel. `cancel-in-progress: false` so an
+# Keying on head_ref (PRs) / ref_name (push, delete, workflow_dispatch)
+# matches the slug derivation below — runs for the same branch queue, runs
+# for different branches stay parallel. `cancel-in-progress: false` so an
 # in-flight deploy completes before teardown starts, rather than being
 # killed mid-build and leaving partial state on GHCR or the host.
+#
+# All fields below MUST resolve to the SAME short branch name across event
+# types, or the deploy and teardown of one branch land in different groups
+# and run in parallel — exactly the race this block exists to stop. Do NOT
+# add `github.event.ref`: on a push it is the FULL ref (`refs/heads/foo`),
+# which differs from the PR event's short `head.ref` (`foo`), so the two
+# never share a group and a deploy finishing after the merge-teardown
+# recreates a zombie preview. `github.ref_name` already covers push /
+# delete / workflow_dispatch with the short name.
 concurrency:
-    group: deploy-preview-${{ github.event.pull_request.head.ref || github.event.inputs.branch || github.event.ref || github.ref_name }}
+    group: deploy-preview-${{ github.event.pull_request.head.ref || github.event.inputs.branch || github.ref_name }}
     cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Zavřené/mergnuté PR měly v `admin/web/previews` stále viset svoje preview prostředí (nahlášeno u [#956](https://github.com/gamecon-cz/gamecon/pull/956), ale postihlo i #955, #924 a dvě větve bez PR).

## Příčina

`concurrency.group` ve `deploy-preview.yml` měl serializovat deploy a teardown stejné větve, aby teardown po mergi nezávodil s dobíhajícím deployem. Klíčoval ale na **surové jméno větve**, které se ovšem u různých event typů bere z různých polí:

- **push** → `github.event.ref` = `refs/heads/sledovani-program-preact-gender`
- **pull_request** → `github.event.pull_request.head.ref` = `sledovani-program-preact-gender`

Různé řetězce → **různé concurrency skupiny** → deploy a teardown běžely paralelně. Reálně se to stalo u #956 (12. 6. 2026):

| čas | běh | konec |
|-----|-----|-------|
| 05:39:32 | deploy (push „Ztmavit oddělovač…") | **05:44:51** |
| 05:41:57 | teardown (`--remove`, PR merge) | 05:42:06 |

Teardown odstranil preview v 05:42, ale deploy doběhl až v 05:44 a `deploy-preview-branch.sh` ho znovu vytvořil → zombie, který už nic neuklidí (teardown se na zavřený PR podruhé nespustí). Časová známka „Deployed 05:44" v seznamu to potvrzuje.

## Oprava

Odstraněn `github.event.ref` z řetězce. `github.ref_name` (krátké jméno větve) pokrývá push / delete / workflow_dispatch a shoduje se s PR `head.ref`, takže všechny event typy spadnou do stejné skupiny a deploy + teardown se serializují.

## Úklid existujících zombie

Tahle změna brání **budoucím** zombie. Už visící zombie (#956, #955, #924 a dvě větve bez PR) je potřeba smazat ručně na hostu:

```
ssh root@gamecon.cz "/usr/local/sbin/deploy-preview-branch.sh --remove '<slug>'"
```

pro slugy: `sledovani-program-preact-gende`, `sledovani-gender-rozdelene-akt`, `document-main-pr-policy`, `1194-kratky-popis-importovane`, `1458-nejdou-pridat-loga`. (`reset-hesla-magic-link` má otevřený PR #891 — nechat.)