### PR TITLE
Report odhlášených objednávek neplatičů

### DIFF
--- a/admin/scripts/zvlastni/reporty/finance-report-odhlaseni-neplaticu.php
+++ b/admin/scripts/zvlastni/reporty/finance-report-odhlaseni-neplaticu.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+use Gamecon\Shop\TypPredmetu;
+
+require_once __DIR__ . '/sdilene-hlavicky.php';
+
+/**
+ * Objednávky (aktivity, předměty, ubytování) zrušené kvůli dluhu.
+ *
+ * Zdroj dat nejsou souhrnné logy (hromadne_akce_log je jen počet lidí za běh),
+ * ale detailní záznamy zrušení, které nesou "zdroj zrušení":
+ *   - předměty a ubytování: shop_nakupy_zrusene.zdroj_zruseni
+ *   - aktivity:             akce_prihlaseni_log.zdroj_zmeny (typ 'odhlaseni')
+ *
+ * Hromadné odhlašování neplatičů razí zdroj "<zaklad>-<poradi>" – automatický
+ * cron používá základ 'automaticky', ruční tlačítko v adminu 'rucne-hromadne'.
+ * Filtrujeme tedy na 'automaticky-%' a 'rucne-hromadne', což jsou právě
+ * odhlášení kvůli dluhu (na rozdíl od 'rucne-sam-sebe' apod.).
+ */
+
+$formatReportu = get('format');
+$jeHtml        = $formatReportu === 'html';
+
+$zdrojeDluh = "zdroj = 'rucne-hromadne' OR zdroj LIKE 'automaticky-%'";
+
+$data = dbFetchAll(<<<SQL
+    SELECT
+        zruseni.rocnik                                    AS rocnik,
+        zruseni.id_uzivatele                              AS id_uzivatele,
+        CONCAT(uzivatele_hodnoty.jmeno_uzivatele, ' ', uzivatele_hodnoty.prijmeni_uzivatele,
+               CASE WHEN uzivatele_hodnoty.login_uzivatele <> ''
+                    THEN CONCAT(' (', uzivatele_hodnoty.login_uzivatele, ')') ELSE '' END) AS ucastnik,
+        uzivatele_hodnoty.email1_uzivatele                AS email,
+        zruseni.je_aktivita                               AS je_aktivita,
+        zruseni.typ_shop                                  AS typ_shop,
+        zruseni.nazev_polozky                             AS nazev_polozky,
+        zruseni.cena                                      AS cena,
+        zruseni.zruseno_kdy                               AS zruseno_kdy,
+        zruseni.zdroj                                     AS zdroj_zruseni
+    FROM (
+        SELECT
+            shop_nakupy_zrusene.rocnik           AS rocnik,
+            shop_nakupy_zrusene.id_uzivatele     AS id_uzivatele,
+            shop_predmety.nazev                  AS nazev_polozky,
+            shop_predmety.typ                    AS typ_shop,
+            NULL                                 AS je_aktivita,
+            shop_nakupy_zrusene.cena_nakupni     AS cena,
+            shop_nakupy_zrusene.datum_zruseni    AS zruseno_kdy,
+            shop_nakupy_zrusene.zdroj_zruseni    AS zdroj
+        FROM shop_nakupy_zrusene
+        JOIN shop_predmety ON shop_predmety.id_predmetu = shop_nakupy_zrusene.id_predmetu
+        WHERE shop_nakupy_zrusene.zdroj_zruseni = 'rucne-hromadne'
+           OR shop_nakupy_zrusene.zdroj_zruseni LIKE 'automaticky-%'
+
+        UNION ALL
+
+        SELECT
+            akce_prihlaseni_log.rocnik           AS rocnik,
+            akce_prihlaseni_log.id_uzivatele     AS id_uzivatele,
+            akce_seznam.nazev_akce               AS nazev_polozky,
+            NULL                                 AS typ_shop,
+            1                                    AS je_aktivita,
+            NULL                                 AS cena,
+            akce_prihlaseni_log.kdy              AS zruseno_kdy,
+            akce_prihlaseni_log.zdroj_zmeny      AS zdroj
+        FROM akce_prihlaseni_log
+        JOIN akce_seznam ON akce_seznam.id_akce = akce_prihlaseni_log.id_akce
+        WHERE akce_prihlaseni_log.typ = 'odhlaseni'
+          AND (akce_prihlaseni_log.zdroj_zmeny = 'rucne-hromadne'
+               OR akce_prihlaseni_log.zdroj_zmeny LIKE 'automaticky-%')
+    ) AS zruseni
+    JOIN uzivatele_hodnoty ON uzivatele_hodnoty.id_uzivatele = zruseni.id_uzivatele
+    ORDER BY zruseni.zruseno_kdy DESC, zruseni.id_uzivatele, nazev_polozky
+    SQL);
+
+$radky = [];
+foreach ($data as $radek) {
+    $typPolozky = $radek['je_aktivita']
+        ? 'aktivita'
+        : TypPredmetu::nazevTypu((int)$radek['typ_shop']);
+
+    $urlUzivatele = URL_ADMIN . '/uzivatel?pracovni_uzivatel=' . $radek['id_uzivatele'];
+
+    $radky[] = [
+        'rocnik'         => (int)$radek['rocnik'],
+        'ucastnik'       => $jeHtml
+            ? "<a target='_blank' href='$urlUzivatele'>{$radek['ucastnik']}</a>"
+            : $radek['ucastnik'],
+        'email'          => $jeHtml && $radek['email']
+            ? "<a href='mailto:{$radek['email']}'>{$radek['email']}</a>"
+            : $radek['email'],
+        'typ_polozky'    => $typPolozky,
+        'nazev_polozky'  => $radek['nazev_polozky'],
+        'cena'           => $radek['cena'] !== null ? (float)$radek['cena'] : '',
+        'zruseno_kdy'    => $radek['zruseno_kdy'],
+        'zdroj_zruseni'  => $radek['zdroj_zruseni'],
+    ];
+}
+
+$report = $radky
+    ? Report::zPole($radky)
+    : Report::zPoli(
+        ['rocnik', 'ucastnik', 'email', 'typ_polozky', 'nazev_polozky', 'cena', 'zruseno_kdy', 'zdroj_zruseni'],
+        [],
+    );
+
+$report->tFormat(
+    $formatReportu,
+    'odhlaseni-neplaticu-' . $report->nazevReportuZRequestu(),
+);

--- a/migrace/2026-07-02-111723_report-odhlaseni-neplaticu.php
+++ b/migrace/2026-07-02-111723_report-odhlaseni-neplaticu.php
@@ -1,0 +1,5 @@
+<?php
+/** @var \Godric\DbMigrations\Migration $this */
+
+$this->q("INSERT INTO reporty (skript, nazev, format_xlsx, format_html, viditelny)
+    VALUES ('finance-report-odhlaseni-neplaticu', 'Finance: Odhlášené objednávky neplatičů', 1, 1, 1)");


### PR DESCRIPTION
Nový admin report **„Finance: Odhlášené objednávky neplatičů"** – přehled objednávek (aktivity, předměty, ubytování), které byly zrušeny kvůli dluhu při hromadném odhlašování neplatičů.

## Odkud data pocházejí

Souhrnné logy (`hromadne_akce_log`, `log_udalosti`) neobsahují detail po jednotlivých objednávkách – `hromadne_akce_log` má jen počet odhlášených lidí za běh. Detail zrušení nese „zdroj zrušení":

- **předměty a ubytování** → `shop_nakupy_zrusene.zdroj_zruseni`
- **aktivity** → `akce_prihlaseni_log.zdroj_zmeny` (`typ = 'odhlaseni'`)

Hromadné odhlašování neplatičů razí zdroj `automaticky-<pořadí>` (noční cron) a `rucne-hromadne` (ruční tlačítko v adminu). Report filtruje právě na tyto zdroje, takže zobrazuje jen odhlášení kvůli dluhu (ne `rucne-sam-sebe` apod.).

Jeden řádek = jedna zrušená objednávka: **ročník, účastník (link do adminu), e-mail, typ položky (aktivita / ubytování / předmět / tričko / jídlo), název, cena, kdy zrušeno, zdroj**. HTML i XLSX export.

## Poznámka k datům

`zruseno_kdy` je okamžik zrušení, `rocnik` je ročník objednávky – mohou se lišit (starší registrace odhlášená později). Ověřeno proti reálným datům 2023–2025 (`log.rocnik` odpovídá `akce.rok`, žádné nesrovnalosti).

## Kde ověřit

- `admin/reporty` → nová položka „Finance: Odhlášené objednávky neplatičů"
- `admin/reporty/finance-report-odhlaseni-neplaticu?format=html` → tabulka
- `admin/reporty/finance-report-odhlaseni-neplaticu?format=xlsx` → export
