### PR TITLE
Testy importu aktivit nezávislé na aktuálním čase

### DIFF
--- a/tests/Aktivity/ActivitiesImporterTest.php
+++ b/tests/Aktivity/ActivitiesImporterTest.php
@@ -11,6 +11,7 @@ use Gamecon\Admin\Modules\Aktivity\Import\Activities\ActivitiesImporter;
 use Gamecon\Admin\Modules\Aktivity\Import\Activities\ActivitiesImportLogger;
 use Gamecon\Aktivita\Aktivita;
 use Gamecon\Cas\DateTimeCz;
+use Gamecon\Cas\DateTimeGamecon;
 use Gamecon\Mutex\Mutex;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\Tests\Db\AbstractTestDb;
@@ -282,6 +283,18 @@ class ActivitiesImporterTest extends AbstractTestDb
     }
 
     /**
+     * Importér odmítá editovat aktivitu, která už začala. Testovací aktivity se plánují
+     * na dny GameConu daného ročníku, takže s reálnými hodinami by testy začaly padat
+     * v okamžiku, kdy ročník reálně proběhne. Čas proto zmrazíme na půlnoc dne zahájení.
+     */
+    private function importedAt(): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromInterface(
+            DateTimeGamecon::zacatekGameconu(ROCNIK)->setTime(0, 0),
+        );
+    }
+
+    /**
      * Helper method to create ActivitiesImporter with mocked dependencies
      */
     private function createImporter(array $mockSheetData): ActivitiesImporter
@@ -309,7 +322,7 @@ class ActivitiesImporterTest extends AbstractTestDb
             googleDriveService: $mockGoogleDrive,
             googleSheetsService: $mockGoogleSheets,
             editActivityUrlSkeleton: '/admin/aktivity/upravit?id=%d',
-            now: new \DateTimeImmutable(),
+            now: $this->importedAt(),
             storytellersPermissionsUrl: '/permissions',
             logovac: $mockLogovac,
             mutexPattern: $mockMutex,


### PR DESCRIPTION
Testy importu aktivit nezávisí na aktuálním čase — tím se odblokuje deploy na ostrou.

## Proč to padá

`ActivitiesImporterTest::testReimportSameDataDoesNotChangeAnything` padá na `Failed asserting that 1 is identical to 3` ([run](https://github.com/gamecon-cz/gamecon/actions/runs/29576214039/job/87871131095)). **Není to flaky test** a nezpůsobilo to PR #1007 — padá stejně i na commitu `cf1cdcdb2`, tedy na posledním běhu, který byl zelený.

Testovací aktivity jsou napevno na „Pátek" 10:00 / 13:00 / 16:00. `DateTimeGamecon::denKolemZacatkuGameconu()` je nemapuje na „nejbližší pátek", ale na **pátek daného ročníku** — pro ROCNIK 2026 to je **17. 7. 2026**. Importér přitom dostával reálný čas (`now: new \DateTimeImmutable()`) a `ImportSqlMappedValuesChecker::checkTime()` odmítá editovat aktivitu, která už začala:

```php
if ($originalActivity->zacatek()->getTimestamp() <= $this->now->getTimestamp()) {
    return ImportStepResult::error('… už nelze editovat importem, protože už začala …');
}
```

Ta podmínka platí jen pro **druhý** import (kdy už `$originalActivity` existuje). První import proto založí 3 aktivity, druhý zahodí všechny, které už podle reálných hodin začaly. CI běželo v 11:15, takže prošla jen ta v 16:00 → `1` místo `3`.

Test tedy **nepadá jen občas — padá od pátku 10:00 letošního ročníku až do přepnutí na ROCNIK 2027.** Do té doby blokuje každý deploy. Že běhy do 14. 7. byly zelené, byla shoda okolností — ročník ještě nezačal.

## Oprava

Čas importu se zmrazí na půlnoc dne zahájení ročníku, místo reálných hodin:

```php
now: $this->importedAt(),   // půlnoc dne zahájení ROCNIK
```

Odvození z `zacatekGameconu(ROCNIK)` drží čas uvnitř správného ročníku (z `$now` se počítá i `$currentYear`, který určuje, na které datum aktivity padnou) a zároveň před začátkem všech testovacích aktivit, takže se to nerozbije ani s posunem termínu konu.

## Ověření

- Celá třída i celá sada zelené (822 testů) — ověřeno **dnes v pátek 14:57**, tedy přesně za podmínek, za kterých `main` padá.
- V testu nezůstalo žádné čtení reálných hodin.
- Zmrazený čas (16. 7. 00:00) je prokazatelně před nejstarší testovací aktivitou (17. 7. 10:00).
