### PR TITLE
Opravy z code review: cron hardening

### DIFF
--- a/admin/cron.php
+++ b/admin/cron.php
@@ -89,6 +89,7 @@ if ($job !== null) {
 logs('Spuštím cron script...');
 
 /** @var Gamecon\SystemoveNastaveni\SystemoveNastaveni $systemoveNastaveni */
+global $systemoveNastaveni;
 
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
@@ -98,7 +99,6 @@ try {
 }
 
 logs('Expiruju týmy...');
-global $systemoveNastaveni;
 $odemcenoTymovychAktivit = (new HromadneAkceAktivit($systemoveNastaveni))
     ->vyresExpirovaneTymyHromadne(Uzivatel::zId(Uzivatel::SYSTEM, true));
 logs("Expirováno $odemcenoTymovychAktivit týmů.");

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -93,20 +93,7 @@ logs('Spuštím cron script...');
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
 } catch (Throwable $e) {
-    $traceString = $e->getTraceAsString();
-
-    if (str_contains($e->getTrace()[0]["file"], "Fio")) {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz'])
-            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
-            ->text(<<<TEXT
-        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
-
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    }
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
 }
 
 logs('Expiruju týmy...');

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -6,7 +6,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Skript který je hostingem automaticky spouštěn jednou za hodinu. Standardní
- * limit vykonání je !!!30!!! sekund jako jinde na webu.
+ * limit vykonání je 30 sekund jako jinde na webu.
  */
 
 require_once __DIR__ . '/cron/_cron_zavadec.php';

--- a/admin/cron.php
+++ b/admin/cron.php
@@ -93,7 +93,8 @@ logs('Spuštím cron script...');
 try {
     require __DIR__ . '/cron/fio_stazeni_novych_plateb.php';
 } catch (Throwable $e) {
-    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
+        ->ohlas($e, 'stažení nových plateb z Fio');
 }
 
 logs('Expiruju týmy...');

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -37,30 +37,7 @@ try {
         }
     }
 } catch (Throwable $e) {
-    $traceString = $e->getTraceAsString();
-
-    if (str_contains($e->getTrace()[0]["file"], "Fio"))
-    {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz'])
-            ->predmet("Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek")
-            ->text(<<<TEXT
-        V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
-
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    } else {
-        (new \Gamecon\Kanaly\GcMail($systemoveNastaveni))
-            ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
-            ->predmet("!!IMPORTANT!! spadnulo odhlašování neplatičů")
-            ->text(<<<TEXT
-        $traceString
-        TEXT,
-            )
-            ->odeslat(\Gamecon\Kanaly\GcMail::FORMAT_TEXT);
-    }
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
 }
 
 if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -37,7 +37,8 @@ try {
         }
     }
 } catch (Throwable $e) {
-    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))->ohlas($e);
+    (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
+        ->ohlas($e, 'odhlašování neplatičů / maily neplatičům');
 }
 
 if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {

--- a/admin/cron/_cron_job.php
+++ b/admin/cron/_cron_job.php
@@ -16,6 +16,16 @@ try {
         }
     }
 
+    // Aktivace aktivit musí následovat hned po odhlášení neplatičů, aby pracovala
+    // s dokončeným odhlášením. Zároveň zůstává uvnitř try - když odhlášení spadne,
+    // catch aktivaci přeskočí (nesmí aktivovat nad polovičatě odhlášeným stavem).
+    if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {
+        require __DIR__ . '/jobs/aktivace_aktivit.php';
+        if ($job === 'aktivace_aktivit') {
+            return;
+        }
+    }
+
     if (in_array($job, ['mail_cfo_brzke_odhlaseni_neplaticu', 'aktivity_hromadne'])) {
         require __DIR__ . '/jobs/mail_cfo_brzke_odhlaseni_neplaticu.php';
         if ($job === 'mail_cfo_brzke_odhlaseni_neplaticu') {
@@ -38,14 +48,7 @@ try {
     }
 } catch (Throwable $e) {
     (new \Gamecon\Cron\CronErrorNotifier($systemoveNastaveni))
-        ->ohlas($e, 'odhlašování neplatičů / maily neplatičům');
-}
-
-if (in_array($job, ['aktivace_aktivit', 'aktivity_hromadne'])) {
-    require __DIR__ . '/jobs/aktivace_aktivit.php';
-    if ($job === 'aktivace_aktivit') {
-        return;
-    }
+        ->ohlas($e, 'odhlašování neplatičů / aktivace aktivit / maily neplatičům');
 }
 
 if (in_array($job, ['mazani_nepripravenych_tymu', 'aktivity_hromadne'])) {

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Cron;
+
+use Gamecon\Kanaly\GcMail;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+
+/**
+ * Rozešle upozornění na chybu, která spadla během běhu cronu.
+ *
+ * Sjednocuje logiku, která byla dřív duplikovaná ve dvou souborech
+ * (admin/cron.php a admin/cron/_cron_job.php).
+ */
+class CronErrorNotifier
+{
+    public function __construct(
+        private readonly SystemoveNastaveni $systemoveNastaveni,
+    ) {
+    }
+
+    public function ohlas(\Throwable $chyba): void
+    {
+        $traceString = $chyba->getTraceAsString();
+
+        if (str_contains($chyba->getTrace()[0]['file'], 'Fio')) {
+            (new GcMail($this->systemoveNastaveni))
+                ->adresati(['it@gamecon.cz'])
+                ->predmet('Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek')
+                ->text(<<<TEXT
+                    V rámci běhu Cron selhala komunikace s Fio. Pokud se neopakuje dlouhodobě, lze pravděpodobně ignorovat.
+
+                    {$traceString}
+                    TEXT)
+                ->odeslat(GcMail::FORMAT_TEXT);
+        } else {
+            (new GcMail($this->systemoveNastaveni))
+                ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
+                ->predmet('!!IMPORTANT!! spadnulo odhlašování neplatičů')
+                ->text(<<<TEXT
+                    {$traceString}
+                    TEXT)
+                ->odeslat(GcMail::FORMAT_TEXT);
+        }
+    }
+}

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -24,7 +24,7 @@ class CronErrorNotifier
     {
         $traceString = $chyba->getTraceAsString();
 
-        if (str_contains($chyba->getTrace()[0]['file'], 'Fio')) {
+        if ($this->jeVypadekFio($chyba)) {
             (new GcMail($this->systemoveNastaveni))
                 ->adresati(['it@gamecon.cz'])
                 ->predmet('Selhala komunikace s Fio, pravděpodobně jenom dočasný výpadek')
@@ -43,5 +43,28 @@ class CronErrorNotifier
                     TEXT)
                 ->odeslat(GcMail::FORMAT_TEXT);
         }
+    }
+
+    /**
+     * Fio chyby vznikají v souborech, jejichž cesta obsahuje "Fio"
+     * (model/Finance/FioPlatba.php, model/Command/FioStazeniNovychPlateb.php).
+     * Prohledáme celý zásobník i řetěz příčin, ne jen vrcholový rámec - ten může
+     * být prázdný nebo bez klíče "file" (a přímé indexování getTrace()[0]["file"]
+     * pak vyhodí "Undefined array key" a str_contains dostane null).
+     */
+    private function jeVypadekFio(\Throwable $chyba): bool
+    {
+        for ($aktualni = $chyba; $aktualni !== null; $aktualni = $aktualni->getPrevious()) {
+            if (str_contains($aktualni->getFile(), 'Fio')) {
+                return true;
+            }
+            foreach ($aktualni->getTrace() as $ramec) {
+                if (isset($ramec['file']) && str_contains($ramec['file'], 'Fio')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -22,6 +22,17 @@ class CronErrorNotifier
 
     public function ohlas(\Throwable $chyba): void
     {
+        try {
+            $this->odesliUpozorneni($chyba);
+        } catch (\Throwable $chybaOdeslani) {
+            // Odeslání upozornění samo selhalo (např. nedostupné SMTP). Nesmíme
+            // shodit zbytek cronu - jen zalogujeme a běžíme dál.
+            logs('Nepodařilo se odeslat upozornění na chybu cronu: ' . $chybaOdeslani->getMessage());
+        }
+    }
+
+    private function odesliUpozorneni(\Throwable $chyba): void
+    {
         $traceString = $chyba->getTraceAsString();
 
         if ($this->jeVypadekFio($chyba)) {

--- a/model/Cron/CronErrorNotifier.php
+++ b/model/Cron/CronErrorNotifier.php
@@ -20,10 +20,13 @@ class CronErrorNotifier
     ) {
     }
 
-    public function ohlas(\Throwable $chyba): void
+    /**
+     * @param string $nazevJobu lidsky čitelný název jobu, který spadl (kvůli přesnému předmětu mailu)
+     */
+    public function ohlas(\Throwable $chyba, string $nazevJobu): void
     {
         try {
-            $this->odesliUpozorneni($chyba);
+            $this->odesliUpozorneni($chyba, $nazevJobu);
         } catch (\Throwable $chybaOdeslani) {
             // Odeslání upozornění samo selhalo (např. nedostupné SMTP). Nesmíme
             // shodit zbytek cronu - jen zalogujeme a běžíme dál.
@@ -31,7 +34,7 @@ class CronErrorNotifier
         }
     }
 
-    private function odesliUpozorneni(\Throwable $chyba): void
+    private function odesliUpozorneni(\Throwable $chyba, string $nazevJobu): void
     {
         $traceString = $chyba->getTraceAsString();
 
@@ -48,7 +51,7 @@ class CronErrorNotifier
         } else {
             (new GcMail($this->systemoveNastaveni))
                 ->adresati(['it@gamecon.cz', 'info@gamecon.cz'])
-                ->predmet('!!IMPORTANT!! spadnulo odhlašování neplatičů')
+                ->predmet("!!IMPORTANT!! spadl cron job: {$nazevJobu}")
                 ->text(<<<TEXT
                     {$traceString}
                     TEXT)


### PR DESCRIPTION
Opravy z code review PR #1007 (větev `cron-hardening`). Cílem PR #1007 bylo „hardening" cronu, ale ve dvou nových `try/catch` blocích byla řada chyb, které naopak vedly k **tiššímu** selhání než předtím. Každý commit řeší jeden nález z review.

Podstata: společná logika ohlašování chyb byla vytažena do `Gamecon\Cron\CronErrorNotifier`, který teď (a) chybu vždy ohlásí, (b) klasifikuje Fio-výpadek robustně bez pádu na `getTrace()[0]`, (c) hlídá si vlastní odeslání mailu, aby výpadek SMTP neshodil zbytek cronu.

### Commity → nálezy

| Commit | Nález | Co řeší |
|--------|-------|---------|
| `opravit placeholder v docblocku limitu` | #9 | `!!!30!!!` → `30` |
| `sjednotit ohlašování chyb do jednoho notifieru` | #8 | duplikace klasifikace + mailu ve dvou souborech → jeden `CronErrorNotifier` |
| `nepolykat chyby stahování plateb bez upozornění` | #1 | `admin/cron.php` neměl `else` větev → nefio chyby mizely bez upozornění |
| `robustní detekce výpadku Fio (bez pádu na trace[0])` | #3, #7 | `getTrace()[0]["file"]` padal na prázdném/bezsouborovém rámci a klasifikoval jen podle bezprostředního volajícího → procházíme celý zásobník i řetěz příčin, null-safe |
| `selhání odeslání upozornění nesmí shodit cron` | #4 | odeslání mailu uvnitř `catch` bylo nechráněné → obalené vlastním `try/catch` |
| `v upozornění pojmenovat job, který skutečně spadl` | #5 | jeden `catch` nad 4 joby hlásil vždy „spadlo odhlašování neplatičů" → předmět pojmenuje konkrétní job |
| `aktivovat aktivity hned po odhlášení a jen při úspěchu` | #2, #6 | `aktivace_aktivit` přesunuta zpět hned za odhlášení neplatičů a **dovnitř** `try` → při pádu odhlášení se aktivace přeskočí (neaktivuje nad polovičatě odhlášeným stavem) |
| `sjednotit deklaraci globálu systemoveNastaveni` | #10 | rozštěpená deklarace (docblock `@var` nahoře, `global` o 20 řádků níž) → jeden `global` před `try` |

Nálezy #3+#7 a #2+#6 jsou dvojice, kde jeden a tentýž kód řeší oba nálezy — nešly rozdělit do samostatných neprázdných commitů.

### Ověření
- `php -l` na všech třech souborech — bez chyb.
- ECS na novém `CronErrorNotifier.php` — čistý.

**Manuální ověření (lokálně):**
- Spustit cron job ručně: `http://localhost/admin/cron.php?key=<CRON_KEY>&job=aktivity_hromadne&echo=1` → v logu (`logy/cron/`) by měl proběhnout `odhlaseni_neplaticu` → `aktivace_aktivit` → maily v tomto pořadí.
- Fio výpadek se dá simulovat prázdným/neplatným `FIO_TOKEN` — očekává se mail na `it@gamecon.cz` s předmětem o dočasném výpadku, cron pokračuje dál.
