### PR TITLE
Oprava zamrzlé obsazenosti po odhlášení z aktivity

### DIFF
--- a/model/Cache/ProgramStaticFileGenerator.php
+++ b/model/Cache/ProgramStaticFileGenerator.php
@@ -348,6 +348,11 @@ class ProgramStaticFileGenerator implements ResetInterface
     public function reset(): void
     {
         $this->activitiesCache = [];
+        // Worker běží jako jeden dlouho žijící proces přes víc iterací. Bez tohoto
+        // by statická Aktivita::$prihlaseniRawCache držela seznam přihlášených
+        // z předchozí iterace (+= nikdy nepřepíše existující id), takže regenerace
+        // vyvolaná odhlášením by přepočítala obsazenost ze zastaralých dat.
+        Aktivita::smazCache();
     }
 
     private function writeJsonFile(

--- a/tests/Cache/ProgramStaticFileGeneratorTest.php
+++ b/tests/Cache/ProgramStaticFileGeneratorTest.php
@@ -586,6 +586,79 @@ class ProgramStaticFileGeneratorTest extends AbstractTestDb
 
     /**
      * @test
+     * Regrese: worker běží jako jeden dlouho žijící proces přes víc iterací.
+     * Odhlásí-li se účastník mezi dvěma iteracemi, přepočítaná obsazenost v
+     * JSONu musí klesnout. Dřív ne — statická Aktivita::$prihlaseniRawCache
+     * přežila reset() (generator čistil jen svou vlastní activitiesCache a
+     * verze tabulek), takže regenerace vyvolaná odhlášením vzala seznam
+     * přihlášených z předchozí iterace a obsazenost zůstala „viset" nahoře.
+     * Fixlo se to teprve novým přihlášením do fresh procesu — přesně jak to
+     * hlásili z produkce.
+     */
+    public function odhlaseniMeziIteracemiWorkeruSniziObsazenost(): void
+    {
+        $idAktivity = $this->insertAktivita([
+            Sql::NAZEV_AKCE => 'Aktivita se stálým procesem workeru',
+            Sql::KAPACITA   => 4,
+        ]);
+
+        $idUcastnika = 900101;
+        dbInsertUpdate('uzivatele_hodnoty', [
+            'id_uzivatele'    => $idUcastnika,
+            'login_uzivatele' => 'ucastnik-obsazenost',
+            'pohlavi'         => \Gamecon\Uzivatel\Pohlavi::MUZ_KOD,
+        ]);
+        dbInsertUpdate('akce_prihlaseni', [
+            'id_uzivatele' => $idUcastnika,
+            'id_akce'      => $idAktivity,
+        ]);
+
+        $systemoveNastaveni = $this->createSystemoveNastaveni();
+        $generator = new ProgramStaticFileGenerator($systemoveNastaveni);
+
+        // === Iterace 1 workeru: obsazenost 1/4 ===
+        $filenameV1 = $generator->generateObsazenosti(self::ROK);
+        self::assertSame(
+            1,
+            $this->obsazenostMuzuZJsonu($filenameV1, $idAktivity),
+            'Po přihlášení musí obsazenost ukazovat 1.',
+        );
+
+        // Účastník se odhlásí (odhlas() smaže řádek v akce_prihlaseni).
+        dbQuery(
+            'DELETE FROM akce_prihlaseni WHERE id_uzivatele = $1 AND id_akce = $2',
+            [$idUcastnika, $idAktivity],
+        );
+
+        // === Iterace 2 workeru ve STEJNÉM procesu ===
+        // Přesně co dělá _program-static-files-worker.php na začátku iterace.
+        $systemoveNastaveni->db()->clearPrefetchedDataVersions();
+        $generator->reset();
+
+        $filenameV2 = $generator->generateObsazenosti(self::ROK);
+        self::assertSame(
+            0,
+            $this->obsazenostMuzuZJsonu($filenameV2, $idAktivity),
+            'Po odhlášení musí regenerace ve stejném procesu ukázat 0 — jinak obsazenost „visí" nahoře.',
+        );
+    }
+
+    private function obsazenostMuzuZJsonu(string $filename, int $idAktivity): int
+    {
+        $data = json_decode(
+            file_get_contents($this->publicCacheDir . '/program/' . $filename),
+            true,
+        );
+        foreach ($data as $item) {
+            if ($item['idAktivity'] === $idAktivity) {
+                return (int) $item['obsazenost']['m'];
+            }
+        }
+        self::fail("Obsazenost aktivity {$idAktivity} nenalezena v {$filename}");
+    }
+
+    /**
+     * @test
      */
     public function readManifestReturnsNullWhenNoManifestExists(): void
     {


### PR DESCRIPTION
> **Navazuje na #1001** (Geretik, „Opravit zamrzlou obsazenost v programu"). Jde o **stejný symptom** („zamrzlá obsazenost / duchové"), ale **druhou, nezávislou příčinu**. #1001 opravil výběr souboru do manifestu (mtime → deterministické jméno vrácené generátorem). Tento PR opravuje **zamrzlý seznam přihlášených v paměti** (`Aktivita::$prihlaseniRawCache` přežil `reset()` mezi iteracemi workeru). Obě opravy jsou potřeba — #1001 sám by nechytil scénář níže, tento PR sám by nechytil mtime scénář. Postaveno nad #1001, bez konfliktu.

## Problém

Obsazenost aktivity (např. „3/4") ve veřejném programu i v adminu **zamrzla po odhlášení účastníka** — DB i prezence ukazovaly správný nižší počet, ale číslo v programu zůstalo viset nahoře. Nepomohl F5, Ctrl+F5, zavření/otevření programu ani přepnutí na jiného uživatele. Jediné, co obsazenost srovnalo, bylo **nové přihlášení** dalšího člověka na tu aktivitu.

## Příčina

Program se čte z předgenerovaných statických JSON souborů (`obsazenosti-{rok}-{hash}.json`), které přegeneruje background worker `_program-static-files-worker.php`. Ten běží jako **jeden dlouho žijící proces přes až 20 iterací** a na začátku každé iterace volá `ProgramStaticFileGenerator::reset()` + `clearPrefetchedDataVersions()`, aby zahodil zastaralá data.

Jenže `reset()` čistil jen generátorovu `activitiesCache` a verze DB tabulek — **ne statickou vlastnost `Aktivita::$prihlaseniRawCache`**, kde je uložený seznam přihlášených. Ta se navíc plní přes `+=`, který existující `id` aktivity nikdy nepřepíše.

Průběh:
1. Iterace po přihlášení naplní `$prihlaseniRawCache[$aktivita]` = 3 lidi.
2. Odhlášení spustí novou iteraci ve **stejném procesu** → `reset()` znovu načte aktivity z DB, ale obsazenost bere ze zamrzlé statické cache → JSON pořád 3/4.
3. Nové přihlášení trefí čerstvý worker proces (aktivita v cache ještě není) → přepočítá se správně a bug „zmizí".

## Oprava

`reset()` nově volá `Aktivita::smazCache()` (metoda, která přesně tyto statické cache už umí vyprázdnit). Protože worker `reset()` volá na začátku každé iterace, každá regenerace se počítá z čerstvých dat.

## Test

Přidán regresní test `odhlaseniMeziIteracemiWorkeruSniziObsazenost`, který simuluje odhlášení mezi dvěma iteracemi workeru v jednom procesu.

- **Bez fixu** selže: `Failed asserting that 1 is identical to 0` (obsazenost visí nahoře — přesně nahlášený bug).
- **S fixem** projde. Celá sada `ProgramStaticFileGeneratorTest` + `ProgramCacheInvalidationTest` = 30 testů OK, ECS čistý.

## Ověření v běžící appce

Admin → Program:
1. Přihlas 1–3 lidi na aktivitu → obsazenost povyskočí.
2. Hned je odhlas → **obsazenost musí klesnout zpět** (dřív zůstala viset).
3. Otevři stejný program pod jiným uživatelem / v anonymním okně → musí ukazovat sníženou obsazenost bez nutnosti kohokoli nově přihlašovat.
