### PR TITLE
Serializovat deploye, zabránit FTP race

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -7,6 +7,15 @@ on:
             - 'beta'
     workflow_dispatch:
 
+# Serialize BETA deploys for the same reason as OSTRA: concurrent FTP
+# syncs race on `.deploytmp` files and fail with "Overwrite permission
+# denied". A separate group from ostra (different target) so the two
+# never block each other. `cancel-in-progress: false` so an in-flight
+# sync completes instead of being killed mid-upload.
+concurrency:
+    group: deploy-beta
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-ostra.yml
+++ b/.github/workflows/deploy-ostra.yml
@@ -7,6 +7,18 @@ on:
             - 'main'
     workflow_dispatch:
 
+# Serialize OSTRA deploys. The FTP deployment uploads each file as a
+# `.deploytmp` then renames it into place; two deploys running at once
+# race on those temp files and the loser dies with "Overwrite permission
+# denied". A burst of merges to `main` (e.g. several Dependabot PRs in
+# quick succession) otherwise launches one concurrent deploy per merge.
+# `cancel-in-progress: false` lets an in-flight sync finish rather than
+# being killed mid-upload, which could leave prod half-updated; later
+# deploys queue and run one after another.
+concurrency:
+    group: deploy-ostra
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problém

`deploy-ostra.yml` ani `deploy-beta.yml` nemají `concurrency` blok. Když na `main` přijde víc merge rychle za sebou (typicky dávka Dependabot PR), spustí se jeden deploy na každý merge a všechny běží **paralelně proti stejnému FTP serveru**.

FTP deployment (`dg/ftp-deployment`) nahrává každý soubor jako `<soubor>.deploytmp` a pak ho přejmenuje na místo. Dva souběžné deploye se na těch temp souborech porvou a poražený spadne na:

```
Deployment\ServerException: /ostra/.../Exporter.php.deploytmp: Overwrite permission denied
```

Reálně se to stalo při dávkovém mergi 21 Dependabot PR — historie `deploy-ostra` byla směs success/failure v 16minutovém okně. Web přitom nikdy nespadl (FTP sync je inkrementální), ale deploye selhávaly a stav byl konzistentní až po posledním, osamoceně běžícím deployi.

## Oprava

Přidává `concurrency` blok do obou workflow:

- `group: deploy-ostra` resp. `deploy-beta` — každý cíl má vlastní skupinu, navzájem se neblokují.
- `cancel-in-progress: false` — rozběhnutý FTP sync se **nesmí** zabít uprostřed (mohl by nechat prod napůl aktualizovaný); další deploye se zařadí do fronty a běží jeden po druhém.

Žádná změna runtime kódu — jen CI.