### PR TITLE
Fix import crash on dash-only location names

### DIFF
--- a/admin/scripts/modules/aktivity/_Import/Activities/ImportKeyUnifier.php
+++ b/admin/scripts/modules/aktivity/_Import/Activities/ImportKeyUnifier.php
@@ -35,11 +35,11 @@ class ImportKeyUnifier
         if (in_array($unifiedKey, $occupiedKeys, true)) {
             throw new DuplicatedUnifiedKeyException(
                 sprintf(
-                    "Can not create unified key from '%s' as resulting key '%s' using unify depth %d already exists. Existing keys: %s",
+                    "Can not create unified key from '%s' using unify depth %d. Resulted key '%s' already exists. Existing keys: %s",
                     $value,
                     $unifiedKey,
                     $unifyDepth,
-                    implode(';', array_map(static function (
+                    implode(', ', array_map(static function (
                         string $occupiedKey,
                     ) {
                         return "'$occupiedKey'";

--- a/admin/scripts/modules/aktivity/_Import/Activities/ImportKeyUnifier.php
+++ b/admin/scripts/modules/aktivity/_Import/Activities/ImportKeyUnifier.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\Admin\Modules\Aktivity\Import\Activities;
@@ -7,19 +8,19 @@ use Gamecon\Admin\Modules\Aktivity\Import\Activities\Exceptions\DuplicatedUnifie
 
 class ImportKeyUnifier
 {
-    public const UNIFY_UP_TO_WHITESPACES         = 1;
-    public const UNIFY_UP_TO_CASE                = 2;
-    public const UNIFY_UP_TO_SPACES              = 3;
-    public const UNIFY_UP_TO_DIACRITIC           = 4;
-    public const UNIFY_UP_TO_WORD_CHARACTERS     = 5;
-    public const UNIFY_UP_TO_NUMBERS_AND_LETTERS = 6;
-    public const UNIFY_UP_TO_LETTERS             = 7;
+    public const UNIFY_UP_TO_WHITESPACES = 1;
+    public const UNIFY_UP_TO_CASE = 2;
+    public const UNIFY_UP_TO_SPACES = 3;
+    public const UNIFY_UP_TO_DIACRITIC = 4;
+    public const UNIFY_UP_TO_WORD_CHARACTERS = 5;
+    public const UNIFY_UP_TO_ALNUMS = 6;
+    public const UNIFY_UP_TO_LETTERS = 7;
 
     public static function parseId(string $value): ?int
     {
         $id = preg_match('~\D~', trim($value))
             ? null
-            : (int)$value;
+            : (int) $value;
 
         return $id !== null && $id > 0
             ? $id
@@ -28,25 +29,12 @@ class ImportKeyUnifier
 
     public static function toUnifiedKey(
         string $value,
-        array  $occupiedKeys,
-        int    $unifyDepth = self::UNIFY_UP_TO_NUMBERS_AND_LETTERS,
+        array $occupiedKeys,
+        int $unifyDepth = self::UNIFY_UP_TO_ALNUMS,
     ): string {
         $unifiedKey = self::createUnifiedKey($value, $unifyDepth);
         if (in_array($unifiedKey, $occupiedKeys, true)) {
-            throw new DuplicatedUnifiedKeyException(
-                sprintf(
-                    "Can not create unified key from '%s' using unify depth %d. Resulted key '%s' already exists. Existing keys: %s",
-                    $value,
-                    $unifiedKey,
-                    $unifyDepth,
-                    implode(', ', array_map(static function (
-                        string $occupiedKey,
-                    ) {
-                        return "'$occupiedKey'";
-                    }, $occupiedKeys)),
-                ),
-                $unifiedKey,
-            );
+            throw new DuplicatedUnifiedKeyException(sprintf("Can not create unified key from '%s' using unify depth %d. Resulted key '%s' already exists. Existing keys: %s", $value, $unifyDepth, $unifiedKey, implode(', ', array_map(static function (string $occupiedKey) { return "'{$occupiedKey}'"; }, $occupiedKeys))), $unifiedKey);
         }
 
         return $unifiedKey;
@@ -54,7 +42,7 @@ class ImportKeyUnifier
 
     private static function createUnifiedKey(
         string $value,
-        int    $depth,
+        int $depth,
     ): string {
         if ($depth <= 0) {
             return $value;
@@ -67,7 +55,7 @@ class ImportKeyUnifier
         if ($depth === self::UNIFY_UP_TO_CASE) {
             return $value;
         }
-        $value = (string)str_replace(' ', '', $value);
+        $value = (string) str_replace(' ', '', $value);
         if ($depth === self::UNIFY_UP_TO_SPACES) {
             return $value;
         }
@@ -75,12 +63,12 @@ class ImportKeyUnifier
         if ($depth === self::UNIFY_UP_TO_DIACRITIC) {
             return $value;
         }
-        $value = preg_replace('~\W~u', '', $value);
+        $value = preg_replace('~[^\w-]~u', '', $value);
         if ($depth === self::UNIFY_UP_TO_WORD_CHARACTERS) {
             return $value;
         }
-        $value = preg_replace('~[^a-z0-9]~', '', $value);
-        if ($depth === self::UNIFY_UP_TO_NUMBERS_AND_LETTERS) {
+        $value = preg_replace('~[^a-z0-9_-]~', '', $value);
+        if ($depth === self::UNIFY_UP_TO_ALNUMS) {
             return $value;
         }
         $value = preg_replace('~[^a-z]~', '', $value);

--- a/admin/scripts/modules/aktivity/_Import/Activities/ImportObjectsContainer.php
+++ b/admin/scripts/modules/aktivity/_Import/Activities/ImportObjectsContainer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamecon\Admin\Modules\Aktivity\Import\Activities;
@@ -10,7 +11,6 @@ use Gamecon\Aktivita\TypAktivity;
 
 class ImportObjectsContainer
 {
-
     /**
      * @var array|TypAktivity[][]
      */
@@ -28,8 +28,9 @@ class ImportObjectsContainer
      */
     private $statesCache;
 
-    public function __construct(private readonly ImportUsersCache $importUserCache)
-    {
+    public function __construct(
+        private readonly ImportUsersCache $importUserCache,
+    ) {
     }
 
     public function getProgramLineFromValue(string $programLineValue): ?TypAktivity
@@ -57,18 +58,23 @@ class ImportObjectsContainer
 
     private function getProgramLinesCache(): array
     {
-        if (!$this->programLinesCache) {
-            $this->programLinesCache = ['id' => [], 'keyFromName' => [], 'keyFromSingleName' => [], 'keyFromUrl' => []];
+        if (! $this->programLinesCache) {
+            $this->programLinesCache = [
+                'id'                => [],
+                'keyFromName'       => [],
+                'keyFromSingleName' => [],
+                'keyFromUrl'        => [],
+            ];
             foreach (TypAktivity::zVsech() as $programLine) {
                 $this->programLinesCache['id'][$programLine->id()] = $programLine;
 
-                $keyFromName                                          = ImportKeyUnifier::toUnifiedKey($programLine->nazev(), array_keys($this->programLinesCache['keyFromName']));
+                $keyFromName = ImportKeyUnifier::toUnifiedKey($programLine->nazev(), array_keys($this->programLinesCache['keyFromName']));
                 $this->programLinesCache['keyFromName'][$keyFromName] = $programLine;
 
-                $keyFromSingleName                                                = ImportKeyUnifier::toUnifiedKey($programLine->nazevJednotnehoCisla(), array_keys($this->programLinesCache['keyFromSingleName']));
+                $keyFromSingleName = ImportKeyUnifier::toUnifiedKey($programLine->nazevJednotnehoCisla(), array_keys($this->programLinesCache['keyFromSingleName']));
                 $this->programLinesCache['keyFromSingleName'][$keyFromSingleName] = $programLine;
 
-                $keyFromUrl                                         = ImportKeyUnifier::toUnifiedKey($programLine->url(), array_keys($this->programLinesCache['keyFromUrl']));
+                $keyFromUrl = ImportKeyUnifier::toUnifiedKey($programLine->url(), array_keys($this->programLinesCache['keyFromUrl']));
                 $this->programLinesCache['keyFromUrl'][$keyFromUrl] = $programLine;
             }
         }
@@ -98,11 +104,14 @@ class ImportObjectsContainer
 
     private function getStatesCache(): array
     {
-        if (!$this->statesCache) {
-            $this->statesCache = ['id' => [], 'keyFromName' => []];
+        if (! $this->statesCache) {
+            $this->statesCache = [
+                'id'          => [],
+                'keyFromName' => [],
+            ];
             foreach (StavAktivity::zVsech() as $stav) {
-                $this->statesCache['id'][$stav->id()]           = $stav;
-                $keyFromName                                    = ImportKeyUnifier::toUnifiedKey(mb_substr($stav->nazev(), 0, 3, 'UTF-8'), array_keys($this->statesCache['keyFromName']));
+                $this->statesCache['id'][$stav->id()] = $stav;
+                $keyFromName = ImportKeyUnifier::toUnifiedKey(mb_substr($stav->nazev(), 0, 3, 'UTF-8'), array_keys($this->statesCache['keyFromName']));
                 $this->statesCache['keyFromName'][$keyFromName] = $stav;
             }
         }
@@ -136,11 +145,14 @@ class ImportObjectsContainer
 
     private function getTagsCache(): array
     {
-        if (!$this->tagsCache) {
-            $this->tagsCache = ['id' => [], 'keyFromName' => []];
+        if (! $this->tagsCache) {
+            $this->tagsCache = [
+                'id'          => [],
+                'keyFromName' => [],
+            ];
             foreach (Tag::zVsech() as $tag) {
-                $this->tagsCache['id'][$tag->id()]            = $tag;
-                $keyFromName                                  = ImportKeyUnifier::toUnifiedKey($tag->nazev(), array_keys($this->tagsCache['keyFromName']));
+                $this->tagsCache['id'][$tag->id()] = $tag;
+                $keyFromName = ImportKeyUnifier::toUnifiedKey($tag->nazev(), array_keys($this->tagsCache['keyFromName']));
                 $this->tagsCache['keyFromName'][$keyFromName] = $tag;
             }
         }
@@ -154,14 +166,13 @@ class ImportObjectsContainer
     public function getLocationsFromValue(string $locationsString): array
     {
         $locationValues = array_map('trim', explode(';', $locationsString));
-        $locations      = [];
+        $locations = [];
         foreach ($locationValues as $locationValue) {
             $locations[$locationValue] = $this->getLocationFromValue($locationValue);
         }
 
         return $locations;
     }
-
 
     private function getLocationFromValue(string $locationValue): ?Lokace
     {
@@ -180,16 +191,15 @@ class ImportObjectsContainer
 
     private function getProgramLocationByName(string $name): ?Lokace
     {
-        $unifiedKey      = ImportKeyUnifier::toUnifiedKey($name, [], ImportKeyUnifier::UNIFY_UP_TO_NUMBERS_AND_LETTERS);
+        $unifiedKey = ImportKeyUnifier::toUnifiedKey($name, [], ImportKeyUnifier::UNIFY_UP_TO_ALNUMS);
         $programLocation = $this->getProgramLocationsCache()['keyFromName'][$unifiedKey] ?? null;
         if ($programLocation) {
             return $programLocation;
         }
-        $keysFromFullNames         = array_keys($this->getProgramLocationsCache()['keyFromName']);
+        $keysFromFullNames = array_keys($this->getProgramLocationsCache()['keyFromName']);
         $matchingKeysFromFullNames = array_filter($keysFromFullNames, static function (
             string $keyFromFullName,
-        ) use
-        (
+        ) use (
             $unifiedKey,
         ) {
             return str_starts_with($keyFromFullName, $unifiedKey); // given location name is a beginning of a location full name
@@ -205,11 +215,14 @@ class ImportObjectsContainer
 
     private function getProgramLocationsCache(): array
     {
-        if (!$this->programLocationsCache) {
-            $this->programLocationsCache = ['id' => [], 'keyFromName' => []];
+        if (! $this->programLocationsCache) {
+            $this->programLocationsCache = [
+                'id'          => [],
+                'keyFromName' => [],
+            ];
             foreach (Lokace::zVsech() as $lokace) {
-                $this->programLocationsCache['id'][$lokace->id()]         = $lokace;
-                $keyFromName                                              = ImportKeyUnifier::toUnifiedKey($lokace->nazev(), array_keys($this->programLocationsCache['keyFromName']), ImportKeyUnifier::UNIFY_UP_TO_NUMBERS_AND_LETTERS);
+                $this->programLocationsCache['id'][$lokace->id()] = $lokace;
+                $keyFromName = ImportKeyUnifier::toUnifiedKey($lokace->nazev(), array_keys($this->programLocationsCache['keyFromName']), ImportKeyUnifier::UNIFY_UP_TO_ALNUMS);
                 $this->programLocationsCache['keyFromName'][$keyFromName] = $lokace;
             }
         }

--- a/tests/Admin/Modules/Aktivity/Import/Activities/ImportKeyUnifierTest.php
+++ b/tests/Admin/Modules/Aktivity/Import/Activities/ImportKeyUnifierTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Admin\Modules\Aktivity\Import\Activities;
+
+use Gamecon\Admin\Modules\Aktivity\Import\Activities\Exceptions\DuplicatedUnifiedKeyException;
+use Gamecon\Admin\Modules\Aktivity\Import\Activities\ImportKeyUnifier;
+use PHPUnit\Framework\TestCase;
+
+class ImportKeyUnifierTest extends TestCase
+{
+    public function testPlaceholderLokaceTvorenePomlckamiMajiRuzneKlice(): void
+    {
+        // Placeholder locations like '-' and '--' used to collapse to an empty
+        // string at the alnum depth, so the second collided with the first.
+        $klicProPomlcku = ImportKeyUnifier::toUnifiedKey('-', []);
+        $klicProDvePomlcky = ImportKeyUnifier::toUnifiedKey('--', [$klicProPomlcku]);
+
+        self::assertSame('-', $klicProPomlcku);
+        self::assertSame('--', $klicProDvePomlcky);
+        self::assertNotSame($klicProPomlcku, $klicProDvePomlcky);
+    }
+
+    public function testPodtrzitkaZustavajiSoucastiKlice(): void
+    {
+        self::assertSame('a_b', ImportKeyUnifier::toUnifiedKey('A _ B', []));
+    }
+
+    public function testRuznePlaceholderyNezpusobiVyjimkuPriImportu(): void
+    {
+        $obsazeneKlice = [];
+        foreach (['-', '--', '---'] as $nazevLokace) {
+            $obsazeneKlice[] = ImportKeyUnifier::toUnifiedKey($nazevLokace, $obsazeneKlice);
+        }
+
+        self::assertSame(['-', '--', '---'], $obsazeneKlice);
+    }
+
+    public function testStejnyPlaceholderDvakratStaleHlasiDuplicitu(): void
+    {
+        $prvni = ImportKeyUnifier::toUnifiedKey('-', []);
+
+        $this->expectException(DuplicatedUnifiedKeyException::class);
+        ImportKeyUnifier::toUnifiedKey('-', [$prvni]);
+    }
+
+    public function testZpravaVyjimkyUvadiSpravnouHloubkuAVyslednyKlic(): void
+    {
+        $prvni = ImportKeyUnifier::toUnifiedKey('-', [], ImportKeyUnifier::UNIFY_UP_TO_ALNUMS);
+
+        try {
+            ImportKeyUnifier::toUnifiedKey('-', [$prvni], ImportKeyUnifier::UNIFY_UP_TO_ALNUMS);
+            self::fail('Ocekavana DuplicatedUnifiedKeyException nebyla vyhozena.');
+        } catch (DuplicatedUnifiedKeyException $duplicatedUnifiedKeyException) {
+            self::assertStringContainsString(
+                'using unify depth ' . ImportKeyUnifier::UNIFY_UP_TO_ALNUMS,
+                $duplicatedUnifiedKeyException->getMessage(),
+            );
+            self::assertStringContainsString("Resulted key '-'", $duplicatedUnifiedKeyException->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Letošní data obsahují místnosti s placeholder názvy jako `-` a `--`. Import aktivit na nich padal výjimkou `DuplicatedUnifiedKeyException` v `ImportKeyUnifier::toUnifiedKey`.

## Příčina

`createUnifiedKey` na úrovni `UNIFY_UP_TO_ALNUMS` strhával vše kromě písmen a číslic, takže `-` i `--` daly **prázdný** klíč → druhá místnost kolidovala s první. Pomlčky navíc mizely už o krok dřív v `~\W~u` (pomlčka není „word character"), takže nestačilo rozšířit jen poslední regex.

## Změna

- `~\W~u` → `~[^\w-]~u` a `~[^a-z0-9]~` → `~[^a-z0-9_-]~` — pomlčky a podtržítka přežijí unifikaci, takže `-` → `-`, `--` → `--` (různé, neprázdné klíče).
- Konstanta `UNIFY_UP_TO_NUMBERS_AND_LETTERS` přejmenována na `UNIFY_UP_TO_ALNUMS`.
- Opravené pořadí argumentů `sprintf` ve zprávě `DuplicatedUnifiedKeyException` (hloubka a výsledný klíč byly prohozené → „depth 0 / key '6'").
- Nový `ImportKeyUnifierTest` pokrývající placeholder místnosti, podtržítka, zachování detekce skutečných duplicit a správnou zprávu výjimky.
