### PR TITLE
Zrychlení přihlašování/odhlašování na aktivitu

### DIFF
--- a/model/BackgroundProcess/BackgroundProcessService.php
+++ b/model/BackgroundProcess/BackgroundProcessService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gamecon\BackgroundProcess;
 
-use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\NativeClock;
 
 /**
  * Služba pro správu background procesů
@@ -22,9 +22,12 @@ class BackgroundProcessService
 
     public static function vytvorZGlobals(): self
     {
-        return new self(
-            SystemoveNastaveni::zGlobals()->kernel()->getContainer()->get('app.clock'),
-        );
+        // Záměrně NEboualíme Symfony kernel jen kvůli hodinám. Získat 'app.clock'
+        // z kontejneru znamená plný boot kernelu (~0,8 s) — a tenhle servis se
+        // volá z legacy hot-path (přihlášení/odhlášení z aktivity) na každý
+        // request, kde kernel jinak nabootovaný není. NativeClock je přesně to,
+        // na co se 'app.clock' v produkci rozhodne (dekoruje výchozí clock).
+        return new self(new NativeClock());
     }
 
     public function __construct(


### PR DESCRIPTION
## Problém

Přihlášení a odhlášení účastníka na aktivitu (v adminu i ve veřejném programu) **trvá násobně déle než dřív** — regrese, která přišla se systémem statických JSON souborů programu (ticket 1405).

## Příčina — změřeno

Endpoint `web/moduly/api/aktivitaAkce.php` na konci každého requestu volá `ProgramStaticFileGenerator::tryStartWorker()` → `BackgroundProcessService::vytvorZGlobals()`. Ta metoda dělala:

```php
SystemoveNastaveni::zGlobals()->kernel()->getContainer()->get('app.clock')
```

tj. **bootovala celý Symfony kernel + DI kontejner** jen kvůli získání hodin. Legacy program endpoint jinak kernel vůbec nebootuje, takže se ten boot platil čerstvě na každém requestu.

Naprofilováno na dev prostředí (`hrtime`), izolovaně po částech hot-pathu:

| Část | Před | Po |
|------|------|-----|
| **`BackgroundProcessService::vytvorZGlobals()`** | **776,7 ms** | **1,1 ms** |
| `Aktivita::zId` (fresh) | 0,2 ms | 0,2 ms |
| `obsazenostObj()` (enrich odpovědi) | 2,8 ms | 2,0 ms |
| `tryStartWorker()` celé | 3,3 ms | 3,8 ms |

Jedno volání `vytvorZGlobals()` dominovalo celému requestu. Vše ostatní jsou jednotky ms.

## Oprava

`vytvorZGlobals()` už nebootuje kernel — použije přímo `new NativeClock()`. To je přesně to, na co se `app.clock` v produkci rozhodne (dekoruje výchozí `clock` = `NativeClock`). Hodiny se v tomto servisu používají jen pro razítka `started_at`/`finished_at` reálných background procesů, takže reálný čas je správně; MockClock v testech se tím nikde neruší (žádný test tenhle servis nemockuje).

Výsledek: **776 ms → 1,1 ms** na tuto část, tj. hot-path přihlášení/odhlášení je zpět v jednotkách ms.

## Ověření

- `php -l` + ECS čisté.
- `ProgramStaticFileGeneratorTest` + `ProgramCacheInvalidationTest` = 31 testů OK.

## Ověření v běžící appce

Admin → Program (`/admin` → Program): přihlas/odhlas účastníka na aktivitu — akce musí proběhnout znatelně svižněji než dřív (dřív ~0,8 s režie navíc na každé kliknutí). Totéž ve veřejném programu.

## Pozn.

Zůstávají další, menší přispěvatelé latence (opakované `refresh()` = plný reload aktivity v `prihlas()`/`odhlas()`, a DB triggery `_table_data_versions` na každý zápis, které serializují souběžná přihlášení). Ty jsou ale řádově menší a nejsou hlavní příčina „násobně déle" — ten dělal boot kernelu. Řešitelné zvlášť, pokud bude potřeba.
