### PR TITLE
Nespouštět preview deploy pro Dependabot PR

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,8 +55,15 @@ concurrency:
 jobs:
     # Deploy on push to a feature branch (or workflow_dispatch). NOT on
     # pull_request (closed → teardown) or delete (branch gone → teardown).
+    #
+    # Skip Dependabot's branches: a `dependabot[bot]` push runs with a
+    # read-only token and no access to the deploy secrets, so the SSH
+    # step always fails — a dependency bump needs no preview anyway.
+    # `workflow_dispatch` stays exempt so a human can still force one.
     deploy:
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: >-
+            (github.event_name == 'push' && github.actor != 'dependabot[bot]')
+            || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-24.04
         steps:
             -   name: Checkout code


### PR DESCRIPTION
Dependabot pushe běží s read-only tokenem bez přístupu k deploy secrets, takže `deploy` job v `deploy-preview.yml` na nich vždy selže na SSH kroku ("Trigger deploy on gamecon.cz"). Bump závislosti žádný preview nepotřebuje.

Přidává podmínku, že `deploy` job běží na `push` jen když `github.actor != 'dependabot[bot]'`. `workflow_dispatch` zůstává nedotčený — člověk může preview vynutit ručně. Teardown joby (zavření PR / smazání větve) se nemění.

Důsledek: Dependabot PR budou mít zelený požadovaný check ("Run tests job") a nebudou už generovat falešně selhávající preview deploy.