### PR TITLE
Logo v mailu obnovy hesla vkládat inline (cid)

### DIFF
--- a/model/Kanaly/GcMail.php
+++ b/model/Kanaly/GcMail.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Gamecon\Kanaly;
 
 use Gamecon\Kanaly\Exceptions\ChybiEmailoveNastaveni;
@@ -8,7 +10,6 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Throwable;
 
 /**
  * Třída pro sestavování mailu
@@ -28,46 +29,55 @@ class GcMail
         );
     }
 
-    private array  $adresati = [];
-    private string $predmet  = '';
+    private array $adresati = [];
+    private string $predmet = '';
     private ?Address $odesilatel = null;
-    /** @var array<int, array{soubor: string, nazev: string}> */
-    private array  $prilohy  = [];
+    /**
+     * @var array<int, array{soubor: string, nazev: string}>
+     */
+    private array $prilohy = [];
+    /**
+     * @var array<int, array{soubor: string, cid: string}>
+     */
+    private array $obrazkyInline = [];
 
     public function __construct(
         private readonly SystemoveNastaveni $systemoveNastaveni,
-        private string                      $text = '',
-        private readonly ?MailLogger        $mailLogger = null,
-    )
-    {
+        private string $text = '',
+        private readonly ?MailLogger $mailLogger = null,
+    ) {
     }
 
     public function adresat(string $adresat): self
     {
         $this->adresati[] = $adresat;
+
         return $this;
     }
 
     public function adresati(array $adresati): self
     {
         $this->adresati = $adresati;
+
         return $this;
     }
 
     public function odesilatel(Address $odesilatel): self
     {
         $this->odesilatel = $odesilatel;
+
         return $this;
     }
 
     /**
      * Odešle sestavenou zprávu.
+     *
      * @return bool jestli se zprávu podařilo odeslat
      */
     public function odeslat(string $format = self::FORMAT_HTML)
     {
         $predmet = $this->pridejPrefixPodleProstredi($this->dejPredmet());
-        $mail    = (new Email())
+        $mail = (new Email())
             ->from($this->odesilatelSPrefixemProstredi())
             ->subject($predmet);
         $body = $this->pridejPrefixPodleProstredi($this->dejText());
@@ -76,6 +86,11 @@ class GcMail
         if ($format === self::FORMAT_HTML) {
             $mail->html($body);
             $teloHtml = $body;
+            foreach ($this->obrazkyInline as $obrazek) {
+                if ($obrazek['soubor'] !== '' && is_file($obrazek['soubor'])) {
+                    $mail->embedFromPath($obrazek['soubor'], $obrazek['cid']);
+                }
+            }
         }
 
         $odeslano = false;
@@ -101,19 +116,20 @@ class GcMail
                 $mailer->send($mail);
                 $odeslano = true;
                 $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString(), $teloHtml);
-            } catch (Throwable $chyba) {
+            } catch (\Throwable $chyba) {
                 $this->zalogujOdeslani($predmet, $format, $adresati, $mail->toString(), $teloHtml, $chyba->getMessage());
                 throw $chyba;
             }
         }
+
         return $odeslano;
     }
 
     private function zalogujOdeslani(
-        string  $predmet,
-        string  $format,
-        array   $adresati,
-        string  $telo,
+        string $predmet,
+        string $format,
+        array $adresati,
+        string $telo,
         ?string $teloHtml = null,
         ?string $chyba = null,
     ): void {
@@ -121,7 +137,7 @@ class GcMail
         $pocetPriloh = 0;
         foreach ($this->prilohy as $priloha) {
             if ($priloha['soubor'] !== '') {
-                $pocetPriloh++;
+                ++$pocetPriloh;
             }
         }
         $mailLogger->zalogujOdeslani(
@@ -143,7 +159,7 @@ class GcMail
     private function odesilatelSPrefixemProstredi(): Address
     {
         $odesilatel = $this->odesilatel ?? $this->vychoziOdesilatel();
-        $prefix     = $this->systemoveNastaveni->prefixPodleProstredi();
+        $prefix = $this->systemoveNastaveni->prefixPodleProstredi();
         if ($prefix === '') {
             return $odesilatel;
         }
@@ -167,68 +183,72 @@ class GcMail
         if (preg_match('~^\s*<html>\s*<body>~i', $text)) {
             return preg_replace('~^\s*<html>\s*<body>~i', '$0' . $prefix . ' ', $text);
         }
+
         return $prefix . ' ' . $text;
     }
 
     private function mailerTransport(): Transport\TransportInterface
     {
-        if (!defined('MAILER_DSN')) {
-            /**
+        if (! defined('MAILER_DSN')) {
+            /*
              * Návod @link https://symfony.com/doc/current/mailer.html#transport-setup
              * SMTP server: smtp.gmail.com:465
              */
-            throw new ChybiEmailoveNastaveni(
-                "Pro odeslání emailu je třeba nastavit konstantu 'MAILER_DSN'"
-            );
+            throw new ChybiEmailoveNastaveni("Pro odeslání emailu je třeba nastavit konstantu 'MAILER_DSN'");
         }
+
         return Transport::fromDsn(MAILER_DSN);
     }
 
     private function adresatiDoSouboru(): array
     {
-        if (!defined('MAILY_DO_SOUBORU') || !MAILY_DO_SOUBORU) {
+        if (! defined('MAILY_DO_SOUBORU') || ! MAILY_DO_SOUBORU) {
             return [];
         }
+
         return array_diff($this->adresati, $this->adresatiPovoleniPodleRoli());
     }
 
     private function adresatiPovoleniPodleRoli(): array
     {
-        if (!defined('MAILY_DO_SOUBORU') || !MAILY_DO_SOUBORU) {
+        if (! defined('MAILY_DO_SOUBORU') || ! MAILY_DO_SOUBORU) {
             return $this->adresati;
         }
-        if (!defined('MAILY_ROLIM') || !MAILY_ROLIM) {
+        if (! defined('MAILY_ROLIM') || ! MAILY_ROLIM) {
             return [];
         }
         $povoleniPodleRoli = [];
         foreach ($this->adresati as $adresat) {
-            if (!preg_match('~(?<email>[^@\s<>]+@[^@\s<>]+)~', $adresat, $matches)) {
+            if (! preg_match('~(?<email>[^@\s<>]+@[^@\s<>]+)~', $adresat, $matches)) {
                 continue;
             }
-            $email    = $matches['email'];
+            $email = $matches['email'];
             $uzivatel = \Uzivatel::zEmailu($email);
-            if (!$uzivatel) {
+            if (! $uzivatel) {
                 continue;
             }
-            foreach ((array)MAILY_ROLIM as $role) {
+            foreach ((array) MAILY_ROLIM as $role) {
                 if ($uzivatel->maRoli($role)) {
                     $povoleniPodleRoli[] = $adresat;
                     break;
                 }
             }
         }
+
         return $povoleniPodleRoli;
     }
 
     public function predmet(string $predmet): self
     {
         $this->predmet = $predmet;
+
         return $this;
     }
 
     public function text(string $text): self
     {
         $this->text = $text;
+
         return $this;
     }
 
@@ -247,12 +267,28 @@ class GcMail
         return $this->predmet;
     }
 
+    /**
+     * Vloží obrázek přímo do těla mailu (multipart/related) a zpřístupní ho
+     * v HTML přes `<img src="cid:$cid">`. Na rozdíl od odkazu na URL ho klient
+     * zobrazí i bez „načíst obrázky" (Gmail, Outlook, Apple Mail, …).
+     */
+    public function obrazekInline(string $cesta, string $cid): self
+    {
+        $this->obrazkyInline[] = [
+            'soubor' => $cesta,
+            'cid'    => $cid,
+        ];
+
+        return $this;
+    }
+
     public function prilohaSoubor(string $cesta): self
     {
         $this->prilohy[] = [
             'soubor' => $cesta,
             'nazev'  => basename($cesta),
         ];
+
         return $this;
     }
 
@@ -263,6 +299,7 @@ class GcMail
                 'soubor' => '',
                 'nazev'  => $nazev,
             ];
+
             return $this;
         }
 
@@ -270,7 +307,7 @@ class GcMail
         if ($posledniPriloha !== null) {
             $this->prilohy[$posledniPriloha]['nazev'] = $nazev;
         }
+
         return $this;
     }
-
 }

--- a/model/Kanaly/GcMailSablona.php
+++ b/model/Kanaly/GcMailSablona.php
@@ -24,6 +24,19 @@ class GcMailSablona
     // záhlaví, proto musí sedět na {@see CERVENA}.
     private const LOGO_CESTA = '/soubory/blackarrow/menu/logo-email.png';
 
+    // Logo vkládáme do mailu inline (cid:) — viz {@see logoSoubor()}. Klient
+    // ho pak zobrazí i bez „načíst obrázky", na rozdíl od odkazu na URL.
+    public const LOGO_CID = 'gamecon-logo';
+
+    /**
+     * Cesta k souboru loga na disku — volající ho vloží do mailu přes
+     * {@see \Gamecon\Kanaly\GcMail::obrazekInline()} pod {@see LOGO_CID}.
+     */
+    public static function logoSoubor(): string
+    {
+        return WWW . self::LOGO_CESTA;
+    }
+
     /**
      * @param string $obsahHtml vnitřní obsah mailu (už jako HTML, např. z hlaskaMail())
      */
@@ -33,9 +46,7 @@ class GcMailSablona
         $tmava = self::TMAVA;
         $kremova = self::KREMOVA;
         $pismo = self::PISMO;
-        // Absolutní URL z aktuálního prostředí — asset i odkaz na něj se
-        // nasazují společně, takže nevzniká okno, kdy obrázek 404uje.
-        $logoUrl = URL_WEBU . self::LOGO_CESTA;
+        $logoCid = self::LOGO_CID;
         $rok = date('Y');
 
         $nadpisHtml = $nadpis === ''
@@ -58,7 +69,7 @@ class GcMailSablona
                             <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width: 600px; max-width: 100%; background-color: #ffffff; border-radius: 12px; overflow: hidden;">
                                 <tr>
                                     <td style="background-color: {$cervena}; padding: 24px 40px;">
-                                        <img src="{$logoUrl}" alt="GameCon" width="175" height="36" style="display: block; border: 0; width: 175px; height: auto; font-size: 24px; font-weight: 800; color: #ffffff;">
+                                        <img src="cid:{$logoCid}" alt="GameCon" width="175" height="36" style="display: block; border: 0; width: 175px; height: auto; font-size: 24px; font-weight: 800; color: #ffffff;">
                                     </td>
                                 </tr>
                                 <tr>

--- a/symfony/src/Controller/ObnovaHeslaController.php
+++ b/symfony/src/Controller/ObnovaHeslaController.php
@@ -240,6 +240,7 @@ class ObnovaHeslaController extends AbstractController
         $mail = new GcMail(\Gamecon\SystemoveNastaveni\SystemoveNastaveni::zGlobals(), $telo);
         $mail->adresat($uzivatel->mail());
         $mail->predmet('Obnova hesla na GameConu');
+        $mail->obrazekInline(GcMailSablona::logoSoubor(), GcMailSablona::LOGO_CID);
         $mail->odeslat();
     }
 


### PR DESCRIPTION
## Proč

Logo v mailu obnovy hesla se načítalo z `https://gamecon.cz/...` (vzdálený obrázek). Mailoví klienti vzdálené obrázky standardně blokují, dokud uživatel neklikne „načíst obrázky" — takže e-mail vypadal rozbitě (rozbitý obrázek / prázdné záhlaví).

## Co se mění

Logo se teď **vkládá přímo do mailu inline (CID, `multipart/related`)** přes `<img src="cid:gamecon-logo">`. Tím se zobrazí i bez „načíst obrázky" v Gmailu, Outlooku, Apple Mailu, Thunderbirdu i jinde. `data:` base64 v `src` jsme záměrně nepoužili — Gmail ho v `<img>` ořezává.

## Jak

- `GcMail::obrazekInline($cesta, $cid)` — vloží obrázek přes Symfony `Email::embedFromPath()`.
- `GcMailSablona` — `<img>` míří na `cid:`; nová `logoSoubor()` vrací cestu k souboru loga a konstanta `LOGO_CID`.
- `ObnovaHeslaController::posliResetMail()` zaregistruje logo k vložení před odesláním.

Odpadá tím i závislost na produkční URL loga (žádné okno, kdy by obrázek 404oval před nasazením assetu).

## Ověřeno

Odeslaný mail v Mailpitu: HTML `<img src="cid:…">`, v MIME je `image/png` část s `Content-ID` (base64), žádný odkaz na vzdálenou URL. Logo tak cestuje uvnitř mailu.
