### PR TITLE
Neztrácet přihlášku kvůli vypršené session

### DIFF
--- a/nastaveni/zavadec-zaklad.php
+++ b/nastaveni/zavadec-zaklad.php
@@ -31,6 +31,12 @@ if (defined('URL_WEBU') && URL_WEBU) {
     $domain = parse_url(URL_WEBU, PHP_URL_HOST) ?: 'localhost';
     $secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
         || (!empty($_SERVER['SERVER_PORT']) && (int)$_SERVER['SERVER_PORT'] === 443);
+    // Výchozí PHP session vyprší po ~24 minutách nečinnosti. Vyplnění přihlášky je
+    // dlouhé a účastník u ní často na chvíli odejde – session pak server-side vyprší,
+    // odeslání dorazí jako nepřihlášené a přihláška tiše propadne. Prodlužujeme proto
+    // jen server-side životnost session (gc_maxlifetime). Cookie záměrně zůstává
+    // session-only (lifetime 0) a umírá při zavření prohlížeče – bezpečnost.
+    ini_set('session.gc_maxlifetime', (string)(60 * 60 * 24));
     session_set_cookie_params([
         'lifetime' => 0,
         'path'     => '/',

--- a/web/moduly/prihlaska/prihlaska.php
+++ b/web/moduly/prihlaska/prihlaska.php
@@ -92,8 +92,14 @@ if ($systemoveNastaveni->gcBezi()) {
 }
 
 if (!$u) {
+    // Když přijde POST (účastník odeslal formulář) a přitom není přihlášen, jeho
+    // session mezitím vypršela – data se neuložila. Bez téhle hlášky odejde s pocitem,
+    // že je přihlášený na GameCon, ač ho odeslání jen odbylo na homepage/přihlášení.
+    $sessionVyprsela = ($_SERVER['REQUEST_METHOD'] ?? '') === 'POST';
     oznameniPresmeruj(
-        'Tato stránka vyžaduje přihlášení',
+        $sessionVyprsela
+            ? 'Mezitím došlo k odhlášení, takže se přihláška neuložila. Přihlas se prosím znovu a odešli ji ještě jednou.'
+            : 'Tato stránka vyžaduje přihlášení',
         URL_WEBU . '/prihlaseni',
         Chyba::VAROVANI
     );


### PR DESCRIPTION
Trello: [#1449 Prihláška nepřihlási na GC](https://trello.com/c/cBvrOwXa)

## Problém

Účastníci popsali, že po vyplnění a odeslání přihlášky skončili na homepage a **nebyli přihlášeni na GameCon** – přitom měli pocit, že vše proběhlo v pořádku.

Příčina (potvrzeno v kódu): vypršela jim přihlášená **session**.

- Session neměla nastavený `gc_maxlifetime`, takže platil default PHP **~24 min nečinnosti**.
- Vyplnění přihlášky je dlouhé a člověk u něj typicky na chvíli odejde k něčemu jinému. Když pak po >24 min odešle, dorazí POST jako **nepřihlášený** → gate `if (!$u)` v `prihlaska.php` přihlášku zahodí a uživatel skončí přesměrovaný pryč, bez srozumitelné hlášky.

(Pozn.: deploy session neresetuje – je to FTP file-sync, nerestartuje PHP-FPM, nemaže session soubory a `APP_SECRET` nativní PHP session nepodepisuje.)

## Řešení

**1. Delší server-side životnost session** (`nastaveni/zavadec-zaklad.php`)
Prodlužujeme `session.gc_maxlifetime` na 24 h, aby session nevypršela během vyplňování ani když účastník na chvíli odejde. **Cookie záměrně zůstává session-only (`lifetime => 0`)** a umírá při zavření prohlížeče – z bezpečnostních důvodů se na tom nic nemění.

**2. Srozumitelná hláška místo tichého odbytí** (`web/moduly/prihlaska/prihlaska.php`)
Když dorazí POST (= účastník odeslal formulář) a přitom není přihlášen, ukážeme jasně: *„Mezitím došlo k odhlášení, takže se přihláška neuložila. Přihlas se prosím znovu a odešli ji ještě jednou."* místo obecného „Tato stránka vyžaduje přihlášení". Pro běžnou nepřihlášenou návštěvu (GET) zůstává původní hláška.

## Poznámka k testům

Obě změny jsou bootstrap konfigurace session a podmíněný text v gate uvnitř web modulu (globální `$u` / `$_SERVER`). Projekt pro tyhle moduly nemá request-level test harness, takže smysluplný automatický test by znamenal postavit celý web request – proto bez nového testu. Ověřitelné ručně: vyplnit přihlášku, nechat session vypršet (nebo cookie smazat) a odeslat → objeví se nová hláška a přesměrování na přihlášení.

## Caveat: sdílený `session.save_path` na hostu

Životnost prodlužujeme z aplikace přes `ini_set('session.gc_maxlifetime', …)` v `zavadec-zaklad.php` (běží před `session_start()`). Ověřeno v ansible (`roles/php`): host **žádné `session.*` direktivy nenastavuje** – `php_settings` obsahuje jen `max_execution_time` / `memory_limit` / `upload_max_filesize` / `date.timezone`. App-level `ini_set` tedy nemá s čím kolidovat a v runtime vyhraje.

Drobné riziko: ansible nenastavuje ani `session.save_path`, takže gamecon i ostatní PHP appky na hostu (passbolt) sdílí default `/var/lib/php/{version}/sessions`. PHP GC čistí adresář podle životnosti requestu, který GC spustí – request jiné appky s defaultním 1440 s by teoreticky mohl posbírat starší gamecon session soubory dřív. V praxi nízké riziko (vlastní requesty gameconu session drží čerstvé). Pokud by to mělo být neprůstřelné, řešením je vyhradit gameconu vlastní `session.save_path` (taky z `zavadec-zaklad.php`) – záměrně teď **neděláme**, jen evidujeme.