### PR TITLE
Zobrazit brigádnickou odměnu v přehledu financí a zůstatku

### DIFF
--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -1032,6 +1032,21 @@ SQL;
                 $this->brigadnickaOdmena(),
                 self::BRIGADNICKA_ODMENA,
             );
+            // Stejně jako bonus za vedení aktivit musí odměna dorazit i do BFGR
+            // přehledu (Accounting::getPersonalFinance), ze kterého se skládá
+            // admin i webový přehled financí a zůstatek – jinak v něm chybí
+            // řádek i vliv na zůstatek.
+            $this->logPolozkaProBfgr(
+                nazev: 'Brigádnická odměna',
+                pocet: 1,
+                priceAfterDiscountDto: new PriceAfterDiscountDto(
+                    finalPrice: -$this->brigadnickaOdmena(),
+                    discount: 0,
+                ),
+                typ: self::BRIGADNICKA_ODMENA,
+                kodPredmetu: '',
+                idPredmetu: '',
+            );
         }
 
         return $cena - $this->brigadnickaOdmena();

--- a/tests/Model/AccountingTest.php
+++ b/tests/Model/AccountingTest.php
@@ -245,6 +245,33 @@ SQL,
         );
     }
 
+    private function udelejBrigadnikem(): void
+    {
+        $idRole = Role::LETOSNI_BRIGADNIK();
+        // Role letošního ročníku musí být v role_seznam s rocnik_role = ROCNIK,
+        // jinak ji view platne_role_uzivatelu (a tím i jeBrigadnik()) neuvidí.
+        dbQuery(
+            <<<SQL
+            INSERT IGNORE INTO role_seznam(id_role, kod_role, nazev_role, popis_role, rocnik_role, typ_role, vyznam_role)
+            VALUES($0, $1, 'Brigádník (test)', '', $2, 'rocnikova', $3)
+            SQL,
+            [
+                0 => $idRole,
+                1 => 'TEST_BRIGADNIK_' . ROCNIK,
+                2 => ROCNIK,
+                3 => Role::VYZNAM_BRIGADNIK,
+            ],
+        );
+        dbQuery(
+            'INSERT INTO uzivatele_role(id_uzivatele, id_role, posadil) VALUES($0, $1, $2)',
+            [
+                0 => 555,
+                1 => $idRole,
+                2 => 555,
+            ],
+        );
+    }
+
     private function dejUzivatele(): \Uzivatel
     {
         return \Uzivatel::zIdUrcite(555);
@@ -609,6 +636,39 @@ SQL,
             '<td>Bonus za aktivity</td><td>' . $ocekavanyBonus . '</td>',
             $htmlProFinance,
         );
+    }
+
+    /**
+     * @test
+     */
+    public function testBrigadnickaOdmenaJeVidetVManualMovements(): void
+    {
+        $this->udelejBrigadnikem();
+        $this->vlozAktivitu(
+            idAktivity: 55620,
+            nazev: 'Bedňák ČT 13-20',
+            cena: 160,
+            typ: TypAktivity::BRIGADNICKA,
+        );
+
+        $finance = $this->dejUzivatele()->finance();
+        self::assertSame(160.0, $finance->brigadnickaOdmena());
+
+        $account = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false);
+        $manualMovements = array_values(array_filter(
+            $account->getTransactions(),
+            fn ($transaction) => $transaction->getCategory() === TransactionCategoryEnum::MANUAL_MOVEMENTS,
+        ));
+
+        self::assertCount(1, $manualMovements, 'Brigádnická odměna musí být reprezentována transakcí v MANUAL_MOVEMENTS');
+        self::assertSame(160, $manualMovements[0]->getTotalAmount());
+        // Brigádnická aktivita je interní (cena účastníka 0), takže do zůstatku
+        // přispívá jen samotná odměna.
+        self::assertSame(160, $account->getTotal(), 'Brigádnická odměna se musí projevit v zůstatku');
+
+        $html = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: true)
+            ->formatForHtml(positivePrices: true);
+        self::assertStringContainsString('Brigádnická odměna', $html);
     }
 
     /**


### PR DESCRIPTION
Brigádnická odměna se logovala jen přes logb() (starý přehled), ale ne přes logPolozkaProBfgr(). Admin detail uživatele i web ale zobrazují finance přes Accounting::getPersonalFinance(), který staví přehled i zůstatek výhradně z položek pro BFGR. Odměna proto v přehledu chyběla jako řádek i ve výsledném zůstatku (na rozdíl od bonusu za vedení aktivit, který loguje obojí). Regrese vznikla přechodem přehledu na BFGR (ticket 1432), kde se na brigádnickou odměnu zapomnělo.

Doplňuje logPolozkaProBfgr() do aplikujBrigadnickouOdmenu() se stejným znaménkem jako u bonusu (kredit), takže nový přehled i getTotal() nově odpovídají hodnotě z stav().