### PR TITLE
cron hardening

### DIFF
--- a/admin/cron.php
+++ b/admin/cron.php
@@ -6,7 +6,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Skript který je hostingem automaticky spouštěn jednou za hodinu. Standardní
- * limit vykonání je 90 sekund jako jinde na webu.
+ * limit vykonání je !!!30!!! sekund jako jinde na webu.
  */
 
 require_once __DIR__ . '/cron/_cron_zavadec.php';
@@ -27,14 +27,14 @@ if (!defined('CRON_KEY') || (string)CRON_KEY === '') {
 }
 
 if (get('key') !== CRON_KEY) {
-    $pocetChybnychPokusu   = 0;
+    $pocetChybnychPokusu = 0;
     $invalidCronKeyLogFile = $logdir . '/invalid_cron_key.log';
     if (file_exists($invalidCronKeyLogFile)) {
         $invalidCronKeyLogContent = file_get_contents($invalidCronKeyLogFile);
         if ($invalidCronKeyLogContent) {
             $predchoziChybnyPokus = json_decode($invalidCronKeyLogContent, true);
-            $pocetChybnychPokusu  = $predchoziChybnyPokus['attempts_count'] ?? 0;
-            $prodlevaSekund       = 10 * $pocetChybnychPokusu;
+            $pocetChybnychPokusu = $predchoziChybnyPokus['attempts_count'] ?? 0;
+            $prodlevaSekund = 10 * $pocetChybnychPokusu;
             if ($pocetChybnychPokusu > 0 && ($predchoziChybnyPokus['at'] ?? false) && ($predchoziChybnyPokus['at'] + $prodlevaSekund) >= time()) {
                 die('Na další pokus ještě počkej');
             }
@@ -43,9 +43,9 @@ if (get('key') !== CRON_KEY) {
     $pocetChybnychPokusu++;
     file_put_contents($invalidCronKeyLogFile,
         json_encode([
-            'request_uri'    => $_SERVER['REQUEST_URI'],
-            'referer'        => $_SERVER['HTTP_REFERER'] ?? null,
-            'at'             => time(),
+            'request_uri' => $_SERVER['REQUEST_URI'],
+            'referer' => $_SERVER['HTTP_REFERER'] ?? null,
+            'at' => time(),
             'attempts_count' => $pocetChybnychPokusu,
         ]),
     );
@@ -55,7 +55,7 @@ if (get('key') !== CRON_KEY) {
 $job = get('job');
 
 // otevřít log soubor pro zápis a přesměrovat do něj výstup
-$logfile = 'cron-' .($job ? "{$job}-" : '') . date('Y-m') . '.log';
+$logfile = 'cron-' . ($job ? "{$job}-" : '') . date('Y-m') . '.log';
 (new Filesystem())->mkdir($logdir);
 
 $_cronOutput = '';
@@ -88,7 +88,26 @@ if ($job !== null) {
 
 logs('Spuštím cron script...');
 
-require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
+/** @var Gamecon\SystemoveNastaveni\SystemoveNastaveni $systemoveNastaveni */
+
+try {
+    require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
+} catch (Throwable $e) {
+    $traceString = $e->getTraceAsString();
+
+    if (str_contains($e->getTrace()[0]["file"], "Fio")) {
+        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
+            ->adresati(['it@gamecon.cz'])
+            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
+            ->text(<<<TEXT
+        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
+
+        $traceString
+        TEXT,
+            )
+            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
+    }
+}
 
 logs('Expiruju týmy...');
 global $systemoveNastaveni;
@@ -101,7 +120,7 @@ $smazanoRozpracovanychTymu = \Gamecon\Aktivita\AktivitaTym::smazRozpracovaneTymy
 logs("smazáno $smazanoRozpracovanychTymu rozpracovaných týmů.");
 
 logs('Zamykám před veřejností už běžící, dosud nezamčené aktivity...');
-$idsZamcenmych  = Aktivita::zamkniZacinajiciDo(
+$idsZamcenmych = Aktivita::zamkniZacinajiciDo(
     new DateTimeImmutable('-' . AUTOMATICKY_UZAMKNOUT_AKTIVITU_X_MINUT_PO_ZACATKU . ' minutes'),
     $systemoveNastaveni,
 );
@@ -109,8 +128,8 @@ $pocetZamcenych = count($idsZamcenmych);
 logs("zamčeno $pocetZamcenych aktivit.");
 
 logs('Odesílám vypravěčům připomenutí, že nezavřeli prezenci...');
-$konciciOd       = new DateTimeImmutable('-' . UPOZORNIT_NA_NEUZAMKNUTOU_AKTIVITU_X_MINUT_PO_KONCI . ' minutes');
-$konciciDo       = $konciciOd->modify('+ 1 hour'); // interval CRONu - abychom nespamovali každou hodinu
+$konciciOd = new DateTimeImmutable('-' . UPOZORNIT_NA_NEUZAMKNUTOU_AKTIVITU_X_MINUT_PO_KONCI . ' minutes');
+$konciciDo = $konciciOd->modify('+ 1 hour'); // interval CRONu - abychom nespamovali každou hodinu
 $pocetUpozorneni = Aktivita::upozorniNaNeuzavreneKonciciOdDo(
     $konciciOd,
     $konciciDo,

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -89,6 +89,7 @@ if ($job !== null) {
 logs('Spuštím cron script...');
 
 /** @var Gamecon\SystemoveNastaveni\SystemoveNastaveni $systemoveNastaveni */
+global $systemoveNastaveni;
 
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
@@ -98,7 +99,6 @@ try {
 }
 
 logs('Expiruju týmy...');
-global $systemoveNastaveni;
 $odemcenoTymovychAktivit = (new HromadneAkceAktivit($systemoveNastaveni))
     ->vyresExpirovaneTymyHromadne(Uzivatel::zId(Uzivatel::SYSTEM, true));
 logs("Expirováno $odemcenoTymovychAktivit týmů.");

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -93,20 +93,7 @@ logs('Spuštím cron script...');
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
 } catch (Throwable $e) {
-    $traceString = $e->getTraceAsString();
-
-    if (str_contains($e->getTrace()[0]["file"], "Fio")) {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz'])
-            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
-            ->text(<<<TEXT
-        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
-
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    }
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
 }
 
 logs('Expiruju týmy...');

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -6,7 +6,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Skript který je hostingem automaticky spouštěn jednou za hodinu. Standardní
- * limit vykonání je !!!30!!! sekund jako jinde na webu.
+ * limit vykonání je 30 sekund jako jinde na webu.
  */
 
 require_once __DIR__ . '/cron/_cron_zavadec.php';

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -93,7 +93,8 @@ logs('Spuštím cron script...');
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
 } catch (Throwable $e) {
-    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
+        ->ohlas($e, 'stažení nových plateb z Fio');
 }
 
 logs('Expiruju týmy...');

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -37,30 +37,7 @@ try {
         }
     }
 } catch (Throwable $e) {
-    $traceString = $e->getTraceAsString();
-
-    if (str_contains($e->getTrace()[0]["file"], "Fio"))
-    {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz'])
-            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
-            ->text(<<<TEXT
-        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
-
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    } else {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
-            ->predmet("!!IMPORTANT!! spadnulo odhlašování neplatičů")
-            ->text(<<<TEXT
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    }
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
 }
 
 if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -37,7 +37,8 @@ try {
         }
     }
 } catch (Throwable $e) {
-    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
+        ->ohlas($e, 'odhlašování neplatičů / maily neplatičům');
 }
 
 if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -16,6 +16,16 @@ try {
         }
     }
 
+    // Aktivace aktivit musí následovat hned po odhlášení neplatičů, aby pracovala
+    // s dokončeným odhlášením. Zároveň zůstává uvnitř try - když odhlášení spadne,
+    // catch aktivaci přeskočí (nesmí aktivovat nad polovičatě odhlášeným stavem).
+    if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/aktivace_aktivit.php';
+        if ($job === 'aktivace_aktivit') {
+            return;
+        }
+    }
+
     if (in_array($job, ['mail_cfo_brzke_odhlaseni_neplaticu', 'aktivity_hromadne'])) {
         require __DIR__ . '/jobs/mail_cfo_brzke_odhlaseni_neplaticu.php';
         if ($job === 'mail_cfo_brzke_odhlaseni_neplaticu') {
@@ -38,14 +48,7 @@ try {
     }
 } catch (Throwable $e) {
     (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
-        ->ohlas($e, 'odhlašování neplatičů / maily neplatičům');
-}
-
-if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/aktivace_aktivit.php';
-    if ($job === 'aktivace_aktivit') {
-        return;
-    }
+        ->ohlas($e, 'odhlašování neplatičů / aktivace aktivit / maily neplatičům');
 }
 
 if (in_array($job, ['mazani_nepripravenych_tymu', 'aktivity_hromadne'])) {

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -1,44 +1,71 @@
 <?php
 /** @var Gamecon\SystemoveNastaveni\SystemoveNastaveni $systemoveNastaveni */
 
-$job   ??= null;
+$job ??= null;
 $znovu = filter_var(get('znovu'), FILTER_VALIDATE_BOOL)
     && ($systemoveNastaveni->jsmeNaLocale()
         || (defined('TEST_HROMADNE_AKCE_AKTIVIT_CRONEM_PORAD') && TEST_HROMADNE_AKCE_AKTIVIT_CRONEM_PORAD)
     );
 
-// Pozor, pořadí je důležité - úkoly na prvním místě jsou ty, co mají přednost (nikoli časovou, ale významovou) před ostatními
-if (in_array($job, ['odhlaseni_neplaticu', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/odhlaseni_neplaticu.php';
-    if ($job === 'odhlaseni_neplaticu') {
-        return;
+try {
+    // Pozor, pořadí je důležité - úkoly na prvním místě jsou ty, co mají přednost (nikoli časovou, ale významovou) před ostatními
+    if (in_array($job, ['odhlaseni_neplaticu', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/odhlaseni_neplaticu.php';
+        if ($job === 'odhlaseni_neplaticu') {
+            return;
+        }
+    }
+
+    if (in_array($job, ['mail_cfo_brzke_odhlaseni_neplaticu', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/mail_cfo_brzke_odhlaseni_neplaticu.php';
+        if ($job === 'mail_cfo_brzke_odhlaseni_neplaticu') {
+            return;
+        }
+    }
+
+    if (in_array($job, ['mail_varovani_neplaticum_o_brzkem_odhlaseni', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/mail_varovani_neplaticum_o_brzkem_odhlaseni.php';
+        if ($job === 'mail_varovani_neplaticum_o_brzkem_odhlaseni') {
+            return;
+        }
+    }
+
+    if (in_array($job, ['mail_cfo_nesparovane_platby', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/mail_cfo_nesparovane_platby.php';
+        if ($job === 'mail_cfo_nesparovane_platby') {
+            return;
+        }
+    }
+} catch (Throwable $e) {
+    $traceString = $e->getTraceAsString();
+
+    if (str_contains($e->getTrace()[0]["file"], "Fio"))
+    {
+        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
+            ->adresati(['it@gamecon.cz'])
+            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
+            ->text(<<<TEXT
+        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
+
+        $traceString
+        TEXT,
+            )
+            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
+    } else {
+        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
+            ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
+            ->predmet("!!IMPORTANT!! spadnulo odhlašování neplatičů")
+            ->text(<<<TEXT
+        $traceString
+        TEXT,
+            )
+            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
     }
 }
 
 if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {
     require __DIR__ . '/jobs/aktivace_aktivit.php';
     if ($job === 'aktivace_aktivit') {
-        return;
-    }
-}
-
-if (in_array($job, ['mail_cfo_brzke_odhlaseni_neplaticu', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/mail_cfo_brzke_odhlaseni_neplaticu.php';
-    if ($job === 'mail_cfo_brzke_odhlaseni_neplaticu') {
-        return;
-    }
-}
-
-if (in_array($job, ['mail_varovani_neplaticum_o_brzkem_odhlaseni', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/mail_varovani_neplaticum_o_brzkem_odhlaseni.php';
-    if ($job === 'mail_varovani_neplaticum_o_brzkem_odhlaseni') {
-        return;
-    }
-}
-
-if (in_array($job, ['mail_cfo_nesparovane_platby', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/mail_cfo_nesparovane_platby.php';
-    if ($job === 'mail_cfo_nesparovane_platby') {
         return;
     }
 }

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Cron;
+
+use Gamecon\Kanaly\GcMail;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+
+/**
+ * Rozešle upozornění na chybu, která spadla během běhu cronu.
+ *
+ * Sjednocuje logiku, která byla dřív duplikovaná ve dvou souborech
+ * (admin/cron.php a admin/cron/_cron_job.php).
+ */
+class CronErrorNotifier
+{
+    public function __construct(
+        private readonly SystemoveNastaveni $systemoveNastaveni,
+    ) {
+    }
+
+    public function ohlas(\Throwable $chyba): void
+    {
+        $traceString = $chyba->getTraceAsString();
+
+        if (str_contains($chyba->getTrace()[0]['file'], 'Fio')) {
+            (new GcMail($this->systemoveNastaveni))
+                ->adresati(['it@gamecon.cz'])
+                ->predmet('Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek')
+                ->text(<<<TEXT
+                    V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
+
+                    {$traceString}
+                    TEXT)
+                ->odeslat(GcMail::FORMAT_TEXT);
+        } else {
+            (new GcMail($this->systemoveNastaveni))
+                ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
+                ->predmet('!!IMPORTANT!! spadnulo odhlašování neplatičů')
+                ->text(<<<TEXT
+                    {$traceString}
+                    TEXT)
+                ->odeslat(GcMail::FORMAT_TEXT);
+        }
+    }
+}

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -24,7 +24,7 @@ class CronErrorNotifier
     {
         $traceString = $chyba->getTraceAsString();
 
-        if (str_contains($chyba->getTrace()[0]['file'], 'Fio')) {
+        if ($this->jeVypadekFio($chyba)) {
             (new GcMail($this->systemoveNastaveni))
                 ->adresati(['it@gamecon.cz'])
                 ->predmet('Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek')
@@ -43,5 +43,28 @@ class CronErrorNotifier
                     TEXT)
                 ->odeslat(GcMail::FORMAT_TEXT);
         }
+    }
+
+    /**
+     * Fio chyby vznikají v souborech, jejichž cesta obsahuje "Fio"
+     * (model/Finance/FioPlatba.php, model/Command/FioStazeniNovychPlateb.php).
+     * Prohledáme celý zásobník i řetěz příčin, ne jen vrcholový rámec - ten může
+     * být prázdný nebo bez klíče "file" (a přímé indexování getTrace()[0]["file"]
+     * pak vyhodí "Undefined array key" a str_contains dostane null).
+     */
+    private function jeVypadekFio(\Throwable $chyba): bool
+    {
+        for ($aktualni = $chyba; $aktualni !== null; $aktualni = $aktualni->getPrevious()) {
+            if (str_contains($aktualni->getFile(), 'Fio')) {
+                return true;
+            }
+            foreach ($aktualni->getTrace() as $ramec) {
+                if (isset($ramec['file']) && str_contains($ramec['file'], 'Fio')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -22,6 +22,17 @@ class CronErrorNotifier
 
     public function ohlas(\Throwable $chyba): void
     {
+        try {
+            $this->odesliUpozorneni($chyba);
+        } catch (\Throwable $chybaOdeslani) {
+            // Odeslání upozornění samo selhalo (např. nedostupné SMTP). Nesmíme
+            // shodit zbytek cronu - jen zalogujeme a běžíme dál.
+            logs('Nepodařilo se odeslat upozornění na chybu cronu: ' . $chybaOdeslani->getMessage());
+        }
+    }
+
+    private function odesliUpozorneni(\Throwable $chyba): void
+    {
         $traceString = $chyba->getTraceAsString();
 
         if ($this->jeVypadekFio($chyba)) {

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -20,10 +20,13 @@ class CronErrorNotifier
     ) {
     }
 
-    public function ohlas(\Throwable $chyba): void
+    /**
+     * @param string $nazevJobu lidsky čitelný název jobu, který spadl (kvůli přesnému předmětu mailu)
+     */
+    public function ohlas(\Throwable $chyba, string $nazevJobu): void
     {
         try {
-            $this->odesliUpozorneni($chyba);
+            $this->odesliUpozorneni($chyba, $nazevJobu);
         } catch (\Throwable $chybaOdeslani) {
             // Odeslání upozornění samo selhalo (např. nedostupné SMTP). Nesmíme
             // shodit zbytek cronu - jen zalogujeme a běžíme dál.
@@ -31,7 +34,7 @@ class CronErrorNotifier
         }
     }
 
-    private function odesliUpozorneni(\Throwable $chyba): void
+    private function odesliUpozorneni(\Throwable $chyba, string $nazevJobu): void
     {
         $traceString = $chyba->getTraceAsString();
 
@@ -48,7 +51,7 @@ class CronErrorNotifier
         } else {
             (new GcMail($this->systemoveNastaveni))
                 ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
-                ->predmet('!!IMPORTANT!! spadnulo odhlašování neplatičů')
+                ->predmet("!!IMPORTANT!! spadl cron job: {$nazevJobu}")
                 ->text(<<<TEXT
                     {$traceString}
                     TEXT)


### PR DESCRIPTION
Ošetření chyb v cronu — pády Fio stahování a jobů kolem odhlašování neplatičů se nově odchytí a pošlou mailem na `it@gamecon.cz` (u netransientních chyb i na `info@gamecon.cz`). Logika je vytažená do nové třídy `Gamecon\Cron\CronErrorNotifier`.

Odesílání mailů funguje ověřeně. Kontrolní běh proti lokální DB (anonymizovaná data, PR head `f4824ccef`) ale odhalil tři chyby v řízení toku okolo `try`/`catch` v `admin/cron/_cron_job.php` — dole i s reprodukcí.

## Nálezy k dořešení

### 1. Cílený job spadne s nepravdivou hláškou „Invalid job“

Když job uvnitř `try` vyhodí výjimku, `catch` ji odchytí a pošle mail, ale **přeskočí se `return`** uvnitř `try`. Běh propadne všemi následujícími `if`y až na závěrečnou pojistku na konci souboru:

```
RuntimeException: Invalid job 'odhlaseni_neplaticu' in admin/cron/_cron_job.php:91
```

Job je přitom platný (soubor ho obsluhuje na ř. 12). **Skutečná výjimka se do logu vůbec nedostane** — jde jen do mailu. V cron logu tak zůstane hláška, která ukazuje mimo reálnou příčinu.

Reprodukce: `?job=odhlaseni_neplaticu` s výjimkou uvnitř jobu.

### 2. `aktivity_hromadne` po chybě tiše pokračuje

Při hodinovém běhu se pád `odhlaseni_neplaticu` spolkne, pokračuje se na `mazani_nepripravenych_tymu` (tj. **mimo `try`**) a běh se ukončí jako úspěšný — log má 1 bajt, žádná stopa po chybě.

To je přesně ten „polovičatě odhlášený stav“, před kterým varuje komentář v tomto PR. `catch` ochrání `aktivace_aktivit` uvnitř `try`, ale joby pod `try` blokem nechrání nic.

### 3. Mail nepojmenuje job, který spadl

Oba běhy výše poslaly bajt po bajtu shodný předmět:

> `!!IMPORTANT!! spadl cron job: odhlašování neplatičů / aktivace aktivit / maily neplatičům`

Spadl přitom jen jeden job. Z mailu nejde odlišit cílený běh od hodinového. `$job` je přitom v scope.

## Návrh opravy

`return` v `catch` řeší body 1 i 2, předání `$job` řeší bod 3:

```php
} catch (Throwable $chyba) {
    (new CronErrorNotifier($systemoveNastaveni))->ohlas($chyba, $job ?? 'neznámý job');
    return;
}
```

Zda má `aktivity_hromadne` skončit úplně, nebo přeskočit jen na skutečně nezávislé joby (`mazani_nepripravenych_tymu` s odhlašováním nejspíš nesouvisí), je rozhodnutí na autorovi. Tiše pokračovat a hlásit úspěch ale není dobrá varianta ani v jednom případě.
