### PR TITLE
Uživatelská nápověda v adminu

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -137,12 +137,20 @@ if (! empty($menu[$stranka]['submenu'])) {
 }
 
 // zjištění práv na zobrazení stránky
+$maNekterePravo = static function (array $polozkaMenu) use ($u): bool {
+    foreach ($polozkaMenu['prava'] ?? [$polozkaMenu['pravo']] as $pravo) {
+        if ($u->maPravo($pravo)) {
+            return true;
+        }
+    }
+    return false;
+};
 $strankaExistuje = isset($menu[$stranka]);
 $podstrankaExistuje = isset($submenu[$podstranka]);
 $uzivatelMaPristup = $strankaExistuje
                      && (
-                         $u->maPravo($menu[$stranka]['pravo'])
-                         || ($podstrankaExistuje && $u->maPravo($submenu[$podstranka]['pravo']))
+                         $maNekterePravo($menu[$stranka])
+                         || ($podstrankaExistuje && $maNekterePravo($submenu[$podstranka]))
                      );
 
 // konstrukce stránky
@@ -240,7 +248,7 @@ if ($u && $u->maPravo(Pravo::ADMINISTRACE_INFOPULT)) {
 
 // výstup menu
 foreach ($menu as $url => $polozka) {
-    if ($u->maPravo($polozka['pravo'])) {
+    if ($maNekterePravo($polozka)) {
         $xtpl->assign('url', $url);
         $xtpl->assign('nazev', $polozka['nazev']);
         $xtpl->assign('aktivni', $stranka === $url
@@ -269,7 +277,7 @@ uasort($submenu, function (
 // výstup submenu
 $allHidden = true;
 foreach ($submenu as $url => $polozka) {
-    if ($u && $u->maPravo($polozka['pravo'])) {
+    if ($u && $maNekterePravo($polozka)) {
         $xtpl->assign('url', $url === $stranka
             ? $url
             : $stranka . '/' . $url);

--- a/admin/scripts/admin-menu.php
+++ b/admin/scripts/admin-menu.php
@@ -31,6 +31,7 @@ class AdminMenu
                 $this->menu[$url]['nazev'] = $m[1];
                 preg_match('@\* pravo: (\d*)@', $fc, $m);
                 $this->menu[$url]['pravo']  = (int)$m[1];
+                $this->menu[$url]['prava']  = $this->parsePrava($fc, (int)$m[1]);
                 $this->menu[$url]['soubor'] = $this->src . $file;
                 if ($this->isSubmenu) {
                     $this->parseSubMenu($fc, $url);
@@ -43,6 +44,7 @@ class AdminMenu
                 $this->menu[$url]['nazev'] = $m[1];
                 preg_match('@\* pravo: (.*)@', $fc, $m);
                 $this->menu[$url]['pravo']   = (int)$m[1];
+                $this->menu[$url]['prava']   = $this->parsePrava($fc, (int)$m[1]);
                 $this->menu[$url]['soubor']  = $this->src . $file . '/' . $file . '.php';
                 $this->menu[$url]['submenu'] = 1;
                 if ($this->isSubmenu) {
@@ -72,6 +74,23 @@ class AdminMenu
             }
             return strcmp($a['nazev'], $b['nazev']);
         });
+    }
+
+    /**
+     * Modul může místo jediného práva (hlavička `pravo:`) vyjmenovat hlavičkou
+     * `prava: 100, 102, ...` víc práv — stránku pak vidí a smí otevřít každý,
+     * kdo má KTERÉKOLI z nich (typicky Nápověda, viditelná pro všechny části
+     * adminu). Bez hlavičky `prava:` zůstává chování jako dřív, tj. jen `pravo:`.
+     *
+     * @return int[]
+     */
+    private function parsePrava(string $fc, int $pravo): array
+    {
+        if (!preg_match('@\* prava: ([\d, ]+)@', $fc, $m)) {
+            return [$pravo];
+        }
+        $prava = array_map('intval', array_filter(array_map('trim', explode(',', $m[1]))));
+        return $prava ?: [$pravo];
     }
 
     private function parseSubMenu(string $fc, string $url)

--- a/admin/scripts/modules/napoveda.php
+++ b/admin/scripts/modules/napoveda.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use Gamecon\Pravo;
+
+/**
+ * Uživatelská nápověda k administraci a k veřejnému webu. Kapitoly jsou
+ * Markdown soubory v docs/napoveda/ (verzované s kódem, nasazované spolu
+ * s aplikací). Uživatel vidí jen kapitoly k částem adminu, na které má právo.
+ *
+ * nazev: Nápověda
+ * pravo: 100
+ * prava: 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113
+ *
+ * @var Uzivatel $u
+ */
+
+$slozkaKapitol = realpath(__DIR__ . '/../../../docs/napoveda');
+
+// Pořadí zde určuje pořadí v navigaci. Práva: kapitolu vidí uživatel
+// s KTERÝMKOLI z uvedených práv, prázdné pole = vidí každý, kdo vidí Nápovědu.
+$kapitoly = [
+    'uvod'          => [],
+    'verejny-web'   => [],
+    'infopult'      => [Pravo::ADMINISTRACE_INFOPULT],
+    'uzivatel'      => [Pravo::ADMINISTRACE_UBYTOVANI, Pravo::ADMINISTRACE_INFOPULT],
+    'aktivity'      => [Pravo::ADMINISTRACE_AKCE],
+    'moje-aktivity' => [Pravo::ADMINISTRACE_MOJE_AKTIVITY],
+    'prezence'      => [Pravo::ADMINISTRACE_PREZENCE],
+    'finance'       => [Pravo::ADMINISTRACE_FINANCE],
+    'penize'        => [Pravo::ADMINISTRACE_PENIZE],
+    'reporty'       => [Pravo::ADMINISTRACE_REPORTY],
+    'statistiky'    => [Pravo::ADMINISTRACE_STATISTIKY],
+    'web'           => [Pravo::ADMINISTRACE_WEB],
+    'nastaveni'     => [Pravo::ADMINISTRACE_NASTAVENI],
+    'prava'         => [Pravo::ADMINISTRACE_PRAVA],
+];
+
+$dostupneKapitoly = [];
+foreach ($kapitoly as $slug => $potrebnaPrava) {
+    $maPravoNaKapitolu = $potrebnaPrava === [];
+    foreach ($potrebnaPrava as $potrebnePravo) {
+        if ($u->maPravo($potrebnePravo)) {
+            $maPravoNaKapitolu = true;
+            break;
+        }
+    }
+    if (!$maPravoNaKapitolu) {
+        continue;
+    }
+    $soubor = $slozkaKapitol . '/' . $slug . '.md';
+    if (!is_file($soubor)) {
+        continue;
+    }
+    $obsahKapitoly = (string)file_get_contents($soubor);
+    $nadpis        = preg_match('@^#\s+(.+)$@m', $obsahKapitoly, $m)
+        ? trim($m[1])
+        : $slug;
+    $dostupneKapitoly[$slug] = [
+        'nadpis' => $nadpis,
+        'obsah'  => $obsahKapitoly,
+    ];
+}
+
+if ($dostupneKapitoly === []) {
+    echo '<p>Nápověda zatím neobsahuje žádnou kapitolu, kterou bys mohl' . $u->koncovkaDlePohlavi() . ' vidět.</p>';
+    return;
+}
+
+$vybranaKapitola = get('kapitola');
+if (!isset($dostupneKapitoly[$vybranaKapitola])) {
+    $vybranaKapitola = array_key_first($dostupneKapitoly);
+}
+?>
+<style>
+    .napoveda {
+        display: flex;
+        gap: 2em;
+        align-items: flex-start;
+    }
+
+    .napoveda__menu {
+        flex: 0 0 14em;
+        position: sticky;
+        top: 1em;
+    }
+
+    .napoveda__menu ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .napoveda__menu li {
+        margin: 0;
+    }
+
+    .napoveda__menu a {
+        display: block;
+        padding: .35em .6em;
+        border-radius: .3em;
+        text-decoration: none;
+    }
+
+    .napoveda__menu a.napoveda__aktivni {
+        background: #ddd;
+        font-weight: bold;
+    }
+
+    .napoveda__obsah {
+        flex: 1 1 auto;
+        max-width: 55em;
+        line-height: 1.5;
+    }
+
+    .napoveda__obsah h1 {
+        margin-top: 0;
+    }
+
+    .napoveda__obsah table {
+        border-collapse: collapse;
+    }
+
+    .napoveda__obsah th,
+    .napoveda__obsah td {
+        border: 1px solid #bbb;
+        padding: .3em .6em;
+    }
+
+    .napoveda__paticka {
+        margin-top: 3em;
+        font-size: .85em;
+        color: #666;
+        border-top: 1px solid #ddd;
+        padding-top: .5em;
+    }
+</style>
+<div class="napoveda">
+    <nav class="napoveda__menu">
+        <ul>
+            <?php foreach ($dostupneKapitoly as $slug => $kapitola) { ?>
+                <li>
+                    <a href="napoveda?kapitola=<?= urlencode($slug) ?>"
+                       class="<?= $slug === $vybranaKapitola ? 'napoveda__aktivni' : '' ?>">
+                        <?= htmlspecialchars($kapitola['nadpis'], ENT_QUOTES) ?>
+                    </a>
+                </li>
+            <?php } ?>
+        </ul>
+    </nav>
+    <div class="napoveda__obsah">
+        <?= markdownNoCache($dostupneKapitoly[$vybranaKapitola]['obsah']) ?>
+        <p class="napoveda__paticka">
+            Našel<?= $u->koncovkaDlePohlavi() ?> jsi v nápovědě chybu nebo ti tu něco chybí?
+            Kapitoly žijí v repozitáři ve složce <code>docs/napoveda/</code> —
+            napiš správci webu, nebo rovnou navrhni úpravu.
+        </p>
+    </div>
+</div>

--- a/docs/napoveda/aktivity.md
+++ b/docs/napoveda/aktivity.md
@@ -1,0 +1,142 @@
+# Aktivity
+
+Sekce **Aktivity** je srdce programu GameConu. Tady zakládáš a upravuješ aktivity (hry, turnaje, přednášky, brigády…), řídíš jejich zveřejnění a otevření přihlašování, hlídáš přihlášené účastníky a týmy, spravuješ štítky a místnosti a hromadně přenášíš aktivity mezi ročníky přes exporty a importy. Podle svých práv nemusíš vidět všechny podstránky.
+
+## Přehled aktivit a životní cyklus
+
+Podstránka **Přehled Aktivit** ukazuje tabulku aktivit s filtrem nahoře:
+
+- **Programová linie** — zobrazí jen aktivity vybrané linie (u každé je v závorce počet aktivit); volba „(všechno)" zruší filtr.
+- Sloupce **Název**, **Čas**, **Vypravěč** a **Typ** lze řadit trojúhelníčky ▲▼ v hlavičce. Najetím na název aktivity se ukážou její štítky.
+- Sloupec **Ins**: ikona řetězu znamená, že aktivita je členem rodiny *instancí* — na webu se zobrazuje jen jednou, s více termíny k přihlášení.
+- Sloupec **Kor**: zelená fajfka = u aktivity proběhla gramatická korekce a od té doby se text neměnil; červený křížek = korekce neproběhla. Kdo má právo provádět korekce, může stav kliknutím přepnout.
+
+### Stavy aktivity
+
+| Stav | Co znamená |
+|------|------------|
+| **nová** | Ve výrobě. Aktivita není vidět na webu. |
+| **publikovaná** | Je vidět na webu, ale nedá se na ni přihlašovat. |
+| **připravená** | Je vidět, nedá se přihlašovat, ale je nachystaná k (hromadné) aktivaci. |
+| **aktivovaná** | Otevřená — účastníci se na ni mohou přihlašovat. |
+| **zamčená** | Aktivita už začíná/proběhla a je zamčená pro změny (typicky kvůli prezenci). |
+| **uzavřená** | Proběhlá aktivita s vyplněnou prezencí; definitivně uzavřená pro změny. |
+| **systémová** | Interní technické položky systému; běžně je neřešíš. |
+
+Obvyklá cesta: **nová → publikovaná → připravená → aktivovaná**, po proběhnutí aktivity **zamčená → uzavřená**. Posouváš ji tlačítky v posledních sloupcích tabulky:
+
+- **pub** — publikovat (ukázat) aktivitu na webu; **odpu** — skrýt zpět před veřejností (s potvrzením).
+- **přip** — připravit k hromadné aktivaci; **odpři** — připravení zrušit.
+- **aktiv** — aktivovat, tj. otevřít k přihlašování (reálně se projeví, jen pokud běží registrace aktivit).
+- **deak** — zavřít přihlašování (vrátit z aktivované zpět). Vidí ho jen šéf programu. Pokud už jsou na aktivitě přihlášení, musíš deaktivaci navíc potvrdit zaškrtnutím „Chci deaktivovat aktivitu s N přihlášenými účastníky".
+- **inst** — vytvořit novou instanci aktivity (kopii na další termín; čas a místo pak doladíš v editaci).
+- **tužka** — otevře podrobnou editaci aktivity.
+- **koš** — **nevratné smazání** aktivity včetně odhlášení všech účastníků. Dobře si rozmysli, potvrzení je jen jedno.
+
+### Hromadná aktivace
+
+Tlačítko **aktivovat hromadně** nad tabulkou aktivuje **všechny „připravené" aktivity ve všech programových liniích najednou**. Je to ostrá akce vázaná na zvláštní právo (drží ho jen člen rady) a jde použít jen bez vybrané programové linie a jen pro letošní rok. Před spuštěním se zobrazí potvrzení — přečti si ho.
+
+Kromě ručního tlačítka se připravené aktivity aktivují i **automaticky v čase vlny** přihlašování. Běžný postup tedy je: aktivity dopředu překlop do stavu „připravená" a v okamžiku vlny se otevřou samy.
+
+## Založení a úprava aktivity
+
+Novou aktivitu založíš na podstránce **Nová aktivita**, existující upravíš tužkou z přehledu. Formulář má tato pole (pole označená ¹ jsou *specifická pro instanci* — u rodiny instancí je má každý termín vlastní):
+
+- **Název** (povinný) a **URL** — adresa na webu, ideálně malá písmena a pomlčky. URL musí být v ročníku jedinečná; stejnou URL smí sdílet jen instance téže aktivity (pro duplikaci použij „inst" v přehledu).
+- **Místnosti¹** — aktivita může být ve více místnostech; volitelně jednu označ jako **hlavní místnost¹**.
+- **Den¹** a **Čas¹** (od–do). Konec musí být po začátku.
+- **Vypravěč¹** — jeden nebo více. Pokud má vypravěč v tu dobu jinou aktivitu, uložení skončí chybou s názvem kolizní aktivity.
+- **Typ** (programová linie) a zaškrtávátko **teamová** — u týmové aktivity si první přihlášený sestavuje tým.
+- **Kapacita** — tři čísla: unisex / muži / ženy (0/0/0 = bez omezení). U týmové aktivity místo toho zadáváš **min** a **max** velikost týmu, **týmů¹** (maximální počet týmů) a volbu **smazat tým po expiraci** (když kapitán tým včas nedokompletuje, tým se smaže; jinak se zveřejní).
+- **Cena** a **bez slev** (cena je pevná, slevy se neaplikují). U brigádnické aktivity se místo ceny zadává **odměna za hodinu** — vyžaduje správně vyplněný čas od–do.
+- **Tagy** — štítky pro vyhledávání na webu (správa viz níže).
+- **Příprava místnosti** — co je potřeba nachystat (vybavení).
+- **Turnaj¹** a **Kolo** — zařazení aktivity do vícekolového turnaje; můžeš vybrat existující turnaj nebo rovnou založit nový. U aktivity v turnaji se zobrazí přehled všech kol s časy a možností publikovat dosud nezveřejněná kola. Pozor: kolo s více aktivitami na výběr dává smysl jen u týmových aktivit — formulář tě na to upozorní.
+- **Obrázek** — nahraješ soubor nebo zadáš URL; šířka minimálně 320 px, poměr 16:9.
+- **Krátký popis** (s počítadlem znaků) a **Popis** — popis se píše ve zjednodušeném formátování (odkaz *help* u pole ukáže syntaxi: kurzíva, tučně, odkazy, seznamy, nadpisy) a vpravo vidíš živý náhled.
+- **Proběhla korekce?** — vidí jen ten, kdo má právo provádět korekce; zaškrtne po jazykové korektuře textu.
+
+Při ukládání změn **dne, času, ceny nebo kapacity** aktivity, na které už jsou přihlášení hráči, se zobrazí potvrzení s počtem dotčených hráčů. Cena a kapacita se u rodiny instancí propisují na všechny instance, takže varování počítá i hráče na sesterských termínech; den a čas se týkají jen upravovaného termínu.
+
+## Seznam přihlášených
+
+Podstránka **Seznam přihlášených** je přehled účastníků po programových liniích — nahoře klikneš na linii a pod sebou uvidíš všechny její letošní aktivity. U každé aktivity je:
+
+- obsazenost (např. `12/20`) s rozpadem podle pohlaví „u + m + ž" a počtem **sledujících** — to jsou lidé, kteří na plné aktivitě čekají na uvolněné místo (systém jim pak pošle e-mail); v tabulce jsou šedě kurzívou s poznámkou „(sledující)",
+- čas, vypravěči a místnost,
+- odkazy **e-mail všem** (otevře e-mail se skrytými kopiemi všem přihlášeným) a **zobrazit maily**,
+- tabulka přihlášených: login, jméno, e-mail, **věk** v den aktivity (u dospělých jen „18+"), telefon a datum přihlášení.
+
+Samotné přihlašování a odhlašování účastníků z adminu děláš v programu na kartě uživatele (viz nápověda k uživatelům). Dvě zvláštnosti, které se hodí vědět:
+
+- Na **skryté (nepublikované) technické a brigádnické aktivity** může účastníky posadit jen organizátor s právem prezenčního admina, a jen v době, kdy běží registrace aktivit. Na jiné typy skrytých aktivit to nejde záměrně.
+- Účastníky brigádnických a technických aktivit jde měnit i hromadně importem (viz níže).
+
+## Štítky, místnosti, týmy a vypravěčské skupiny
+
+### Štítky
+
+Podstránka **Štítky** vypisuje všechny štítky (tagy) seskupené po kategoriích, s poznámkou. Tlačítkem **Přidat tag** založíš nový, tlačítkem **uprav** u řádku upravíš název, kategorii a poznámku. Štítky pak přiřazuješ aktivitám v editaci a účastníci podle nich filtrují program na webu.
+
+### Místnosti
+
+Podstránka **Místnosti** spravuje seznam místností: **Pořadí** (šipkami ▲▼ — určuje řazení v programu), **Název**, **Dveře** (číslo dveří) a **Poznámka** (slouží i jako kategorie pro seskupení místností v editoru aktivity). Tlačítko **vytvořit další místnost** přidá novou, **uprav** → **ulož** změní existující. Aktivitám místnosti přiřazuješ v editaci aktivity.
+
+### Týmy
+
+Podstránka **Týmy** ukazuje všechny letošní **týmové aktivity** a jejich týmy: kapacitu týmů, celkový počet přihlášených, u každého týmu název, kapitána, obsazenost, veřejnost a čas založení, plus členy s e-maily a odkaz **E-mail všem členům**. K dispozici jsou akce:
+
+- **Smazat tým** — rozpustí tým (s potvrzením),
+- **Zamknout tým / Odemknout tým** — zamčený tým už členové nemohou měnit; zamykat a odemykat smí jen šéf infopultu.
+
+Tlačítko **Kontrola stavu týmů** projde všechny týmy a vypíše problémy s nabídnutým řešením: týmy bez aktivity (smazat), připravené týmy bez kapitána (předat kapitána konkrétnímu členovi nebo automaticky), týmy s chybným počtem aktivit v kolech turnaje (přihlásit/odhlásit po kolech), hráče nepřihlášené na všechny aktivity turnaje a hráče na týmové aktivitě bez týmu či ve více týmech (odhlásit z aktivity). Když je vše v pořádku, vypíše „Vše v pořádku – žádné chyby nenalezeny."
+
+### Nová vypravěčská skupina
+
+Podstránka **Nová vypravěčská skupina** vytvoří „falešný" účet (např. Albi, Deskofobie…), který jde uvést jako vypravěče aktivity. **Pozor:** pokud jako vypravěče uvedeš jen tento účet místo konkrétních lidí, skutečným vypravěčům se nezapočtou slevy a nezablokuje se jim slot v programu.
+
+## Exporty a importy
+
+Tlačítka **Exportovat/Importovat aktivity** a **Exportovat/Importovat účastníky** najdeš nad přehledem aktivit.
+
+### Export a import aktivit (Google Sheets)
+
+Slouží hlavně k **hromadnému založení ročníku recyklací loňských aktivit** a k hromadným úpravám. Napoprvé musíš **povolit Gameconu přístup** ke svému Google Drive — Gamecon smí číst a zapisovat *pouze soubory, které sám vytvoří*.
+
+Postup: vyber programovou linii (a případně rok) → **Exportovat aktivity** vytvoří tabulku na tvém Google Drive → tabulku upravíš → na stránce importu ji vybereš v seznamu a dáš **Importovat aktivity**. Pravidla úprav v tabulce:
+
+- **Nová aktivita**: smaž ID (řádek bez ID se založí jako nová); jméno je povinné, pokud nejde o instanci.
+- **Nová instance**: musí mít stejné URL jako mateřská aktivita.
+- **Úprava stávající**: ponech původní ID — co na řádku přepíšeš, to se importem změní.
+- Vypravěče zadávej jako ID, jméno, nick nebo e-mail — ale nové vypravěče naklikej do adminu **před** importem, jinak je import vynechá. Přehled vypravěčů, štítků a místností je v exportu na dalších kartách. Štítky jde psát bez ohledu na velikost písmen a diakritiku, stavy stačí zkrátit na první tři písmena (PUB…).
+- Po importu čti barevný výsledek: **červená** = řádek se nenahrál, **oranžová** = varování, přečti si detail a rozhodni, jestli vadí.
+- **Jednou použitý import nejde recyklovat** — pro další kolo úprav si udělej nový export.
+
+### Export a import účastníků
+
+- **Export účastníků** stáhne soubor XLSX s účastníky aktivit vybrané programové linie — ve stejném formátu, jaký očekává import, takže ho můžeš rovnou upravit a nahrát zpět.
+- **Import účastníků** nahraje soubor XLSX se sloupci `id_aktivity` a `ucastnik` (účastník opět jako ID, jméno, nick nebo e-mail). Funguje **jen pro brigádnické a technické aktivity**, a jen dokud aktivita není v provozu (nová, publikovaná, připravená). **Pozor, import je stav, ne přírůstek:** účastníci uvedení v souboru se přihlásí a účastníci dané aktivity, kteří v souboru chybí, se **odhlásí**. Po dokončení se vypíše, kolik lidí bylo přihlášeno a odhlášeno, plus případná varování.
+
+## Ostatní podstránky
+
+- **Program po místnostech** — tisková sestava programu členěná po místnostech (otevírá se v novém okně); hodí se na vylepení na dveře a pro orgy na místě. Aktivita ve více místnostech se ukáže v každé z nich.
+- **Neubytovaní vypravěči** — přesměruje na report nepřihlášených a neubytovaných vypravěčů; rychlá kontrola, kdo z vypravěčů si ještě nevyřešil přihlášku nebo ubytování.
+- **Medailonky** — správa medailonků vypravěčů zobrazovaných na webu. Horní část medailonku je obecná („o sobě"), dolní je pro DrD. V přehledu vidíš fajfkou/křížkem, kdo má kterou část vyplněnou; nový medailonek založíš zadáním ID uživatele.
+
+## Typické postupy
+
+1. **Nový ročník z loňska:** exportuj loňské aktivity linie do Google Sheets → smaž ID u řádků, které chceš založit znovu → uprav termíny a vypravěče → importuj. Aktivity vzniknou jako „nové" (skryté).
+2. **Zveřejnění programu:** u hotových aktivit klikej **pub** — účastníci je vidí, ale nemohou se hlásit.
+3. **Příprava vlny:** aktivity, které se mají otevřít, překlop přes **přip** do „připravená". V čase vlny se aktivují samy, případně je člen rady spustí tlačítkem **aktivovat hromadně**.
+4. **Přidání dalšího termínu:** u aktivity klikni **inst** a v editaci nové instance nastav den, čas a místnost. Na webu se rodina ukáže jako jedna aktivita s výběrem termínu.
+
+## Na co si dát pozor
+
+- **Smazání aktivity (koš) je nevratné** a odhlásí všechny přihlášené účastníky.
+- **Hromadná aktivace** otevře najednou všechny připravené aktivity ve všech liniích — spouštěj ji, jen když je celý balík opravdu nachystaný.
+- **Deaktivace aktivity s přihlášenými** je zásah do už provedených přihlášek; proto ji smí jen šéf programu a vyžaduje zvláštní potvrzení.
+- **Import účastníků odhlašuje** každého, kdo v nahraném souboru chybí — nikdy nenahrávej neúplný seznam „jen s novými lidmi".
+- Změna **dne, času, ceny nebo kapacity** aktivity s přihlášenými se dotkne hráčů — potvrzující dialog ber vážně; cena a kapacita se navíc propíšou na všechny instance.
+- Tlačítko **aktiv** má viditelný efekt jen v době, kdy běží registrace aktivit.
+- **Vypravěčská skupina** (fake účet) nenahrazuje skutečné vypravěče — bez nich se nezapočtou slevy ani neblokují sloty.

--- a/docs/napoveda/finance.md
+++ b/docs/napoveda/finance.md
@@ -1,0 +1,213 @@
+# Finance
+
+Sekce **Finance** je zázemí pro správu peněz festivalu: přehled stavů účtů
+účastníků, správa e-shopu (trička, jídlo, ubytování…), slevy a slevové
+poukazy, párování plateb z banky a úklidové nástroje na konec ročníku
+(hromadné odhlášení neplatičů, promlčení starých zůstatků, slučování
+duplicitních účtů, anonymizace).
+
+Sekci vidí jen organizátoři s právem na administraci financí. Ve spodní části
+každé stránky sekce je patička **„Nastavený kurz € = … Kč"** s odkazem do
+nastavení, kde jde kurz změnit.
+
+Několik akcí v této sekci je **nevratných** — jsou níže výrazně označeny.
+
+## Finance (hlavní přehled)
+
+Do pole **„Vypsat uživatele, kteří mají stav účtu vyšší rovno jak"** zadej
+částku a klikni na **Vypsat**. Zobrazí se tabulka uživatelů přihlášených na
+letošní GameCon se sloupci **Login**, **Stav účtu**, **aktiv** (cena aktivit),
+**ubyt** (ubytování) a **předm** (předměty a strava). Chceš-li dlužníky, zadej
+záporné číslo. Pozn. z přehledu: *vypravěči mají právo „zaplatil včas" vždy*.
+Když filtru nikdo nevyhovuje, uvidíš **(žádní uživatelé)**.
+
+**Připsat slevu** — formulář s poli **Výše slevy** (Kč), **Uživateli s ID**
+(předvyplní se právě vybraný pracovní uživatel), **Poznámka** (povinná)
+a **Připsal/a** (tvoje jméno, needitovatelné). Sleva jde připsat jen uživateli
+přihlášenému na letošní GameCon — jinak dostaneš chybu.
+
+**Údržba kupónů „jedna aktivita zdarma"** — tlačítko **Přepočítat kupóny**
+přepočítá hodnotu kupónů všem aktuálním držitelům práva (podle nejdražší
+reálně placené aktivity). Běžně se kupóny přepočítávají samy při změně role
+nebo přihlášky — tohle použij jen **při chybě nebo po změně cen aktivit**.
+Akce se potvrzuje dialogem, protože přepíše hodnotu kupónu u všech držitelů.
+
+Dále je tu tabulka **Report** s exportem **BFGR** (xlsx) a **Importér
+ubytování** — nahráním XLSX souboru (vychází z *Reportu ubytování*)
+**přepíše kompletně letošní údaje o ubytování**. Přepis či mazání osobních
+údajů (OP a občanství) z importu projde jen se zaškrtnutým
+**„Povolit přepis / mazání osobních údajů"**.
+
+## Shop
+
+Tabulka letošních položek e-shopu seskupená podle typu (trička, jídlo,
+ubytování…). U každé položky vidíš **Název**, **Cenu za kus**, **Sumu**
+(celkem utrženo), **Model rok**, **Naposledy koupeno**, **Letos prodáno
+kusů** a **Zbývá kusů** (∞ = neomezeno). Hvězdička u názvu znamená
+*„Vybráno pro slevu či zdarma organizátorům"*.
+
+Upravit můžeš dva sloupce a pak klikni na **Uložit změny**:
+
+| Sloupec | Význam |
+|---------|--------|
+| **Kusů celkem** | Kolik kusů je vyrobeno/k dispozici; prázdné = neomezeno. |
+| **Stav** | **Veřejný** (běžně v prodeji), **Prodejný na místě**, **Orgové** (podpultový), **Vyřazený**. |
+
+**Importér e-shopu** — nahráním XLSX (vychází z *Reportu e-shopu*)
+**přepíše kompletně letošní nabízené předměty a ubytování**. Pozor na
+varování přímo ve formuláři: *⚠️ Položky, které nebudou v importním souboru,
+import skryje ⚠️*.
+
+Pod importérem je **Nastavení mřížkového prodeje** (mřížky obchodu, např.
+prodej jídla po dnech).
+
+## Slevové poukazy
+
+Přehled poukazů na jednu aktivitu zdarma s počty **Celkem / platných /
+použitých**. Tlačítko **Vygenerovat nový poukaz** vytvoří nový kód; přes odkaz
+**Zobrazit poukaz** ho zobrazíš a vytiskneš.
+
+Každý poukaz má stav **Platný**, **Použitý** nebo **Zneplatněný**. U poukazu
+můžeš:
+
+- **Zneplatnit** — jen dosud nepoužitý poukaz; potvrzuje se dialogem
+  *„Opravdu zneplatnit tento poukaz? Nepůjde pak uplatnit."* Použitý poukaz
+  zneplatnit nejde (hláška *„Poukaz nešlo zneplatnit – už byl uplatněný."*).
+- **Obnovit platnost** — vrátí omylem zneplatněný (a stále nepoužitý) poukaz
+  zpět mezi platné.
+- Uložit **Poznámku** (komu byl předán, k jaké akci patří apod.).
+
+## Nespárované platby
+
+Platby stažené z banky, které se nepodařilo automaticky přiřadit k uživateli
+(typicky chybný nebo chybějící variabilní symbol). U každé vidíš **Částku**,
+**Zprávu pro příjemce**, **Skrytou poznámku**, **Název protiúčtu** (po najetí
+myší i číslo účtu a banku), **VS** a časy připsání.
+
+Ve sloupci **Spárovat s uživatelem** začni psát jméno/ID — našeptávač uživatele
+dohledá a po potvrzení dialogu **„Opravdu spárovat?"** se platba připíše na
+jeho účastnický účet. Ověř si předem podle částky a jména na protiúčtu, že
+páruješ správného člověka — přiřazenou platbu už tady zpátky „odpáruješ" jen
+s pomocí IT.
+
+## Rušení storna
+
+Seznam letošních záznamů o stornu za aktivity (účastník se nedostavil apod.):
+**Uživatel**, **Aktivita**, **Začátek aktivity**, **Typ storna**. Tlačítkem
+**zrušit** storno smažeš — *zrušení storna vymaže i záznam, že účastník na
+aktivitu nedorazil*. **Pozor: tlačítko se na nic neptá, ruší okamžitě.**
+Když letos žádná storna nejsou, uvidíš *„Letos zatím žádná storna."*
+
+## Hromadné rušení objednávek
+
+Nástroj na zrušení objednávek (jídlo / ubytování / tričko) lidem se zůstatkem
+nižším než zadaná hranice — typicky neplatičům před festivalem. Ve výpisu se
+neobjeví lidé s právem „nerušit automaticky objednávky".
+
+1. Zadej **Minimální zůstatek** (výchozí −20 Kč) a **Typ objednávek**.
+2. Klikni na **Vypsat uživatele s nižším zůstatkem** a seznam zkontroluj.
+3. Teprve pak klikni na **Zrušit vypsaným uživatelům vybrané objednávky**.
+   Bez předchozího výpisu tě zastaví hláška *„Nejdříve si musíte uživatele
+   vypsat."*
+
+**⚠️ Nevratná akce bez dalšího potvrzení** — po kliknutí se objednávky
+vypsaným lidem rovnou zruší. Před krokem 3 si výpis opravdu projdi.
+
+## Promlčení zůstatků 🤫
+
+Odepsání starých zůstatků lidí, kteří už na GameCon nejezdí.
+
+1. Zadej rozmezí zůstatku (druhou hranici můžeš nechat prázdnou pro
+   „nekonečno"; jde zadat i záporná čísla pro zjištění nedoplatků) a rok
+   poslední účasti na GC.
+2. **Zobrazit uživatele** vypíše kandidáty s ID, jménem, stavem účtu, ročníky
+   přihlášení a poslední připsanou platbou. **Exportovat do XLSX** ti stejný
+   seznam dá do tabulky. Hodí se i odkaz na report *Finance: Zůstatky všech
+   účastníků*.
+3. Zaškrtávátky vyber, komu promlčet, a klikni na **Promlčet X účtům**.
+   Potvrzuje se dialogem *„Opravdu promlčet X účtů?"*
+
+**⚠️ Nevratná akce** — zůstatek vybraných účtů se vynuluje. Akce se zapisuje
+do interního logu (kdo, komu, kolik). Při velkém počtu účtů se může objevit
+upozornění *„Kvůli technickým omezením PHP lze najednou promlčet pouze X ze
+Y účtů"* — pak promlčení spusť vícekrát po dávkách.
+
+## Hromadné odhlášení účastníků
+
+Odhlášení neplatičů z GameConu naráz. **Nelze hromadně odhlásit účastníky,
+kteří jsou již přítomni na Gameconu** (prošli infopultem) — takové ID musíš
+ze seznamu vyřadit, jinak se neodhlásí nikdo.
+
+1. Do pole **ID účastníků** vlož IDčka oddělená čárkou, mezerou nebo
+   středníkem a klikni na **Připravit k hromadnému odhlášení**.
+2. Zkontroluj vypsaný seznam (ID, jméno, zůstatek). Už odhlášené lidi systém
+   sám vyřadí a oznámí to.
+3. Klikni na **Hromadně odhlásit** a potvrď dialog *„Trvale odhlásit uživatele
+   z GameConu a smazat všechny jejich aktivity a nakoupené věci?"*
+
+**⚠️ Nevratná akce** — odhlášeným se zruší přihláška na GC, všechny aktivity
+i nákupy; o odhlášení dostanou e-mail.
+
+## Slučování uživatelů
+
+Sloučení duplicitních účtů jednoho člověka. Vhodné vycházet z **reportu**
+s potenciálně duplicitními uživateli (odkaz přímo na stránce).
+
+1. Zadej obě ID a klikni na **Načíst údaje**.
+2. Vedle sebe uvidíš historii přihlášení na ročníky a u každého údaje (login,
+   heslo, mail, jméno a příjmení, adresa, telefon, poznámka, OP, pohlaví,
+   datum narození) vybereš přepínačem, ze kterého účtu se převezme. Vidíš
+   i zůstatky z předchozích ročníků a poslední platbu obou účtů.
+3. Klikni na **Sloučit uživatele** a potvrď dialog *„Opravdu sloučit … s …?"*
+
+**⚠️ Nevratná akce.** Výsledné ID by mělo být vždy to nižší (přihláška na GC
+se zachová, i když ji měl účet s vyšším ID). Případné dluhy / zůstatky se
+sečtou. Pokud je slučovaný uživatel vybrán pro práci, je potřeba ho zrušit
+a vybrat znova. Pokud se vyskytne chyba, hlásit. Dole na stránce je
+**Historie slučování uživatelů** — kdy, jaká ID, zůstatky a e-maily před
+a po sloučení.
+
+## Anonymizace 👻
+
+Vyhovění žádosti o výmaz osobních údajů (GDPR). Zadej **ID uživatele**
+a klikni na **Anonymizovat uživatele**.
+
+**⚠️ Varování přímo ze stránky:** *Tato akce nenávratně anonymizuje všechna
+osobní data uživatele (jméno, příjmení, adresa, telefon, email, atd.).*
+Potvrzuje se dialogem *„Opravdu chcete anonymizovat tohoto uživatele? Tato
+akce je nevratná!"* Před spuštěním si dvakrát ověř ID.
+
+## Typické postupy
+
+**Přišla platba bez VS (nebo s chybným VS).** Otevři **Nespárované platby**,
+podle částky, zprávy pro příjemce a názvu protiúčtu dohledej, čí platba to je,
+a ve sloupci **Spárovat s uživatelem** ji přiřaď. Když si nejsi jistý, radši
+se člověka doptej — přiřazení se tady zpět nevrací.
+
+**Účastník chce vrátit peníze / má přeplatek.** Zůstatek si ověř přes hlavní
+přehled **Finance** (vypiš uživatele se stavem účtu ≥ 1 Kč) nebo na kartě
+uživatele. Samotné vrácení peněz proběhne převodem z banky mimo tuto sekci.
+Staré nevyzvednuté zůstatky lidí, kteří už nejezdí, řeš hromadně přes
+**Promlčení zůstatků**.
+
+**Před festivalem / konec ročníku.** Obvyklý úklid: (1) **Hromadné rušení
+objednávek** uvolní jídlo a ubytování rezervované neplatiči; (2) **Hromadné
+odhlášení účastníků** odhlásí ty, kdo nezaplatili vůbec; (3) po festivalu
+**Rušení storna** pro odpuštění storn v odůvodněných případech; (4) čas od
+času **Slučování uživatelů** podle reportu duplicit a **Promlčení zůstatků**
+za staré ročníky.
+
+## Na co si dát pozor
+
+- **Nevratné akce:** hromadné odhlášení, hromadné rušení objednávek,
+  promlčení zůstatků, sloučení účtů, anonymizace. Vždy si nejdřív seznam
+  vypiš/zkontroluj a teprve potom klikej.
+- **Rušení storna a hromadné rušení objednávek nemají potvrzovací dialog** —
+  kliknutí rovnou provede akci.
+- **Import e-shopu a import ubytování kompletně přepisují letošní data.**
+  Položky, které v importním souboru chybí, import skryje.
+- Sleva jde připsat jen uživateli **přihlášenému na letošní GameCon**.
+- Použitý slevový poukaz už nejde zneplatnit; omylem zneplatněný jde
+  **Obnovit platnost**.
+- Hromadně nejde odhlásit nikdo, kdo už **prošel infopultem** — jediné takové
+  ID v seznamu zablokuje celou dávku.

--- a/docs/napoveda/infopult.md
+++ b/docs/napoveda/infopult.md
@@ -1,0 +1,100 @@
+# Infopult
+
+Infopult je hlavní obrazovka pro práci s účastníky přímo na festivalu: přihlášení na GameCon na místě, odbavení příjezdu a výdej materiálů, připsání platby v hotovosti, úprava ubytování a jídla, prodej předmětů a rychlé založení účtu novému příchozímu.
+
+## Výběr účastníka (omnibox vlevo nahoře)
+
+Skoro všechno na Infopultu se točí kolem **pracovního uživatele** — účastníka, kterého si vybereš v poli vlevo nahoře. Napiš začátek přezdívky, jména, příjmení, e-mailu nebo ID (zkratka **alt+U**) a vyber ho z našeptávače. Dokud nikoho nevybereš, Infopult ukazuje jen výzvu „Vyberte uživatele (pole vlevo nahoře)".
+
+Po výběru vidíš vlevo nahoře jeho přezdívku, jméno, ID a stav. Práci s ním ukončíš tlačítkem **zrušit**; pod polem se pak nabízejí odkazy ↻ na naposledy otevřené účastníky. Odkaz s ikonou řetězu / kopírování ti dá URL, kterou můžeš poslat kolegovi — otevře mu stejného účastníka.
+
+Pokud jsi infopulťák (a ne šéf Infa), při klepnutí na **zrušit** tě systém může zastavit potvrzovací hláškou „Účastník … Přesto ukončit práci s uživatelem?", když má účastník nedoplatek, chybí mu potvrzení od rodičů, formulář cizince nebo nemá kompletní či zkontrolované osobní údaje. Nejdřív to s ním dořeš.
+
+## Horní tlačítka — stav účastníka na GameConu
+
+| Tlačítko | Kdy je aktivní | Co udělá |
+|----------|----------------|----------|
+| **Přihlásit** | účastník není přihlášen na GC a registrace běží | přihlásí ho na letošní GameCon |
+| **Přijel(a) a Dát materiály** | je přihlášen, ale ještě nedorazil | označí ho jako přítomného na GC |
+| **Odjel(a) z GC** | je přítomen a ještě neodjel | označí ho jako odjetého (potvrzuje se dotazem „Opravdu odjel(a)?") |
+| **Odhlásit z GC** | je přihlášen, ale nedorazil; **jen správce financí** | úplně ho odhlásí z GameConu |
+
+U tlačítka **Přijel(a) a Dát materiály** je kontrolní seznam — před odkliknutím zkontroluj, že proběhlo: předání trička, placky, stravenek, číslo pokoje, srovnání nedoplatku; vysvětlení last moment přihlašování; doplnění chybějících údajů (adresa, telefon…); vyplnění čísla OP. Infopulťákovi navíc vyskočí potvrzení „… Přesto dát materiály?", pokud má účastník nedoplatek nebo nekompletní údaje/dokumenty.
+
+U tlačítka **Odjel(a) z GC** zkontroluj: vyrovnaný nedoplatek a vrácený klíč od pokoje.
+
+**Pozor — nevratná akce:** **Odhlásit z GC** se ptá „Trvale odhlásit uživatele z GameConu a smazat všechny jeho aktivity a nakoupené věci?" — přesně to se stane. Používej jen po rozmyslu; tlačítko funguje pouze správci financí.
+
+Pokud účastník není přihlášen na GC, ukazuje se červená hláška „Uživatel(ka) není přihlášen(a) na GameCon." Před spuštěním registrací navíc „Registrace na GameCon není spuštěna." — pak nejde na místě přihlašovat nikoho.
+
+## Přehled
+
+- **Stav účtu** — zůstatek účastníka; záporný (dluh) svítí červeně. Tlačítko **🗘 Fio** znovu stáhne platby z banky — hodí se, když účastník tvrdí, že „právě zaplatil mobilem". Když se stažení nezdaří, objeví se ⚠️ s hláškou „Stahování plateb z Fio se nezdařilo. Zkus to prosím za chvíli znovu."
+- **Poznámka** — interní poznámka k účastníkovi, ulož tlačítkem **uložit**.
+- **Potvrzení** — jen u účastníků, kterým na začátku letošního GameConu ještě nebylo 15 let. Vidíš „má potvrzení od rodičů" nebo „chybí potvrzení od rodičů!"; zaškrtnutím políčka a uložením potvrdíš, že papírové potvrzení máte. Pokud rodiče potvrzení nahráli elektronicky, je tu „odkaz na potvrzení".
+- **Cizinec** — u ubytovaných účastníků s jiným než českým občanstvím koleje vyžadují registrační formulář cizince. Opět „má formulář cizince" / „chybí formulář cizince!", zaškrtni a ulož, až ho vyplní.
+- **Údaje** — souhrn stavu osobních údajů: „chybí údaje", „zkontrolovat údaje", „údaje v pořádku" nebo „údaje kompletní".
+- **Kontakt** — telefon účastníka.
+- **Balíček** — co má účastník předplacené k výdeji (tričko, kostky, placka…, případně „jen stravenky"); najetím myší se rozbalí přesný seznam. U brigádníka připomene „papír na bonus ✍️" — nech podepsat převzetí bonusu.
+- Odkazy **Program** a **Program účastníka** vedou na jeho osobní program.
+
+## Osobní údaje
+
+Tabulka osobních údajů (jméno, adresa, datum narození, e-mail, telefon…). Platí „Pro úpravu klikni na údaj" — údaj se změní na políčko, přepiš a ulož. U ubytovaných je potřeba údaje zkontrolovat proti dokladu (viz stav „zkontrolovat údaje" v Přehledu).
+
+## Připsat platbu
+
+Formulář pro hotovost (nebo ruční opravu):
+
+1. Vyplň **Částku** v Kč a případně **Poznámku**.
+2. Klikni **Připsat**. Kdo platbu připsal, se ukládá automaticky (pole „Připsal(a)").
+
+- **Záporná částka** (vrácení peněz) jde zadat, ale **poznámka je pak povinná** — jinak tě zastaví hláška „Pro zápornou platbu je poznámka povinná".
+- Když připíšeš platbu účastníkovi nepřihlášenému na GC, projde to, ale dostaneš varování „Platba připsána uživateli, který není přihlášen na Gamecon".
+- Tlačítko **QR platby** otevře okno s QR kódy pro platbu mobilem — přepínač **CZ** (domácí převod v CZK), **SK** (Pay by Square) a **SEPA** (EUR převod). Účastník si kód naskenuje a zaplatí ze svého bankovnictví; platba se pak spáruje automaticky, nic nepřipisuj ručně.
+- Pole „ID Fio pohybu" a „Datum platby" se ukazují jen na testovacím prostředí, na ostré je neuvidíš.
+
+## Ubytování a Nastavení pokojů
+
+Sekce **Ubytování** ukazuje pokoj, spolubydlící (se jmény a telefony), objednané ubytování a případně „Nechce ubytování". V tabulce nocí můžeš ubytování upravit a uložit tlačítkem **Uložit**. Pozor: „Zrušit jiné ubytování než neděli může pouze šéf Infa."
+
+Sekce **Nastavení pokojů**:
+
+- **Vypsat** — zadej číslo pokoje a uvidíš, kdo v něm bydlí a jestli už dorazil (zeleně „dorazil", červeně „nedorazil").
+- **Přidělit** — přidělí vybranému účastníkovi zadaný pokoj. Pozor, „přepíše stávající stav".
+
+## Jídlo uživatele
+
+Zaškrtávací přehled objednaných jídel po dnech, uloží se tlačítkem **Uložit**. Platí pravidla ze samotné obrazovky: „Zrušit jídlo je možné jenom oproti vrácené stravence. Při objednání jídla je naopak potřeba předat stravenku (a zkontrolovat stav financí). Snídaně nabízíme jen organizátorům a vypravěčům." Odkaz **Tisk stravenek** otevře stravenky účastníka k vytištění.
+
+## Objednávky
+
+Seznam nakoupených předmětů a jídel účastníka. Kdo má právo rušit nákupy, vidí u položek (včetně vstupného a dobrovolného vstupného) ikonu koše — **zrušení objednávky** se potvrzuje dotazem „Opravdu zrušit objednávku …". Rozmysli si to: zrušená položka zmizí z účtu účastníka a změní jeho zůstatek.
+
+## Prodej
+
+Velké tlačítko **Prodej** otevře obchod, kde vybranému účastníkovi prodáš předměty na místě (trička, kostky…). Prodané kusy se připíšou na jeho účet. Detaily k nákupům a financím účastníka najdeš v kapitole Karta uživatele.
+
+## Čip
+
+Podstránka **Čip** (odkaz „Čip 🏷️" v Přehledu u Balíčku) je rozpracovaná stránka pro párování NFC čipů s účastníkem. Zatím nabízí testovací čtení a zápis čipu („Test NFC Read" / „Test NFC Write") a ukazuje, jestli to tvé zařízení zvládne: čtení i zápis vyžadují zabezpečené (https) spojení a prohlížeč s podporou NFC — použij **Chrome na Android telefonu s NFC**. Jinak stránka napíše „Tvůj prohlížeč bohužel neumí číst z NFC čipu". Bez vybraného pracovního uživatele stránka jen vyzve „Vyber pracovního uživatele". Odkaz na Čip se zatím ukazuje jen na vývojovém prostředí, na ostrém webu ho neuvidíš.
+
+## Rychloregistrace
+
+Když **nemáš** vybraného žádného účastníka, dole na stránce je box **Rychloregistrace** s tlačítkem **Jen registrovat**. To okamžitě založí nový prázdný účet a ukáže hlášku „Vytořen uživatel s ID …" — ID si poznamenej, podle něj účet hned vybereš omniboxem a doplníš osobní údaje. Pokud běží registrace, nový účet se rovnou přihlásí na GameCon, a pokud už GameCon probíhá, označí se i jako přítomný. Vedle je i samostatný box **Vypsat pokoj** — funguje stejně jako v Nastavení pokojů.
+
+## Typické postupy
+
+**Účastník přišel zaplatit hotově:** vyber ho omniboxem → zkontroluj Stav účtu → v „Připsat platbu" zadej částku → **Připsat**. Platí mobilem? Ukaž mu **QR platby** a po zaplacení klikni **🗘 Fio**.
+
+**Účastník se chce registrovat na místě:** nemá účet → **Jen registrovat**, vyber nový účet podle ohlášeného ID, doplň osobní údaje. Má účet → vyber ho a klikni **Přihlásit**. Pak s ním vyřiď platbu, ubytování a jídlo a nakonec **Přijel(a) a Dát materiály**.
+
+**Účastník si jde pro tričko/materiály:** vyber ho → v Přehledu u **Balíčku** najedeš myší na seznam, co mu patří → předej věci, stravenky a číslo pokoje, srovnej nedoplatek → **Přijel(a) a Dát materiály**. Tričko koupené až na místě prodáš přes **Prodej**.
+
+## Na co si dát pozor
+
+- **Odhlásit z GC** trvale smaže všechny aktivity a nákupy účastníka — nevratné, jen pro správce financí.
+- **Rušení objednávek** (koš v Objednávkách) měň zůstatek účastníka — potvrzuj s rozmyslem.
+- **Přidělit pokoj** přepíše stávající přidělení bez ptaní.
+- **Zrušit jídlo** jen proti vrácené stravence; nové jídlo = vydat stravenku.
+- Před **Dát materiály** a před ukončením práce s účastníkem vyřeš nedoplatek, potvrzení od rodičů (mladší 15 let), formulář cizince a chybějící osobní údaje — systém tě na ně upozorní, ale nezastaví šéfa Infa.

--- a/docs/napoveda/moje-aktivity.md
+++ b/docs/napoveda/moje-aktivity.md
@@ -1,0 +1,91 @@
+# Moje aktivity
+
+**Moje aktivity** jsou tvoje vypravěčská stránka v adminu: přehled aktivit,
+které letos vedeš, a hlavně **online prezence** — odškrtávání, kdo na aktivitu
+opravdu dorazil, přidávání náhradníků a uzavření aktivity po jejím konci.
+Stránka je dělaná i na mobil, ať ji můžeš vyplnit přímo na místě.
+
+Kartičku **Moje aktivity** vidí každý, kdo má právo na tento panel — typicky
+každý s letošní rolí **Vypravěč** (a také organizátoři či partneři). Na stránce
+se ale ukážou jen aktivity, u kterých jsi uveden jako vypravěč v aktuálním
+ročníku. Pokud žádnou nevedeš, uvidíš jen hlášku **„Nevedeš žádné aktivity 😞"**.
+
+## Co u své aktivity vidíš
+
+Každá aktivita má vlastní blok s nadpisem ve tvaru *název – vypravěči — místnost*.
+Po najetí na nadpis se ukáže **Začátek** a **Konec**, vedle je počet přihlášených
+(bez sledujících) a odkaz **Program**, který otevře aktivitu ve veřejném programu.
+Tlačítkem s knížkou 📖 nahoře rozbalíš stručný návod, jak prezenci vyplnit.
+
+Pod nadpisem je tabulka přihlášených. U každého účastníka vidíš:
+
+| Sloupec / ikonka | Význam |
+|---|---|
+| ✔ (první sloupec) | Jestli účastník vůbec **prošel infopultem** — „**Prošel** infopultem 😊" / „**Neprošel** infopultem 😡" |
+| ⏰ | „Přihlásil se méně než 10 minut před začátkem aktivity a měl by si pospíšit." — nejspíš je na cestě |
+| ikona náhradníka | **Náhradník** |
+| 💤 | **Zrušený náhradník** |
+| 👀 | **Sledující** — aktivita byla plná a on čeká na uvolněné místo. „Pokud sháníš náhradníka, tenhle bude mít zájem." |
+| ikona miminka | Účastník **mladší 18 let** (v bublině uvidíš věk) |
+| zaškrtávátko | **„Dorazil účastník na aktivitu?"** — tohle vyplňuješ ty |
+| jméno, obálka, telefon | Kontakt na účastníka; obálka nad tabulkou otevře e-mail **všem přihlášeným najednou** („Emaily přihlášených (ne sledujících)") |
+
+Sloupce s šipkou jdou kliknutím **seřadit** (např. podle času přihlášení nebo jména).
+Stránka se sama průběžně obnovuje — když se někdo přihlásí nebo odhlásí, uvidíš to
+bez nutnosti stránku načítat znovu.
+
+## Co můžeš upravit — a co ne
+
+Na téhle stránce spravuješ **jen prezenci**, tedy kdo dorazil:
+
+- **Zaškrtnout / odškrtnout účast** u přihlášených.
+- **Přidat účastníka** polem **„Přidej účastníka…"** — začni psát jméno, nick
+  nebo e-mail (aspoň 3 znaky) a vyber ze seznamu. Takhle přidáš i náhradníky.
+- **Uzavřít aktivitu** tlačítkem **„Uzavřít 📕"**, až je prezence hotová.
+
+**Nemůžeš tu měnit anotaci, kapacitu, časy, místnost ani cenu aktivity.** To vše
+spravuje správce programu. Přímo v návodu na stránce stojí: *„Změny (místa atp.),
+problémy a dotazy prosím vyřeš s MODem (703 997 328) a/nebo šéfem své sekce.
+(Ne s infopultem!)"*
+
+Prezence jde vyplňovat až **krátce před začátkem aktivity** — dřív u ní běží
+odpočet **„⏳ Můžeš ji editovat za … ⏳"**. Krátce po začátku se aktivita sama
+označí **„🔒 Zamčena pro online přihlašování 🔒"** — účastníci už se nemůžou sami
+hlásit, ale ty prezenci pořád upravuješ normálně.
+
+## Typický postup na místě
+
+1. 15 minut předem buď u maskota své sekce (bez mobilu si půjč tablet od Spojky).
+2. Najdi / svolej si přihlášené hráče, nepřítomným zkus zavolat. Účastníkům
+   s ⏰ dej chvíli na doběhnutí.
+3. Kdo dorazil, tomu **zaškrtni účast**. Pokud neprošel infopultem (😡), pošli
+   ho tam, než aktivitu začneš.
+4. Volná místa nabídni náhradníkům — sledující 👀 můžeš oslovit první.
+   Náhradníky **přidej na prezenčku** polem „Přidej účastníka…".
+5. Po skončení **prezenčku uzavři** tlačítkem **„Uzavřít 📕"**.
+6. Po hře dej místnost do původního stavu, vybavení nech bedňákům na místě.
+
+Když aktivitu do hodiny po konci neuzavřeš, přijde ti upozornění e-mailem.
+
+## Na co si dát pozor
+
+- **Uzavření aktivity je nevratné.** Potvrzovací okno **„Opravdu uzavřít
+  aktivitu?"** říká přesně: *„Po uzavření aktivity už nebudeš mít možnost
+  prezenci měnit. Až do 1 hodiny po skončení aktivity můžeš ještě někoho
+  přidat."* Odškrtnout někoho po uzavření už nejde — omylem uzavřenou aktivitu
+  řeš se správcem programu.
+- **Uzavření bez účastníků** musíš zvlášť potvrdit zaškrtnutím *„Uvědomuji si,
+  že aktivitu uzavírám bez účastníků (tj. není zaškrtlá ničí účast)."* Pokud sis
+  jen nevšiml prázdné prezence, zvol **„Opravit prezenci"**.
+- U skončené aktivity uvidíš **„✋ Aktivita už skončila, pozor na úpravy ✋"**
+  a po vypršení lhůty **„🧊 Už ji nelze editovat ani zpětně 🧊"**.
+- Přidání účastníka do už uzavřené aktivity ukáže **„⚠️ Pozor, aktivita je už
+  uzavřená! ⚠️"** s vysvětlením *„Přídání účastníka zvýší jeho dluh. Zkontroluj
+  jeho finance."* — účast na placené aktivitě se účastníkovi počítá do útraty.
+- Odkaz na konkrétní aktivitu může skončit chybovou stránkou: **„Neznámá
+  aktivita"**, **„Stará aktivita"** (není letošní), **„Proběhlá aktivita"**
+  (už skončila) nebo **„Cizí aktivita"** (*„…není Tvá."*). Tlačítko
+  **„↶ Zpět na Moje aktivity"** tě vrátí na přehled.
+- Telefonní čísla účastníků se ti (pokud nejsi organizátor) zobrazují jen po
+  dobu konání GameConu — před akcí a po ní jsou kvůli ochraně osobních údajů
+  skrytá.

--- a/docs/napoveda/nastaveni.md
+++ b/docs/napoveda/nastaveni.md
@@ -1,0 +1,70 @@
+# Nastavení
+
+Stránka **Nastavení** je řídicí pult celého ročníku. Měníš tu termíny (vlny přihlašování, konce prodejů, hromadná odhlašování neplatičů), částky a sazby (kurz eura, bonusy vypravěčů) i chování systému (notifikace, zamykání aktivit). Vidí ji jen organizátoři s právem na panel Nastavení.
+
+**Pozor: všechno, co tady změníš, platí okamžitě pro celý web** — pro přihlášku účastníků, výpočty cen, automaty na pozadí i admin. Není tu žádné tlačítko „Uložit" ani „Zpět". Než něco změníš, měj jasno, co děláš; ideálně si změnu nejdřív vyzkoušej na betě.
+
+## Jak se hodnoty mění a kdy se projeví
+
+- Hodnota se **ukládá automaticky hned při změně** políčka. U políčka se objeví ✔️ („Změny jsou uloženy") nebo ❗ s popisem chyby, pokud systém hodnotu odmítl (třeba špatný formát data).
+- U každé položky vidíš ve sloupci **Poslední změna**, kdy byla naposledy změněna a kdo to udělal (po najetí myší). Starší historie se na stránce nezobrazuje — o to opatrněji s přepisováním.
+- Sloupec **Vlastní**: řada položek má **výchozí hodnotu**, kterou si systém spočítá sám (typicky termíny odvozené od začátku a konce GC). Odškrtnutím políčka Vlastní svou ruční hodnotu vyřadíš a necháš to na systému; zaškrtnutím ji zase převezmeš. Položky bez výchozí hodnoty přepnout nejdou.
+- Po najetí na název položky se zobrazí podrobný popis včetně aktuální výchozí hodnoty. Odkaz **#** u názvu zkopíruje do adresy odkaz přímo na tu položku — hodí se, když chceš kolegovi poslat „tohle nastav".
+- Některé položky jsou **jen pro čtení** (šedé) — třeba **Ročník** nebo **Průměrné loňské vstupné**. Ty tady změnit nejde.
+
+## Časy
+
+Nejdůležitější skupina — termíny, které řídí celý ročník.
+
+| Nastavení | Co dělá |
+|-----------|---------|
+| Začátek / Konec Gameconu | Kdy akce běží. Od těchto dat se odvozuje většina výchozích termínů níže. |
+| Začátek / Ukončení registrací účastníků | Od kdy a do kdy se lze registrovat na GC přes web. Konec registrací musí být nejpozději na konci GC — dřívější datum systém odmítne. |
+| Začátek první / druhé / třetí vlny aktivit | Kdy se hromadně aktivují aktivity „Připravené k aktivaci" — tedy kdy se otevře přihlašování na další dávku aktivit. **Klíčové termíny ročníku**; posun vlny na špatné datum znamená, že se aktivity neotevřou, kdy mají. |
+| První / Druhé / Třetí hromadné odhlašování | Kdy budou hromadně odhlášeni neplatiči. |
+| Ukončení prodeje ubytování / jídla / triček / mikin / předmětů | Do kdy (včetně daného dne) lze v přihlášce danou věc objednat a měnit, než se zamkne. |
+| Do kolika dní po GC lze přidat účastníka | Jak dlouho po akci mohou vypravěči doplňovat účastníky na neuzavřené aktivity. |
+| Ročník | Který ročník GC je aktivní — jen pro čtení, tady ho nezměníš. |
+
+## Finance
+
+| Nastavení | Co dělá |
+|-----------|---------|
+| Kurz Eura | Kolik Kč je letos jedno €. |
+| Bonus za vedení 3–5h aktivity | Základní odměna vypravěče. Bonusy za kratší i delší aktivity se z ní dopočítávají automaticky — spočítané částky vidíš v popisu položky. |
+| Text pro rozpoznání odchozí GC platby | Přesné znění poznámky, podle kterého se páruje odchozí platba (vracení zůstatku) s účastníkem. Neměň, pokud přesně nevíš, co posíláte z banky. |
+| Jakou slevu mají mít orgové na jídlo | Sleva pro všechny s rolí „Jídlo se slevou". |
+| Podezřele vysoká platba účastníka | Částka, od které se na právě spárovanou platbu odešle upozornění CFO. |
+| Průměrné loňské vstupné | Jen pro čtení; používá se pro kostku na posuvníku dobrovolného vstupného. |
+
+## Aktivita
+
+Minutové limity kolem začátku a konce aktivit: od kdy před začátkem může vypravěč editovat přihlášené, jak dlouho po konci lze potvrzovat účastníky, kolik minut před začátkem se pozdní přihlášení bere jako „na poslední chvíli" (Moje aktivity pak ukážou varování, ať na účastníka počkají), po kolika minutách běhu se aktivita sama zamkne a kdy přijde vypravěči mail, že aktivitu nezavřel. Patří sem i **Kolik minut je odhlášení aktivity bez pokuty** — omylem přihlášený účastník se může do pár minut odhlásit bez storna i těsně před začátkem.
+
+## Neplatič
+
+Kdo je při hromadném odhlašování považován za neplatiče: jak velký dluh je ještě „příliš velký", jakou částku musí účastník poslat, aby byl v bezpečí, a kolik dní od registrace je nový účastník chráněn. Samotné termíny odhlašování jsou ve skupině Časy.
+
+## Notifikace
+
+**Poslat nám e-mail o uvolněném ubytování** — přepínač, zda má na info@gamecon.cz přijít zpráva, když se odhlásí účastník s objednaným ubytováním.
+
+## Zkopírování databáze z ostré (jen beta / preview / lokál)
+
+Na betě, preview a lokálním prostředí je pod tabulkou nastavení sekce pro přepsání zdejších dat čerstvými daty. Slouží k tomu, aby testovací prostředí vypadalo jako ostrý web — na ostré se tato sekce vůbec nezobrazuje.
+
+- **Zkopírovat databázi z ostré** — přepíše zdejší data aktuálním stavem ostré.
+- **Zkopírovat archivní databázi** — přepíše je daty vybraného staršího ročníku (jen na betě).
+- **Zkopírovat ze zálohy ostré** — přepíše je vybraným záložním souborem; u každého vidíš datum a stáří zálohy. **Na preview je k dispozici jen tato varianta.**
+
+Každé tlačítko se ještě jednou zeptá, jestli opravdu chceš data přemazat. Kopírování běží na pozadí (může trvat řadu minut), na stránce sleduješ průběh a odhad zbývajícího času, o výsledku přijde e-mail. Naráz může běžet jen jedna kopie.
+
+**Kopírování je nevratné** — všechno, co bylo v cílovém prostředí naklikáno (testovací účastníci, rozpracovaná nastavení), zmizí a nahradí se zdrojovými daty. Ostré databáze se nic z toho nedotkne, čte se z ní jen zdroj.
+
+## Na co si dát pozor
+
+- **Změny platí okamžitě a bez potvrzení.** Překlep v datu vlny nebo v částce se hned promítne účastníkům. Po každé změně zkontroluj uloženou hodnotu a ✔️.
+- **Vrácení změny je jen ruční.** Vidíš pouze poslední změnu a jejího autora; starou hodnotu musíš znát a nastavit zpět sám.
+- **Termíny vln a hromadných odhlašování** jsou nejcitlivější — řídí automaty, které se spouštějí samy. Neposouvej je na poslední chvíli bez domluvy s ostatními orgy.
+- **Odškrtnutí „Vlastní"** znamená, že hodnota začne žít vlastním životem podle výpočtu systému (a změní se třeba při posunu termínu GC). Zaškrtnutá vlastní hodnota naopak zůstává, i když se ostatní termíny posunou — nezapomeň ji pak posunout taky.
+- **Kopírování databáze nevratně maže data cílového prostředí.** Nikdy ho nepouštěj, pokud si na betě/preview někdo něco rozpracoval a neví o tom.

--- a/docs/napoveda/penize.md
+++ b/docs/napoveda/penize.md
@@ -1,0 +1,115 @@
+# Peníze
+
+Kartička **Peníze** slouží k drobným finančním operacím nad účty účastníků:
+vyplácení bonusů vypravěčům, ruční připsání slevy a stažení reportů ubytování.
+Pod stejnou kartičkou najdeš i podstránky **Info věci před GC** (nástroje pro
+infopult před začátkem festivalu) a **Rušení storna**.
+
+## Převést bonus za vedení aktivity na peníze
+
+Vypravěči za vedení aktivit vzniká bonus (v přehledu financí ho vidí jako
+*Slevy za organizované aktivity*). Když si ho vypravěč nechce nechat na útratu,
+tady mu ho převedeš na peníze:
+
+1. V poli **Uživatel** vyber vypravěče. Nabídka se chvíli načítá a obsahuje jen
+   **vypravěče s letošní účastí na GC**, kteří mají nějaký nevyužitý bonus —
+   u každého rovnou vidíš částku, např. „Jan Novák - bonus k vyplacení 500 Kč".
+2. **Poznámka** je předvyplněná textem „Převedení bonusu", můžeš ji upravit.
+3. Pole **Převedl/a** je jen pro kontrolu — automaticky obsahuje tvoje jméno.
+4. Klikni na **Převést**.
+
+Po úspěchu se zobrazí hláška **„Bonus … Kč vyplacen uživateli …"**. Převádí se
+vždy **celý** zbývající bonus najednou, částku nelze zvolit.
+
+Pozor na nápovědu u tlačítka: *„Jde pouze o převod bonusu (Slevy za
+organizované aktivity) na pohyb na účtu (připsání). Samotné fyzické vyplacení
+je potřeba provést ručně."* — tzn. hotovost nebo převod na bankovní účet musíš
+zařídit mimo systém.
+
+Možné chybové hlášky: „Uživatel … není přihlášen na GameCon." a „Uživatel …
+nemá žádný bonus k převodu."
+
+## Připsat slevu
+
+Ruční připsání slevy konkrétnímu účastníkovi (stejný formulář je i na kartičce
+**Finance**):
+
+1. Do pole **Výše slevy** napiš částku v Kč (jen číslice, případně desetinná
+   čárka).
+2. Do pole **Uživateli s ID** napiš ID účastníka. Pokud máš na kartičce
+   **Uživatel** někoho načteného, jeho ID je tu předvyplněné — přesto ho
+   zkontroluj.
+3. **Poznámka** je povinná — napiš, proč slevu připisuješ (bude vidět
+   v přehledu financí).
+4. Pole **Připsal/a** obsahuje automaticky tvoje jméno.
+5. Klikni na **Připsat**.
+
+Po úspěchu se zobrazí **„Sleva … Kč připsána k uživateli …"**. Chybové hlášky:
+„Zadej slevu.", „Uživatel … neexistuje.", „Uživatel … není přihlášen na
+GameCon."
+
+## Reporty
+
+Dole na stránce je box **Reporty** se dvěma odkazy, které stáhnou soubor XLSX:
+
+| Odkaz | Obsah |
+|-------|-------|
+| **Report ubytování** | přehled ubytování pro finance |
+| **Report ubytovaných cizinců** | ubytovaní cizinci (např. pro hlášení ubytovatele) |
+
+## Podstránka Info věci před GC
+
+Nástroje pro infopult před začátkem GameConu:
+
+- **Nastavení mřížkového prodeje** — interaktivní nastavení „mřížek" obchodu
+  (prodeje na místě) pro letošní ročník. Po otevření se chvíli načítá
+  („Nastavení mřížek obchodu se načítá ...").
+- **Importér balíčků** — nahrání informace, kdo má dostat **velký balíček**.
+  Jako zdroj slouží report *Infopult: Balíčky účastníků* ve formátu XLSX (odkaz
+  je přímo na stránce). Do sloupce `balicek` napiš **velký balíček** u těch,
+  kdo ho mají dostat; u ostatních nech cokoli jiného. Soubor vyber a klikni na
+  **Nahrát**. Podle textu na stránce import nerozbije, co už systém ví o
+  balíčcích a stravenkách.
+
+## Podstránka Rušení storna
+
+Když se účastník nedostavil na aktivitu (nebo se pozdě odhlásil), naskočí mu
+storno poplatek. Stránka **Rušení storna za aktivity** ukazuje tabulku všech
+letošních storen (Id, Uživatel, Aktivita, Začátek aktivity, Typ storna).
+Tlačítkem **zrušit** u řádku storno odpustíš — potvrdí se hláškou „Zrušeno
+storno pro … za … (…)". Pozor: *„Zrušení storna vymaže i záznam, že účastník
+na aktivitu nedorazil."* Pokud žádná storna nejsou, uvidíš „Letos zatím žádná
+storna."
+
+## Kupóny „jedna aktivita zdarma"
+
+Údržbové tlačítko **Přepočítat kupóny** najdeš na kartičce **Finance** (sekce
+*Údržba kupónů „jedna aktivita zdarma"*). Přepočítá hodnotu kupónů všem
+aktuálním držitelům práva podle nejdražší reálně placené aktivity. Běžně se
+kupóny přepočítávají samy — tlačítko použij jen **při chybě nebo po změně cen
+aktivit**. Před spuštěním se zobrazí potvrzení: *„Opravdu přepočítat všechny
+kupóny „jedna aktivita zdarma"? Přepíše to jejich hodnotu u všech držitelů."*
+Výsledek: „Přepočítáno kupónů „jedna aktivita zdarma": …".
+
+## Typický postup: vypravěč si přišel pro bonus
+
+1. Otevři kartičku **Peníze** a počkej, až se načte seznam v poli **Uživatel**.
+2. Najdi vypravěče a zkontroluj s ním částku „bonus k vyplacení" u jeho jména.
+3. Doplň případně poznámku a klikni na **Převést**.
+4. Vyplať mu peníze **ručně** (hotovost / převod) — systém udělal jen zápis na
+   jeho účet v GameConu.
+
+## Na co si dát pozor
+
+- **Převod bonusu je nevratný a bez potvrzovacího dotazu** — po kliknutí na
+  **Převést** se okamžitě převede celý zbývající bonus. Částku i vypravěče si
+  zkontroluj předem.
+- **Připsání slevy** se také provede hned bez dalšího potvrzení; překlep v ID
+  připíše slevu jinému účastníkovi. Sleva jde vidět (i s tvou poznámkou a
+  jménem) v přehledu financí účastníka.
+- **Zrušení storna** maže i záznam o tom, že účastník nedorazil — nedá se
+  jednoduše vrátit.
+- **Brigádnická odměna** (odměna za brigádnické aktivity) se účastníkovi
+  zobrazuje automaticky jako řádek *Brigádnická odměna* v přehledu financí
+  (v adminu i na webu) a započítává se do jeho zůstatku — nic pro ni na
+  kartičce Peníze vyplácet nemusíš.

--- a/docs/napoveda/prava.md
+++ b/docs/napoveda/prava.md
@@ -1,0 +1,85 @@
+# Práva a role
+
+## Jak to funguje: uživatel → role → práva
+
+Přístupy a výhody se v GameConu nikdy nepřidělují člověku napřímo. Funguje to ve třech krocích:
+
+1. **Právo** je jedna konkrétní schopnost nebo výhoda — třeba „vidí kartičku Finance v adminu“ nebo „má zdarma páteční noc ubytování“.
+2. **Role** je pojmenovaný balíček práv — třeba Vypravěč, Organizátor (zdarma), Infopult.
+3. **Uživatel** dostane roli (v aplikaci se říká „posadit na roli“) a tím získá všechna její práva. Odebráním role („sesazením“) o ně zase přijde.
+
+Jeden uživatel může mít rolí víc a jeho práva se sčítají.
+
+> **Pozor: každá změna platí okamžitě.** Jakmile někoho posadíš na roli, má její práva hned při dalším načtení stránky — žádné potvrzování, žádné čekání. Role jako Organizátor nebo práva na kartičky Infopult, Finance či Reporty dávají **přístup k osobním údajům a financím účastníků**. Než roli přidělíš, ujisti se, že ji dotyčný opravdu má mít — a že sedíš u správného uživatele.
+
+## Obrazovka správy práv
+
+Obrazovku **Práva** najdeš v adminu (vidí ji jen ten, kdo má právo na administraci práv). Pracuje se na ní vždy nad **aktuálně otevřeným (pracovním) uživatelem** — tím, kterého sis předtím vyhledal(a) v adminu.
+
+Na hlavním výpisu vidíš:
+
+- **Role s právy** — rozdělené na **Trvalé role** a **Ročníkové role** (pro aktuální ročník). U každé role je zelená tečka, pokud na ní pracovní uživatel právě sedí.
+- Odkazy **posaď** / **sesaď** — přidají nebo odeberou roli pracovnímu uživateli. U „sesaď“ se po najetí myší zobrazí, kdo a kdy uživatele na roli posadil.
+- Odkaz **detail** — otevře stránku jedné role.
+- **Role bez práv** — role účasti (přihlášen / přítomen / odjel na letošní GC). Ty slouží jen k evidenci a nenesou žádná práva.
+
+Na **detailu role** pak vidíš:
+
+- seznam práv, která role dává, s popisem každého práva — a možnost **přidat roli právo** nebo **vzít roli právo**,
+- seznam všech uživatelů, kteří na roli sedí, s možností je **sesadit** nebo si je rovnou otevřít,
+- tlačítko pro posazení/sesazení aktuálního pracovního uživatele.
+
+Všechny změny (posazení, sesazení, přidání i odebrání práva) se **logují** — vždy je dohledatelné, kdo změnu udělal.
+
+### Kdo smí co měnit
+
+- **Posazovat a sesazovat** na běžné role smí každý, kdo má přístup na obrazovku Práva.
+- **Omezené role** (typicky role s velkým dopadem: Organizátor, CFO, Člen rady, Brigádník, Zázemí, Přepínání na uživatele…) smí přidělovat a odebírat **jen člen rady**. Ostatní tyto role na obrazovce ani nevidí.
+- **Měnit práva role** (přidat/vzít roli právo) smí jen ten, kdo má navíc speciální právo **změna práv** — a i tak jen u rolí, které smí přidělovat. Tohle je nejsilnější operace na obrazovce: změna práv role se okamžitě dotkne **všech** lidí, kteří na roli sedí.
+
+## Druhy práv
+
+Práva se dají rozdělit do tří skupin:
+
+| Skupina | Co dává |
+|---|---|
+| **Přístup do adminu** | Každé právo zpřístupní jednu kartičku (sekci) administrace: Infopult, Ubytování, Akce, Prezence, Reporty, Web, Práva, Statistiky, Finance, Moje aktivity, Nastavení, Peníze, Loga na webu, Dev. Kdo právo nemá, kartičku vůbec nevidí. |
+| **Výhody a slevy** | Hmotné benefity: jídlo se slevou nebo zdarma; jednotlivé noci ubytování zdarma (středa až neděle) nebo ubytování zdarma po celou dobu; trička zdarma (jakékoli, dvě jakákoli, tričko zdarma při dosažení bonusu) a možnost objednávat modrá či červená trička; placka a kostka zdarma; slevy na aktivity (částečná sleva, aktivity úplně zdarma, jedna nejdražší aktivita zdarma); plný servis (uživatele kompletně platí a zajišťuje GC). |
+| **Speciální schopnosti a chování** | Pořádání aktivit (dotyčný je v nabídce vypravěčů a má v adminu „Moje aktivity“); registrace více aktivit ve stejný čas; přihlašování a odhlašování lidí z aktivit, které už proběhly, nebo které ještě nejsou aktivované; **přepnutí na uživatele** (viz níže); nebezpečné tlačítko hromadné aktivace aktivit; rušení nákupů uživatelů; nerušit uživateli objednávky při pozdní platbě; možnost objednat jen jednu noc ubytování; provádění korektur textů aktivit; „bez bonusu za vedení aktivit“ (vypravěčská sleva se nepočítá); označování jako organizátor ve výpisech; zobrazování role ve statistikách a reportech; **unikátní role** a **změna práv** (viz jinde v této kapitole). |
+
+Dvě práva si zaslouží zvláštní pozornost:
+
+- **Přepnutí na uživatele** — držitel se v adminu může přihlásit jako **libovolný** uživatel a vidět i měnit vše, co on. Je to nejsilnější právo v systému. Visí na ročníkové roli **Přepínání na uživatele**, kterou každý rok znovu přiděluje rada — s novým ročníkem loňská přiřazení přestávají platit a nikdo přepínat nemůže, dokud rada roli znovu neudělí. (Infopulťák má nezávisle na tom vlastní omezené přepínání jen na vypravěče a partnery.)
+- **Unikátní role** — uživatel může sedět **jen na jedné** roli, která má toto právo. Používá se u rolí, které se navzájem vylučují (typy orgovství apod.). Pokus posadit člověka na druhou takovou roli skončí chybou „Uživatel už má jinou unikátní roli.“
+
+## Letošní vs. trvalé role
+
+- **Trvalé role** platí napříč ročníky — jednou posazený Organizátor jím zůstává, dokud ho někdo nesesadí.
+- **Ročníkové role** (Vypravěč, Zázemí, Infopult, Partner, Brigádník, noci zdarma, Přepínání na uživatele…) platí jen pro jeden ročník. Při překlopení na nový ročník se **automaticky vytvoří znovu**: loňská verze se přejmenuje s prefixem ročníku (např. „GC2025 Vypravěč“) a vznikne čerstvá letošní role **se stejnými právy, ale bez lidí**. Kdo má roli mít i letos, musí na ni být posazen znovu.
+- **Role účasti** (přihlášen / přítomen / odjel) vznikají pro každý ročník také a nenesou žádná práva — slouží k evidenci, kdo na GC byl.
+
+Praktický důsledek: na začátku každé sezóny je potřeba **znovu posadit vypravěče, zázemí, infopult a další ročníkové role**. Není to chyba, je to záměr — ročníkové výhody a přístupy se nemají „vozit“ z minulého roku automaticky.
+
+## Typické postupy
+
+**Nový organizátor:**
+
+1. Vyhledej uživatele v adminu, ať je otevřený jako pracovní uživatel.
+2. Otevři obrazovku Práva a u role **Organizátor (zdarma)** klikni **posaď**. Roli smí přidělit jen člen rady (je omezená).
+3. Zkontroluj zelenou tečku u role — od té chvíle má dotyčný všechna práva organizátora, včetně přístupů do adminu.
+
+**Nový vypravěč (pro letošní ročník):**
+
+1. Vyhledej uživatele a otevři obrazovku Práva.
+2. V sekci **Ročníkové role** posaď uživatele na roli **Vypravěč**.
+3. Tím se dotyčný objeví v nabídce vypravěčů u aktivit a získá výhody navázané na roli (podle toho, jaká práva role letos má). Příští rok bude potřeba ho posadit znovu.
+
+## Na co si dát pozor
+
+- **Změny platí okamžitě.** Neexistuje „uložit“ ani „vrátit zpět“ — jediná cesta zpátky je roli zase odebrat, ale mezitím měl dotyčný plný přístup.
+- **Špatně přidělená role = přístup k osobním údajům a penězům.** Kartičky Infopult, Finance, Reporty či Statistiky odhalují osobní a finanční data účastníků. Roli s takovými právy dávej jen lidem, kteří ji opravdu potřebují.
+- **Změna práv role zasáhne všechny na roli.** Než roli přidáš nebo vezmeš právo, podívej se na detail role, kdo všechno na ní sedí.
+- **Role Prezenční admin** je určená jen pro změny účastníků v uzavřených aktivitách a je označena jako nebezpečná — bez jasného důvodu ji nepoužívej.
+- **Hromadná aktivace aktivit** je nebezpečné tlačítko — právo na ni dávej jen lidem, kteří vědí, co dělají.
+- **Role a výhody ovlivňují peníze.** Posazení či sesazení může okamžitě změnit uživateli cenu aktivit, ubytování nebo jídla — přepočet proběhne hned.
+- Ročníkové role s ročníkem v názvu (např. „GC2025 Vypravěč“) jsou už jen historie — nová přiřazení dělej vždy na letošní verzi role.

--- a/docs/napoveda/prezence.md
+++ b/docs/napoveda/prezence.md
@@ -1,0 +1,82 @@
+# Prezence
+
+Prezence slouží k odbavení účastníků přímo na místě konání aktivity: zaškrtnout, kdo skutečně dorazil, doplnit náhradníky nebo úplně nové účastníky a nakonec prezenci uzavřít. Skládá se ze dvou obrazovek:
+
+- **Karta Prezence** v adminu — přehled aktivit v daném čase a stavu jejich prezence. Slouží hlavně ke kontrole, co ještě není vyplněné nebo uzavřené.
+- **Formulář Online prezence** — samotné vyklikávání prezence u jedné či více aktivit. Otevřeš ho z karty Prezence tlačítkem **Vyplnit prezenci**. Vypravěči se ke stejnému formuláři pro své aktivity dostanou i přes **Moje aktivity**.
+
+## Výběr času a aktivity
+
+Nahoře na kartě Prezence je vybírátko času („Zobrazují se aktivity začínající od …"). Chová se takto:
+
+- **Během GameConu** se čas předvolí automaticky podle aktuálního času (hláška „Čas vybrán automaticky podle aktuálního času") — zobrazí se aktivity, které právě začínají nebo před chvílí začaly.
+- **Mimo GameCon** se předvolí čas první letošní aktivity („Čas vybrán automaticky podle první letošní aktivity").
+- Čas můžeš kdykoli přepnout ručně v roletce — stránka se hned překreslí.
+
+Pod vybírátkem jsou filtry:
+
+| Filtr | Co zobrazí |
+|-------|------------|
+| **Ignorovat výběr času** | všechny letošní aktivity bez ohledu na čas |
+| **Všechny** | všechny aktivity ve vybraném čase |
+| **Jen zamčené, ale dosud neuzavřené** | aktivity, kde už vypravěč zamkl přihlašování, ale ještě neuzavřel prezenci |
+| **Jen uzavřené, ale nevyplněné** | uzavřené aktivity, kde nikdo nemá zaškrtnuto, že dorazil — kandidáti na zapomenutou prezenci |
+| **Jen bez přihlášených účastníků** | letošní aktivity, na které není nikdo přihlášen |
+
+K tomu můžeš filtrovat podle programové linie. Když filtrům nic neodpovídá, uvidíš „Žádné aktivity neodpovídají zadaným filtrům."
+
+## Co vidíš v přehledu
+
+Každá aktivita má nadpis ve tvaru *název – vypravěči – místnost – den a čas*, případně doplněný ikonou 🔒 („Zamčená pro přihlašování") a 📕 („S uzavřenou prezencí"). U každého přihlášeného účastníka vidíš:
+
+- zda **je přítomen na GameConu** (prošel infopultem) — zelená/červená ikona,
+- symbol **$** zeleně či červeně podle zůstatku; po najetí myší uvidíš přesný stav jeho financí,
+- ID, jméno a **telefon** — hodí se, když účastník nedorazil a chceš mu zavolat,
+- stav prezence: **Dorazil** (zaškrtnutý čtvereček), **Nedorazil** (křížek), nebo **Nepotvrzeno** (otazník) — dokud prezence neproběhla.
+
+U aktivit bez uzavřené prezence svítí červené upozornění **„Pozor, aktivita nemá uzavřenou prezenci!"** a tlačítko **Vyplnit prezenci**, které tě přenese do formuláře Online prezence rovnou na danou aktivitu.
+
+## Vyplnění prezence
+
+Formulář Online prezence má u každé aktivity tabulku účastníků. U jména se zobrazují pomocné ikony (legendu najdeš po najetí na hlavičku sloupce):
+
+- ⏰ — přihlásil se jen pár minut před začátkem a je nejspíš na cestě, dej mu chvíli na doběhnutí,
+- ikona náhradníka — dorazil jako náhradník,
+- 💤 — zrušený náhradník,
+- 👀 — **sledující**: na aktivitu se nevešel, ale má o ni zájem. Pokud sháníš náhradníka, oslov ho prvního,
+- ikona miminka — účastník je mladší 18 let,
+- zelená/červená ikona přítomnosti na GC — pokud účastník **neprošel infopultem**, pošli ho tam, než aktivitu začneš.
+
+Sloupce jdou řadit kliknutím na hlavičku; u aktivity je i hromadný odkaz na e-maily přihlášených a telefonní čísla jako klikatelné odkazy.
+
+**Kdo dorazil, tomu zaškrtni checkbox ve sloupci „Dorazil účastník na aktivitu?".** Změna se ukládá okamžitě — žádné tlačítko Uložit. Když checkbox zase odškrtneš:
+
+- řádný přihlášený se vrátí do stavu „jen přihlášen",
+- náhradník z aktivity úplně zmizí (u aktivit, kde je to možné, se vrátí mezi sledující).
+
+Formulář se průběžně obnovuje — změny, které mezitím udělá kolega na jiném zařízení, se ti samy propíšou.
+
+## Přidání náhradníka nebo nového účastníka
+
+Volná místa po nedorazivších nabídni náhradníkům. Do pole **„Přidej účastníka…"** napiš aspoň 3 znaky jména, přezdívky, e-mailu nebo ID; našeptávač ukazuje i zůstatek a zda dotyčný prošel infopultem. Vybraný člověk se přidá do tabulky rovnou jako **dorazivší náhradník** — nemusel být na aktivitu vůbec přihlášen. Po najetí na pole vidíš kapacitu aktivity.
+
+## Uzavření prezence
+
+Když je prezence vyklikaná, stiskni **Uzavřít 📕**. Objeví se potvrzení **„Opravdu uzavřít aktivitu?"** s textem: *„Po uzavření aktivity už nebudeš mít možnost prezenci měnit. Až do 1 hodiny po skončení aktivity můžeš ještě někoho přidat."* Pokud nemá zaškrtnutou účast vůbec nikdo, musíš navíc potvrdit **„Uvědomuji si, že aktivitu uzavírám bez účastníků (tj. není zaškrtlá ničí účast)."** Tlačítkem **Opravit prezenci** se vrátíš zpět, tlačítkem **Uzavřít aktivitu** prezenci definitivně uzavřeš.
+
+**Uzavření má finanční důsledky.** Každý přihlášený, který při uzavření nemá zaškrtnuto „dorazil", se označí jako **nedorazivší** — propadá mu storno poplatek z ceny aktivity a u většiny typů aktivit mu odejde e-mail „Nedostavení se na aktivitu". Naopak zaškrtnutí „dorazil" ruší případnou dřívější pokutu (za nedorazení či pozdní zrušení) na této aktivitě.
+
+## Časová omezení
+
+- Prezenci lze vyplňovat až krátce před začátkem aktivity — dřív uvidíš odpočet „⏳ Můžeš ji editovat za …".
+- Po skončení aktivity se objeví „✋ Aktivita už skončila, pozor na úpravy" a po vypršení lhůty „🧊 Už ji nelze editovat ani zpětně".
+- Vypravěč může do **uzavřené** aktivity přidávat další účastníky ještě zhruba hodinu po jejím konci; měnit už zapsanou prezenci ale nelze.
+- Někteří admini mají **právo na změnu historie aktivit** — mohou přihlašovat a odhlašovat lidi i z aktivit, které už proběhly, prakticky kdykoli až do dalšího ročníku. Právě jim se u zamčených aktivit s vyplněnou prezencí ukazuje varování **„Pozor, aktivita už je vyplněná!"** s vysvětlením: *přidání účastníka zvýší jeho dluh, zkontroluj jeho finance.* Stejné varování („⚠️ Pozor, aktivita je už uzavřená! ⚠️") svítí u pole pro přidání účastníka v Online prezenci.
+
+## Na co si dát pozor
+
+- **Neuzavírej prezenci předčasně** — po uzavření už zaškrtnutí nezměníš a nedorazivším naskočí storno.
+- **Přidání účastníka na uzavřenou (vyplněnou) aktivitu mu zvýší dluh** — vždy zkontroluj jeho finance (symbol $ u jména).
+- **Nedorazivší dostávají pokutu i e-mail automaticky** — než uzavřeš, zkus nepřítomným zavolat (telefon je přímo v tabulce).
+- Účastníka, který **neprošel infopultem**, pošli nejdřív na infopult — na aktivitě má co dělat až odbavený.
+- Změny (místa apod.), problémy a dotazy řeš podle návodu ve formuláři s MODem nebo šéfem své sekce, ne s infopultem.

--- a/docs/napoveda/reporty.md
+++ b/docs/napoveda/reporty.md
@@ -1,0 +1,83 @@
+# Reporty
+
+Stránka **Reporty** je centrální místo, odkud si stáhneš data z GameConu — seznamy účastníků, přehledy financí, maily pro rozesílky, podklady pro program a podobně. Vidí ji organizátoři s právem na administraci reportů; některé jednotlivé reporty jsou navíc omezené na další právo (poznáš je podle ikony 🫥 — po najetí myší se dozvíš, jaké právo je potřeba).
+
+Reporty **nejsou optimalizované na rychlost**. Počítej s tím, že větší report (zvlášť finanční přehledy přes všechny účastníky) se může generovat i desítky sekund. Neklikej opakovaně — jen bys server zatížil víc.
+
+## Jak report stáhnout
+
+U každého reportu v seznamu jsou odkazy na dostupné formáty:
+
+| Formát | Co se stane | Na co se hodí |
+|--------|-------------|---------------|
+| **xlsx** | Stáhne se soubor pro Excel / LibreOffice / Google Sheets. Čísla jsou v něm rovnou jako čísla, takže můžeš hned filtrovat a sčítat. | Další zpracování dat, sdílení s ostatními. |
+| **html** | Report se otevře jako tabulka v nové záložce prohlížeče. | Rychlé nakouknutí bez stahování souboru. |
+
+Ne každý report nabízí oba formáty — čistě grafické reporty bývají jen v html, některé exporty naopak jen v xlsx.
+
+U každého reportu je také ikona 📊 — po najetí myší ukáže, **kdo report naposledy použil, kdy a kolikrát byl celkem použit**. Hodí se, když si nejsi jistý, jestli report ještě někdo potřebuje, nebo chceš vědět, s kým řešit jeho obsah.
+
+Nad seznamem je pole pro **omezení reportu na jediného uživatele** — začni psát přezdívku, jméno, příjmení, e-mail nebo ID a vyber člověka z našeptávače. Odkazy na reporty se pak upraví tak, aby report počítal jen s vybraným uživatelem. Využívají to hlavně souhrnné (finanční) reporty; reporty, které s filtrem nepočítají, ho ignorují.
+
+## Přehled důležitých reportů
+
+Přesný seznam se v čase mění (a liší se podle tvých práv), tohle jsou ty nejpoužívanější:
+
+### Účastníci a aktivity
+
+- **Historie přihlášení na aktivity** — kdo se kdy na jakou aktivitu přihlásil či odhlásil.
+- **Účastníci a počty jejich aktivit** — kolik aktivit má každý účastník.
+- **Graf rozložení rozmanitosti her** — grafický přehled, jak pestré programy si lidé skládají.
+- **Duplicitní uživatelé** — kandidáti na sloučení účtů (stejná jména, e-maily…).
+- **Počty rolí platných v ročnících** — kolik lidí mělo jakou roli v jednotlivých ročnících.
+
+### Finance
+
+- **Finance: Zůstatky všech účastníků** — kdo má kolik zaplaceno / kolik dluží.
+- **Finance: Neplatiči k odhlášení** a **Finance: Odhlášené objednávky neplatičů** — podklady pro řešení neplatičů.
+- **Finance: E-shop** — přehled objednávek z e-shopu (vyžaduje právo na administraci financí).
+- **Finance: Rozpočtový report** a **Sirienův rozpočtový report** — souhrnné rozpočtové podklady.
+- **BFGR report** — velký celkový finanční report; odkaz z této stránky vede na stránku Finance, kde se generuje.
+- **Udělené slevy** a **Finance: Aktivity bez slev** — kontrola slev.
+- **Finance: Příjmy a výdaje infopulťáka** — pokladní přehled pro infopult.
+
+### Maily a rozesílky
+
+- **Maily – přihlášení na letošní GC** — e-mailové adresy letos přihlášených.
+- **Maily – letošní vypravěči** — adresy letošních vypravěčů.
+- **Přihlášení k odběru newsletterů** — kdo si přeje dostávat novinky.
+- **Zázemí & Program: Emaily na účastníky / vypravěče dle linií** — adresy rozdělené podle programových linií.
+
+### Zázemí a program
+
+- **Zázemí & Program: Časy a umístění aktivit**, **Přehled místností**, **Zařízení místností** — podklady pro plánování prostor.
+- **Zázemí & Program: Seznam účastníků a triček** — velikosti triček pro objednávku.
+- **Zázemí & Program: Potvrzení pro návštěvníky mladší patnácti let** — kdo potřebuje potvrzení od rodičů.
+- **Nepřihlášení a neubytovaní vypravěči + další** — koho z vypravěčů je potřeba ještě „dohnat".
+- **Stravenky uživatelů** a **Stravenky (bianco)** — tisk stravenek.
+
+### Infopult
+
+- **Infopult: Balíčky účastníků** — co má kdo připraveno k vyzvednutí.
+- **Infopult: Nezkontrolované potvrzení rodičů** — u koho ještě chybí kontrola potvrzení.
+- **Infopult: Účastníci aktivit bez průchodu infopultem** — kdo je na aktivitě, ale neprošel odbavením.
+
+Názvy reportů někdy obsahují letošní rok — reporty pracují vždy s aktuálním ročníkem, pokud z názvu neplyne jinak (např. historie napříč ročníky).
+
+## Quick reporty
+
+Pod univerzálními reporty je sekce **Quick reporty** — jednorázové reporty, které si organizátoři vytvářejí sami. Je to **pokročilá funkce pro lidi, kteří umí SQL**: quick report je pojmenovaný vlastní dotaz do databáze, jehož výsledek se pak dá stahovat stejně jako u běžných reportů (html / xlsx).
+
+- Nový quick report založíš přes stránku **Přidat quick report**; existující upravíš tlačítkem **upravit** u reportu v seznamu.
+- Dotaz smí data **jen číst** — pokusy o zápis či mazání systém odmítne a dotaz se při ukládání rovnou zkontroluje, jestli funguje.
+- V dotazu můžeš použít zástupky `{ROK}` nebo `{ROCNIK}` — nahradí se aktuálním ročníkem, takže report zůstane platný i příští rok.
+- Po uložení se u reportu objeví odkaz **Vyzkoušet** pro rychlou kontrolu výsledku.
+
+**Pozor:** jak varuje i samotná stránka, quick reporty „samy náhodně mizí a nelze tomu zabránit". Ber je jako pomůcku na jedno použití — pokud report potřebuješ dlouhodobě a spolehlivě, nech si ho převést mezi univerzální reporty (domluv se s vývojáři).
+
+## Na co si dát pozor
+
+- **Rychlost** — reporty nejsou stavěné na časově kritické použití. Velké reporty generuj s předstihem, ne pět minut před poradou.
+- **Aktualita** — report je snímek dat v okamžiku stažení. Přihlášky i platby se mění průběžně, stažený soubor rychle zastarává.
+- **Osobní údaje** — reporty obsahují jména, e-maily i finanční údaje účastníků. Stažené soubory nešiř mimo organizátory a po použití je smaž.
+- **Quick reporty nejsou trvalé** — viz výše; na nic důležitého se na ně nespoléhej.

--- a/docs/napoveda/statistiky.md
+++ b/docs/napoveda/statistiky.md
@@ -1,0 +1,58 @@
+# Statistiky
+
+Obrazovka **Statistiky** ti dává rychlý přehled o letošním ročníku (přihlášky, prodeje, ubytování, jídlo) a k tomu dlouhodobé srovnání napříč ročníky. Vidí ji organizátoři s právem na administraci statistik.
+
+Hned nahoře je odpočet — kolik dní (a týdnů) zbývá do začátku letošního GC.
+
+## Účast
+
+Tabulka vlevo nahoře ukazuje počty lidí podle rolí. Vždy obsahuje role „přihlášen na letošní GC" a „přítomen na letošním GC", a navíc **každou roli, která má přidělené právo „Statistiky - tabulka účasti"**. Chceš-li tedy ve statistikách sledovat další skupinu (třeba nový typ pomocníků), stačí její roli tohle právo přidat — tabulka se rozšíří sama.
+
+| Sloupec | Význam |
+|---------|--------|
+| Celkem | Všichni uživatelé, kteří roli mají — včetně těch, kteří se letos (zatím) nepřihlásili. |
+| Přihlášen | Jen ti z nich, kteří jsou zároveň přihlášeni na letošní GC. |
+
+Vedle je malá tabulka **Pohlaví** — kolik mužů a žen je přihlášeno na letošní GC a jaký je podíl žen.
+
+## Graf vývoje přihlášek
+
+Čárový graf ukazuje, jak den po dni rostl počet přihlášených na GC — pro každý zvolený ročník jedna barevná čára. Čísla platí vždy **k půlnoci daného dne**; odhlášení počet zase snižují, čára tedy ukazuje aktuálně přihlášené, ne součet všech pokusů.
+
+- Ve výchozím stavu se zobrazují poslední čtyři ročníky; zaškrtávátky pod grafem si můžeš přidat nebo ubrat libovolné roky. Rok 2020 (Call of Covid) vybrat nejde.
+- **Zarovnání grafu** volí, jak se roky položí přes sebe: buď podle začátku registrací, nebo podle konce GC (výchozí) — to se hodí, protože registrace nezačínají každý rok stejně dlouho před akcí.
+- Přihlášky vzniklé ještě před oficiálním spuštěním registrací jsou shrnuté do jednoho bodu „před registracemi"; podobně vše po skončení akce spadne do bodu „po GC".
+- V popisech dnů graf vyznačuje spuštění registrací, začátek a konec GC jednotlivých ročníků a u letošního roku i **dnešek**.
+- U ročníků před rokem 2013 se přesná data přihlášení nedochovala, takže se celý ročník ukáže až na konci grafu.
+
+## Prodeje letošního ročníku
+
+Pod grafem jsou čtyři tabulky s letošními nákupy:
+
+| Tabulka | Co ukazuje |
+|---------|------------|
+| Předměty | Kolik kusů jednotlivých předmětů a triček se letos prodalo. U každé položky je i modelový rok (stejné tričko se může prodávat víc let). |
+| Ubytování dny a místa | Počty prodaných ubytování po jednotlivých položkách — tedy po kombinacích typu ubytování a noci. |
+| Ubytování dny | Souhrn po nocích a navíc řádek **neubytovaní** — přihlášení na letošní GC, kteří nemají koupené žádné ubytování. |
+| Jídlo | Počty objednaných jídel po položkách, s cenou. Sloupec **Slev** říká, kolik z těch objednávek udělali lidé s nárokem na jídlo zdarma nebo se slevou. |
+
+## Dlouhodobé statistiky
+
+Dole na stránce jsou tabulky srovnávající všechny ročníky. Široké tabulky jdou posouvat do stran; nejnovější roky jsou vpravo.
+
+**Registrovaní vs Dorazili** — pro každý ročník počet registrovaných a počet těch, kteří skutečně dorazili, plus rozpad:
+
+- **z toho nováčků** — lidé, pro které je daný ročník úplně první, na který se kdy přihlásili (resp. na který kdy dorazili). Sleduje se až od ročníku 2022, starší roky jsou prázdné.
+- **z toho studenti / ostatní** — počty studentů jsou dostupné jen pro některé starší ročníky (doplněné ručně z historických záznamů).
+- **Podpůrný tým** a jeho rozpad na **organizátory**, **zázemí** a **vypravěče** — u novějších ročníků se počítá z rolí lidí, kteří dorazili; u starších ročníků jde o ručně doplněná historická čísla.
+
+**Lidé na GC celkem** — kolik lidí v každém ročníku dorazilo, kolik z toho mužů a žen a jaký byl podíl žen.
+
+**Prodané předměty** — počty prodaných placek, kostek a triček po ročnících. Počítají se jen kusy aktuálního modelového roku; údaje do roku 2013 jsou doplněné ručně (starší data v systému nesedí) a rok 2020 je vynechaný.
+
+**Ubytování** — historie prodaného ubytování po ročnících: celkové počty za postel, spacák, penzion a kemp, u každého typu rozepsané po jednotlivých nocích (středa až neděle).
+
+## Tipy
+
+- Když v tabulce Účast chybí skupina, kterou chceš sledovat, přidej její roli právo „Statistiky - tabulka účasti" ve správě práv a rolí.
+- Ručně doplněná historická čísla ve starých ročnících se už nemění — slouží jen pro srovnání trendů.

--- a/docs/napoveda/uvod.md
+++ b/docs/napoveda/uvod.md
@@ -1,0 +1,118 @@
+# Úvod do administrace
+
+Administrace (admin) je interní část webu GameConu pro organizátory, vypravěče
+a další pomocníky. Spravuješ v ní účastníky, aktivity, platby, obsah webu
+i nastavení ročníku. Veřejný web je výkladní skříň — admin je zázemí, kde se
+festival doopravdy řídí. Platí tu proto dvojnásob citát z patičky:
+*„Bacha, tady můžeš něco posrat, seš si jistej, že víš co děláš?"*
+
+## Přihlášení
+
+Admin najdeš na adrese `/admin`. Přihlašuješ se stejným účtem jako na veřejném
+webu GameConu:
+
+1. Do pole **Jméno** napiš svůj login (přezdívku).
+2. Do pole **Heslo** napiš heslo.
+3. Klikni na **Přihlásit**.
+
+Když se přihlášení nepovede, uvidíš hlášku **„Chybné přihlašovací jméno nebo
+heslo"** — zkontroluj překlepy a zkus to znovu.
+
+Po přihlášení tě admin pošle rovnou na stránku, která pro tebe dává největší
+smysl: organizátoři přistanou na kartě **Uživatel** (infopult), vypravěči bez
+dalších práv na **Moje aktivity**. Kdo nemá do adminu žádné právo, je
+přesměrován zpět na veřejný web.
+
+Odhlásíš se tlačítkem **Odhlásit** v levém sloupci pod textem
+**Přihlášen jako …**.
+
+## Orientace: kartičky a podmenu
+
+Vlevo je sloupec s **kartičkami** — hlavním menu adminu. Kartička = jedna
+oblast: **Uživatel**, **Infopult**, **Aktivity**, **Moje aktivity**,
+**Prezence**, **Finance**, **Peníze**, **Reporty**, **Statistiky**, **Web**,
+**Nastavení**, **Práva**, **Nápověda**, případně **Dev**. Právě otevřená
+kartička je zvýrazněná.
+
+**Vidíš jen kartičky, na které máš právo.** Co v adminu vidíš a smíš dělat,
+řídí práva tvých rolí (role ti přiděluje ten, kdo spravuje **Práva** — typicky
+hlavní organizátoři). Dva lidé tak mohou mít admin úplně jinak zaplněný:
+vypravěč uvidí třeba jen **Moje aktivity** a **Nápovědu**, organizátor
+infopultu skoro všechno. Když otevřeš odkaz na stránku, na kterou právo nemáš,
+admin ti to řekne: **„Pro přístup k této stránce nemáš oprávnění."**
+
+Stejně funguje i **Nápověda**: ukazuje jen kapitoly k částem adminu, na které
+máš právo. Nediv se proto, když kolega vidí v nápovědě víc kapitol než ty.
+
+Větší kartičky (např. Aktivity, Finance, Web) mají nahoře na stránce ještě
+**podmenu** s jednotlivými podstránkami — např. u Aktivit najdeš mimo jiné
+**Nová aktivita**, **Týmy**, **Místnosti**, **Štítky** nebo **Export & Import
+aktivit**. I položky podmenu se filtrují podle tvých práv.
+
+V patičce každé stránky jsou odkazy **Program GameConu**, **Volná místa**
+a **Program test** (otevírají se do nové záložky) a náhodný **Protip** —
+krátká rada, jak si práci v adminu zrychlit. Vyplatí se je číst.
+
+## Pracovní uživatel
+
+Máš-li právo na infopult, je úplně nahoře v levém sloupci políčko pro výběr
+**pracovního uživatele** — účastníka, kterému zrovna pomáháš (řešíš mu
+přihlášky, platby, ubytování…):
+
+- Napiš **začátek přezdívky, jména, příjmení, e-mailu nebo ID** a vyber
+  z našeptávače. Do políčka skočíš i zkratkou **alt+U**.
+- Vybraný uživatel se ukáže i s avatarem, jménem, ID a stavem přihlášení na GC.
+  Zůstává vybraný, dokud ho nezrušíš — všechny infopultové akce se pak týkají jeho.
+- Tlačítkem **zrušit** (zkratka **alt+Z**) práci s ním ukončíš.
+- Ikonka odkazu / kopírování vedle ID zkopíruje adresu aktuální stránky
+  s předvybraným uživatelem — hodí se pro poslání kolegovi, kterému se po
+  otevření odkazu vybere tentýž uživatel.
+- Pod políčkem se pamatuje **předchozí pracovní uživatel** — kliknutím na
+  odkaz **↻ jméno** se k němu rychle vrátíš.
+
+Důležité: pracovní uživatel je jen „koho obsluhuji". **Ty jsi pořád přihlášen
+sám za sebe** a akce děláš svým jménem.
+
+Pozor na nevratné akce s pracovním uživatelem — **odhlášením uživatele
+z GameConu se nenávratně zruší všechny jeho aktivity a nákupy.**
+
+## Přepnutí na uživatele
+
+Něco jiného je **přepnout se na uživatele** — políčko v levém sloupci pod
+textem **Přihlášen jako …**. Tím se opravdu přihlásíš jako někdo jiný a admin
+i web vidíš přesně jeho očima (jeho práva, jeho kartičky). Hodí se, když
+potřebuješ ověřit, co konkrétní člověk vidí, nebo něco vyřešit za něj.
+
+- Přepnutí na **libovolného** uživatele má jen ten, komu pro letošní ročník
+  přidělila zvláštní právo rada — právo se každý ročník uděluje znovu.
+- Infopulťáci mají omezenou variantu: mohou se přepnout jen na **letošní
+  vypravěče a partnery** (např. kvůli kontrole jejich aktivit). Po přepnutí
+  na vypravěče skončíš rovnou na jeho **Moje aktivity**.
+- Po přepnutí **jsi** ten uživatel — cokoli uděláš, děláš jeho jménem. Zpátky
+  na svůj účet se dostaneš tlačítkem **Odhlásit** a novým přihlášením pod
+  svým jménem.
+
+## Jak poznám, že nejsem na ostré verzi
+
+Ostrá (produkční) verze adminu nemá žádné zvláštní označení. Testovací
+prostředí poznáš podle barevné **stužky v rohu obrazovky** — je vidět už na
+přihlašovací stránce:
+
+| Stužka | Kde jsi |
+|--------|---------|
+| *(nic)* | ostrá verze — tady se pracuje naostro |
+| **β beta** | beta — testovací kopie |
+| **🧐 preview** | preview — náhled rozpracované novinky |
+| **άλφα local** | lokální vývojářská verze |
+
+Než uděláš cokoli důležitého (platby, odhlašování, mazání), mrkni do rohu.
+Bez stužky = ostrá data.
+
+## Klávesové zkratky
+
+- **Tlačítka s podtrženým písmenem** jdou zmáčknout zkratkou
+  **alt+podtržené písmeno** (např. **z̲rušit** = alt+Z).
+- **alt+U** — skočí do políčka výběru pracovního uživatele.
+- **alt+Z** — zruší vybraného pracovního uživatele.
+
+Používání klávesových zkratek práci na infopultu znatelně urychlí.

--- a/docs/napoveda/uzivatel.md
+++ b/docs/napoveda/uzivatel.md
@@ -1,0 +1,96 @@
+# Karta uživatele
+
+Stránka **Uživatel** je hlavní pracovní plocha infopultu a ubytovatelů: na jednom místě vidíš a upravuješ ubytování, jídlo, osobní údaje, slevy, objednávky a historii účasti vybraného účastníka a můžeš mu rovnou prodat předměty. Pokud jsi organizátor s přístupem na infopult, přistane tě na ní admin rovnou po přihlášení.
+
+## Výběr uživatele, se kterým pracuješ
+
+Skoro celá stránka se točí kolem tzv. *pracovního uživatele* — účastníka, kterého sis vybral(a) do pole vlevo nahoře (na úzké obrazovce je pole nahoře):
+
+- Do pole napiš **začátek přezdívky, jména, příjmení, e-mailu nebo ID** a vyber z našeptávače. Do pole skočíš i klávesovou zkratkou **Alt+U**.
+- Vybraného uživatele vidíš vlevo i s avatarem, přezdívkou, jménem a ID. Tlačítkem **zrušit** (zkratka **Alt+Z**) práci s ním ukončíš.
+- Vedle ID je ikonka odkazu a kopírování — zkopíruješ si tak URL stránky s předvybraným uživatelem, které můžeš poslat kolegovi.
+- Pod výběrem se nabízí odkaz **↻** na předchozího uživatele, se kterým jsi pracoval(a) — hodí se, když se potřebuješ rychle vrátit.
+
+Dokud nikoho nevybereš, stránka zobrazuje výzvu **„Vyberte uživatele"** a většina sekcí je prázdná. Pokud vybraný uživatel **není přihlášen na letošní GameCon**, uvidíš červenou hlášku „Uživatel není přihlášen na GC" a ubytování ani jídlo mu nenastavíš (přihlášení na GC se řeší na stránce **Infopult**).
+
+## Sekce stránky
+
+### Ubytování uživatele
+
+Tabulka nocí (sloupce) a typů ubytování (řádky) s cenou za noc a obsazeností ve tvaru `obsazeno/kapacita`. U každé noci vybereš typ ubytování, nebo volbu **Žádné**. Do pole **„Na pokoji chci být s:"** se píší jména spolubydlících oddělená čárkou. Změny potvrď tlačítkem **Uložit**.
+
+- Na této stránce jde ubytování upravovat **i po ukončení prodeje** na webu.
+- Šéf Infopultu má navíc tlačítko **„přes kapacitu"**, kterým může ubytovat i na plně obsazený typ.
+- Pokud uživatel nemá objednané ubytování, zobrazuje se řádek **„Nechce ubytování: ano/ne"** — informace, zda si na webu zaškrtl, že ubytování nechce.
+
+### Jídlo uživatele
+
+Mřížka dnů a jídel (snídaně, obědy, večeře) se zaškrtávátky. Platí pravidla uvedená přímo na stránce: **„Zrušit jídlo je možné jenom oproti vrácené stravence. Při objednání jídla je naopak potřeba předat stravenku (a zkontrolovat stav financí). Snídaně nabízíme jen organizátorům a vypravěčům."** Změny ulož tlačítkem **Uložit**. Pokud má uživatel nějaké jídlo objednané, objeví se odkaz **Tisk stravenek**.
+
+### Nastavení pokojů
+
+Dva formuláře:
+
+| Formulář | Co dělá |
+|---|---|
+| **Vypsat pokoj** | Zadáš číslo pokoje a tlačítkem **Vypsat** zobrazíš, kdo na něm bydlí, včetně informace, zda už dorazil (zeleně), nebo nedorazil (červeně). |
+| **Přidělit pokoj** | Zadáš číslo pokoje a tlačítkem **Přidělit** na něj nastěhuješ aktuálně vybraného uživatele. **Přepíše to jeho stávající pokoj.** |
+
+### Slevy
+
+Přehled slev vybraného uživatele, rozdělený na **„Na aktivity"** a **„Na všechno"**. Jen ke čtení; když žádné nemá, vidíš „(žádné)".
+
+### Objednávky a platby
+
+Přehled financí uživatele pro letošní ročník — objednané položky, platby a výsledný stav. Jen ke čtení.
+
+### Osobní údaje
+
+Tabulka s údaji: Přezdívka, Zobrazení na webu, Jméno, Příjmení, Pohlaví, Ulice, Město, PSČ, Telefon, Narozen/Narozena (s nápovědou věku na začátku letošního GameConu), E-mail, Typ dokladu, Číslo dokladu a Státní občanství.
+
+Úprava funguje přesně podle nápisu **„Pro úpravu klikni na údaj"**: klikneš na zobrazenou hodnotu, tabulka se přepne do editačních políček, přepíšeš, co potřebuješ, a potvrdíš tlačítkem **uložit**. To je i význam protipu z patičky adminu *„osobní údaje lze upravit kliknutím a přepsáním na úvodní straně"* — úvodní strana adminu je právě tato karta (případně Infopult, kde je stejná tabulka).
+
+- Červená ikonka u řádku znamená, že údaj chybí.
+- Při uložení e-mailu nebo přezdívky, kterou už má někdo jiný, dostaneš chybu **„Uživatel se stejným e-mailem již existuje."** a nic se neuloží.
+- Pokud měl uživatel údaje potvrzené jako zkontrolované a po úpravě mu nějaký povinný údaj chybí, potvrzení kontroly se automaticky zruší a stránka tě vyzve: oprav údaje a zkontroluj je znovu.
+
+Pod tabulkou jsou odkazy **Program** (program vybraného uživatele) a **Program účastníka**.
+
+### Historie účasti
+
+Seznam ročníků, kterých se uživatel účastnil. Letošní ročník je uveden jen číslem, starší ročníky jsou odkazy do administrace archivu daného roku — otevřou se s tímto uživatelem rovnou předvybraným.
+
+### Prodej předmětů
+
+Rychlý prodej triček, kostek a dalších předmětů letošního ročníku:
+
+1. Vyber **Předmět** — v závorce u každého vidíš zbývající počet kusů a cenu.
+2. Uprav **počet kusů** (políčko vedle názvu, výchozí 1).
+3. Klikni **Prodat** — částka se propíše do objednávek uživatele.
+
+Když nemáš vybraného žádného uživatele, formulář zobrazuje **„Anonymní prodej"** — prodej se zaeviduje bez konkrétního účastníka (hotovostní prodej kolemjdoucímu).
+
+## Typické postupy
+
+- **Účastník chce změnit noci nebo typ ubytování** → vyber ho, uprav mřížku v sekci Ubytování uživatele, **Uložit**.
+- **Ubytovatel rozděluje pokoje** → vyber účastníka, v Nastavení pokojů zadej číslo a **Přidělit**; složení pokoje ověříš přes **Vypsat**.
+- **Oprava překlepu ve jméně / telefonu** → v Osobních údajích klikni na údaj, přepiš, **uložit**.
+- **Prodej trička na místě** → sekce Prodej předmětů, vyber tričko, **Prodat**.
+
+## Na co si dát pozor
+
+- **Odhlášení uživatele z GameConu je nevratné.** Provádí se tlačítkem **„Odhlásit z GC"** na stránce **Infopult** (na kartě uživatele takové tlačítko není) a systém se ptá: *„Trvale odhlásit uživatele z GameConu a smazat všechny jeho aktivity a nakoupené věci?"* — přesně to se stane, zruší se **všechny jeho přihlášky na aktivity i všechny nákupy** a nejde to vzít zpět. Odhlásit lze jen účastníka, který je přihlášen, ale ještě nedorazil, a smí to pouze správce financí. Odtud pramení protip *„odhlášením uživatele z GC se nenávratně zruší všechny jeho aktivity a nákupy"*.
+- **Rušení jednotlivých nákupů** (ikonka koše u objednávky na stránce Infopult, jen pro lidi s právem rušit nákupy) také chce potvrzení *„Opravdu zrušit objednávku …"* — zrušený nákup se maže, nejde ho obnovit.
+- **Přidělení pokoje přepíše stávající stav** — pokud už uživatel pokoj měl, bez varování se přestěhuje.
+- **Jídlo ruš jen proti vrácené stravence** a při doobjednání stravenku vydej — jinak nebude sedět výdej jídel.
+- Před ukončením práce s uživatelem zkontroluj **stav financí** v sekci Objednávky a platby, ať nikdo neodchází s nedoplatkem.
+
+## Občasné importní nástroje
+
+Mimo tuto kartu existují hromadné nástroje, které infopult a ubytovatelé používají párkrát do roka (najdeš je na stránkách financí a „Peníze"):
+
+- **Importér ubytování** — nahraješ upravený *Report ubytování* (XLSX) a kompletně tím přepíšeš letošní údaje o ubytování (pokoje, noci, typy). Přepis či mazání osobních údajů (číslo dokladu, občanství) provede jen se zvlášť zaškrtnutým povolením.
+- **Importér balíčků** — z reportu *Infopult: Balíčky účastníků* (XLSX) uloží, kdo má dostat **velký balíček**.
+- **Importér e-shopu** — z *Reportu e-shopu* (XLSX) kompletně přepíše letošní nabízené předměty a ubytování; položky, které v souboru chybí, skryje.
+
+U všech importů platí: soubor vychází z reportu vyexportovaného ze systému, upravuje se v Excelu a nahrává zpět. Import vypíše, co změnil, a na problémové řádky upozorní.

--- a/docs/napoveda/verejny-web.md
+++ b/docs/napoveda/verejny-web.md
@@ -1,0 +1,110 @@
+# Veřejný web očima účastníka
+
+Tahle kapitola ti popisuje, co vidí a dělá účastník na veřejném webu gamecon.cz — od založení účtu až po zaplacení. Hodí se, když odpovídáš na dotazy účastníků.
+
+Typické flow účastníka: **registrace účtu → přihláška na GameCon (ubytování, předměty, jídlo) → výběr aktivit v programu → platba převodem → případné změny či odhlášení**.
+
+## Účet: registrace a přihlášení
+
+- Na stránce **Registrace** účastník vyplňuje: e-mail, telefon, jméno, příjmení, datum narození, státní občanství, adresu trvalého pobytu (ulice a č. p., město, PSČ, země), typ a číslo dokladu totožnosti, přezdívku, „Zobrazení na webu" (jak se jeho jméno ukazuje veřejně — v adminu se nemění), pohlaví a heslo (2×). Musí zaškrtnout „Souhlasím se zpracováním osobních údajů" a projít antirobotickou kontrolou.
+- Adresu a doklad odevzdáváme ze zákona poskytovateli ubytování (koleje VŠB-TUO) — tak to říká i nápověda přímo ve formuláři. Pohlaví slouží interně pro přidělování ubytování a pro genderově omezená místa na aktivitách.
+- Tlačítka: **„Přihlásit na GameCon"** (uloží účet a pošle rovnou na přihlášku) a **„Jen vytvořit účet"**. Před spuštěním přihlašování je první tlačítko neaktivní s vysvětlením, že „přihlašování se spustí …" a spuštění připomeneme e-mailem.
+- Přihlášený uživatel vidí tutéž stránku jako **„Nastavení"** — může údaje upravovat a uložit. Pozor: po kontrole dokladů na infopultu se některé údaje **zamknou** a přes web už je změnit nejde.
+- Přihlášení (login) je e-mailem a heslem, s volbou „Trvale přihlásit" a odkazem **„zapomenuté heslo"**.
+
+## Přihláška na GameCon
+
+Stránka **Přihláška** je dostupná jen přihlášenému uživateli a jen v období přihlašování (jinak ukazuje „Přihlašování na GameCon bude spuštěno …", resp. „Přihlašování na GameCon je uzavřeno od …"). Skládá se ze sekcí:
+
+- **Předměty** — GameCon merch (placky, kostky, mikiny, trička…), lze objednat i více kusů. Trička a mikiny mají vlastní (dřívější) uzávěrku než ostatní merch; konkrétní termíny jsou vypsané přímo ve formuláři.
+- **Ubytování** — čísla ukazují obsazenost/kapacitu, ubytování je od středy (program začíná ve čtvrtek v poledne), běžně jde objednat minimálně na 2 navazující noci, hotelové pokoje mají v ceně snídani. Organizátoři mají ubytování zdarma, vypravěči mají bonus dle množství vyprávěných aktivit.
+- **Jídlo** — obědy a večeře, na výběr 3–5 jídel včetně vegetariánského, jídelníček je na webu. Objednat nebo zrušit lze do termínu uvedeného ve formuláři.
+- **Dobrovolné vstupné** — libovolný příspěvek, na posuvníku se ukazuje průměrné loňské vstupné.
+- **„Chceš se zapojit do organizace?"** — účastník může vyznačit zájem pomoct jako dobrovolník, vypravěč, organizátor či partner a dopsat detail.
+
+Tlačítko dole je **„Přihlásit na GameCon"** (poprvé) nebo **„Uložit změny"** (při úpravách). Po přihlášení hlásí „Přihlášení na GameCon … proběhlo úspěšně", po úpravě „Přihláška aktualizována."
+
+Další důležité body:
+
+- Aktivní přihláška jde upravovat „až téměř do začátku GameConu" — každá sekce má svou uzávěrku vypsanou ve formuláři.
+- Hned v hlavičce přihlášky je: **„Objednávku je potřeba uhradit do … včetně."** s odkazem na Přehled financí.
+- **Účastník mladší 15 let** musí dodat potvrzení o souhlasu zákonného zástupce — formulář ke stažení je na přihlášce, vyplněný ho nahraje přímo tam (nebo donese fyzicky na infopult; formuláře budou i na infopultu). Po nahrání se ukáže „Potvrzení je úspěšně nahrané ✅".
+- **Odhlášení z GameConu**: tlačítko „Odhlásit se z GameConu" s potvrzením: *„Odhlášení z GameConu zruší všechny tvé registrace na aktivity a nákupy předmětů."* Během GameConu se účastník sám odhlásit nemůže — dostane hlášku „Během Gameconu se nemůžeš sám odhlásit. Stav se na infopultu."
+- Jakmile GameCon běží, přihlášku už online upravit nejde — změny se řeší na infopultu; přehled plateb zůstává v záložce finance.
+
+## Program a aktivity
+
+### Stránka Program
+
+- Program je interaktivní tabulka po dnech; přihlášený účastník má navíc záložku **„můj program"** (jen jeho aktivity) a přepínač „všechny dny".
+- Filtrování podle stavu aktivit: **Otevřené / V další vlně / Připravujeme / Sleduji / Přihlášen(a) / Plno** (+ „organizuji" pro vypravěče).
+- Aktivity se otevírají pro přihlašování **ve vlnách** (první, druhá, třetí…). Aktivity, které se otevřou až v příští vlně, jsou v programu vidět, ale zatím na ně nejde kliknout „přihlásit" — program ukazuje, kdy další vlna začne.
+
+### Stránka Aktivity (podle linií)
+
+Každá programová linie (RPG, deskovky, larpy…) má vlastní stránku se seznamem aktivit: anotace, vypravěč, čas a místo konání, kapacita (nebo „neomezeně"), cena a obsazenost. U vícekolových aktivit (např. DrD) se vypisují jednotlivé termíny.
+
+### Přihlašování na aktivity
+
+- Přihlašovat se může jen ten, kdo **má aktivní přihlášku na GameCon** (jinak: „Nemáš aktivní přihlášku na GameCon.").
+- Odkazy u aktivity: **„přihlásit"** / **„odhlásit"**.
+- Nelze se přihlásit na dvě aktivity ve stejném čase: „V daném čase už máš přihlášenu jinou aktivitu."
+- Když je plno, systém hlásí „Místa jsou už plná". Některé aktivity mají **genderově dělená místa** — pak se může zobrazit „pouze ženská místa" / „pouze mužská místa" (tj. pro tebe je plno, i když ukazatel obsazenosti nevypadá plný).
+- Aktivity se platí — jejich cena se propisuje do Přehledu financí. Přihlášením/odhlášením se finance přepočítají.
+
+### Sledování aktivity (náhradníci)
+
+- Když je aktivita plná, nabídne místo „přihlásit" odkaz **„sledovat"** (a naopak „zrušit sledování"). Sledovat jde jen běžné aktivity — **ne týmové aktivity a ne aktivity v turnaji**.
+- Jakmile se na sledované plné aktivitě uvolní místo, přijde sledujícím e-mail: *„Na aktivitě …, která se koná v …, se uvolnilo místo. … Přihlaš se na aktivitu přes program (pospěš si, ať ti místo nezabere někdo jiný)."* Sledování **není rezervace** — místo dostane, kdo se přihlásí první.
+- Sledovat nejde aktivitu v čase, kdy už má účastník jinou přihlášenou aktivitu. A když se účastník přihlásí na aktivitu, sledování jiných aktivit ve stejném čase se mu automaticky zruší.
+
+### Týmové aktivity
+
+- U týmové aktivity je místo běžného „přihlásit" tlačítko **„Přihlásit tým"** (resp. **„Nastavení týmu"**, když už v týmu je).
+- **Kapitán** založí tým; u turnajů s více termíny v kole si vybere termíny pro všechna kola. Na dokončení základního nastavení má omezený čas (cca 30 minut), jinak se rozpracovaný tým smaže — UI na to výrazně upozorňuje odpočtem.
+- Členové týmu vidí **kód týmu**, který pošlou spoluhráčům — ti se jím do týmu přihlásí. Tým může být i **veřejný**, do toho se dá přihlásit bez kódu.
+- Kapitán může předat kapitánství, vyhodit člena, upravit limit velikosti týmu (v rozmezí min–max daných aktivitou) a tým **zamknout** — to jde až při naplnění minimální kapacity. Na zamčení má kapitán 72 hodin; pak se tým podle nastavení aktivity zveřejní, nebo smaže.
+- **Zamčený tým už nejde upravovat** (nikdo se nepřihlásí ani neodhlásí). Odemknout ho může jen organizátor, případně ho odemkne systém, když z něj odhlásí neplatiče.
+- Odhlášení z jedné aktivity turnaje odhlašuje ze všech kol turnaje.
+
+### Odhlášení z aktivity a storno
+
+- Odhlásit se jde odkazem „odhlásit" kdykoli během přihlašování; z už proběhlé/uzavřené aktivity to nejde.
+- **Pozdní odhlášení** (méně než cca 24 hodin před začátkem aktivity — přesná hranice je nastavení ročníku) se počítá jako „pozdě zrušil" se **storno poplatkem (zpravidla polovina ceny aktivity)**. Výjimka: kdo se přihlásil omylem a do několika minut se zase odhlásí, storno neplatí.
+- Kdo je přihlášen a **vůbec nedorazí**, platí zpravidla plnou cenu aktivity. Kdo dorazí jako náhradník na místě, platí normálně.
+
+## Platby a Přehled financí
+
+Stránka **Přehled financí** (odkaz „finance") ukazuje přihlášenému účastníkovi:
+
+- **Objednané věci** — všechny letošní položky (aktivity, ubytování, jídlo, předměty…) s cenami po slevách, plus sekci **Bonusy** (slevy, bonus za vedení aktivit apod.).
+- Celkový stav: buď dluh s pokyny k platbě, nebo „Všechny tvoje pohledávky jsou **v pořádku zaplaceny**".
+
+Placení:
+
+- Platí se **převodem na účet**. Stránka nabízí přepínač **CZ / SK / SEPA** (předvybraný podle země účastníka) — u každé varianty jsou údaje (číslo účtu, resp. IBAN + BIC/SWIFT), částka a **QR kód**, který stačí naskenovat v bankovní aplikaci.
+- **Variabilní symbol = ID účastníka** (u zahraniční platby „Reference platby: VS:…"). Podle VS se platba po stažení z banky **automaticky spáruje** s účtem účastníka — proto je důležité VS nezkomolit. Systém umí VS vyčíst i ze zprávy pro příjemce ve tvaru „VS:123456". Platba bez rozpoznatelného VS zůstane nespárovaná a řeší se ručně.
+- Částka v eurech (SK/SEPA) zahrnuje **kurzovou rezervu**: „nemusí proto přesně odpovídat aktuálnímu kurzu. Případný přeplatek ti zůstane na GC účtu nebo ti ho rádi vrátíme."
+- **Do kdy zaplatit**: „GameCon je nutné zaplatit převodem **do {datum}** (tento den musejí být peníze na účtu GameConu)." Stránka rovnou varuje: „Při pozdější platbě tě systém dne {datum} **automaticky odhlásí**." Hromadné odhlašování neplatičů probíhá ve více vlnách před GameConem; čerstvě registrovaní jsou pár dní chráněni.
+- Přeplatky: „Peníze navíc můžeš využít na přihlášení aktivit na GameConu a přeplatek ti po GameConu rádi vrátíme." I plně zaplacený účastník si může poslat peníze „do zásoby" na dokupování aktivit na místě.
+
+## Obsahové stránky, novinky, maily
+
+- **Titulka** — představení festivalu, dlaždice programových linií, odpočet do spuštění přihlašování / do začátku GameConu.
+- **Novinky a Blog** — stránkovaný výpis novinek, delší články na blogu.
+- **Newsletter** — formulář „Chcete dostávat informace do emailu?" s tlačítkem „Přihlásit k odběru"; posíláme „maximálně tři e-maily ročně s hlavními informacemi pro blížící se ročník".
+- **Odhlášení z mailů** — odkaz v patičce e-mailů vede na stránku, která e-mail odhlásí z odběru novinek a potvrdí to hláškou.
+
+## Časté dotazy účastníků
+
+| Dotaz | Odpověď |
+|---|---|
+| Do kdy musím zaplatit? | Do data uvedeného na přihlášce a v Přehledu financí (ten den už musí být peníze na účtu GC). Při pozdější platbě systém účastníka v uvedený den automaticky odhlásí. |
+| Poslal jsem peníze a pořád svítí dluh. | Nejčastěji špatný/chybějící variabilní symbol (má to být ID účastníka) — platba se pak nespárovala automaticky a musí se dohledat ručně. Chvíli také trvá, než se platba z banky načte. |
+| Co znamená „sledovat" u aktivity? | Aktivita je plná; sledování znamená, že přijde e-mail, až se uvolní místo. Není to rezervace — přihlásit se musí účastník sám a rychle. |
+| Proč u aktivity vidím „pouze ženská/mužská místa"? | Aktivita má dělenou kapacitu podle pohlaví a pro tvoje pohlaví už je plno; lze ji sledovat. |
+| Jak se přihlásí parta na týmovku? | Jeden založí tým (kapitán), ostatním pošle kód týmu; kapitán pak tým do 72 hodin zamkne. Nezamčený tým se po limitu zveřejní nebo smaže, rozpracovaný tým se maže už po cca 30 minutách. |
+| Můžu se odhlásit z aktivity? | Ano, ale při odhlášení na poslední chvíli (zhruba den před začátkem) se platí storno; kdo nedorazí vůbec, platí plnou cenu. |
+| Jak se odhlásím z celého GameConu? | Tlačítkem na přihlášce — zruší se tím všechny aktivity i nákupy. Během GameConu to jde už jen na infopultu. |
+| Je mi méně než 15 let, co potřebuji? | Potvrzení zákonného zástupce — formulář je ke stažení na přihlášce, nahrává se tamtéž, případně se odevzdá na infopultu. |
+| Můžu změnit objednávku po odeslání přihlášky? | Ano, přihláška jde upravovat opakovaně; každá sekce (trička, ostatní merch, ubytování, jídlo) má ale svou uzávěrku uvedenou přímo ve formuláři. Po začátku GameConu už jen na infopultu. |

--- a/docs/napoveda/web.md
+++ b/docs/napoveda/web.md
@@ -1,0 +1,152 @@
+# Správa webu
+
+Kartička **Web** v adminu slouží ke správě obsahu veřejného webu GameConu:
+novinek a blogu, obsahových stránek, hlaviček programových linií a log
+sponzorů a partnerů. Najdeš tu také odkazy na preview prostředí a archivy
+starých ročníků. Co z toho vidíš, závisí na tvých právech — **Loga 🎨**
+mají vlastní právo, takže je nemusí vidět každý, kdo spravuje zbytek webu.
+
+## Novinky (hlavní stránka)
+
+Po otevření kartičky **Web** vidíš tabulku všech novinek a blogových
+příspěvků se sloupci **Vydat** (datum vydání), **Typ** (novinka / blog),
+**Název** a **Akce**. Novou položku založíš tlačítkem **Přidat novinku**,
+existující otevřeš odkazem **upravit**.
+
+Formulář novinky obsahuje:
+
+| Pole | K čemu je |
+|------|-----------|
+| **Typ** | výběr **novinka** / **blog** — podle toho se příspěvek zařadí na webu |
+| **Vydat** | datum a čas vydání — na veřejném webu se příspěvek objeví až po tomto okamžiku, takže můžeš psát do zásoby |
+| **Url** | adresa příspěvku (část URL na webu); musí být unikátní |
+| **Nazev** | titulek příspěvku |
+| **Autor** | jméno autora |
+| text | vlastní obsah v Markdownu — vlevo píšeš, vpravo se rovnou ukazuje náhled, jak bude text vypadat |
+
+Uložíš tlačítkem **Uložit**; po úspěchu se zobrazí hláška **Uloženo**.
+První obrázek vložený do textu se na webu použije jako náhledový obrázek
+příspěvku.
+
+## Editace stránek
+
+Podstránka **Editace stránek** vypisuje všechny obsahové stránky webu podle
+jejich **URL**. Novou založíš tlačítkem **Přidat stránku**, existující
+otevřeš přes **upravit**.
+
+Formulář stránky obsahuje **Url stranky** (adresa na webu), **Poradi**
+(řadicí číslo), zaškrtávátko **Redirect** a obsah v Markdownu s živým
+náhledem vpravo. Když je **Redirect** zaškrtnutý, stránka nic nezobrazuje
+a místo toho přesměruje návštěvníka na adresu zapsanou v poli obsahu.
+
+**Pozor:** v obsahu některých stránek najdeš speciální vložky — widgety ve
+tvaru `(widget:nazev)` a zástupné značky ohraničené procenty (např.
+`%PRVNI_VLNA_KDY%`, doplní se z nastavení ročníku). Nemaž je ani nepřepisuj,
+pokud přesně nevíš, co dělají — web si je při zobrazení nahrazuje živým
+obsahem.
+
+## Návod (formátování textů)
+
+Podstránka **Návod** shrnuje, jak se formátují texty na webu (aktivity,
+stránky, novinky). Používá se jazyk **Markdown** — stejný jako na Trellu
+nebo GitHubu: nadpisy křížky (`## Nadpis`), prázdný řádek mezi odstavci,
+`_podtržítka_` pro zvýraznění (`__dvojitá__` pro řvoucí), odkaz
+`[Google](http://google.com)`, odrážky pomlčkou, číslované seznamy `1.`
+(čísluje se samo). Odkazy mimo web GameConu se automaticky otevírají
+v novém tabu — neřeš to ručně přes HTML. Na podstránce najdeš živou ukázku
+„Skutečně napsáno" vs. „Zobrazí se jako".
+
+## Hlavičky linií
+
+Podstránka **Hlavičky linií** upravuje text a obrázek v hlavičce programové
+linie na webu aktivit. Každá linie zobrazovaná v menu má řádek se třemi
+sloupci: **Linie** (název a odkaz **otevřít veřejnou stránku**), **Texty**
+a **Obrázek**.
+
+- Texty: pole **Sekce**, **Jméno** a **E-mail** (kontakt na šéfa linie),
+  uložíš tlačítkem **Uložit texty**. Když necháš všechna tři pole prázdná,
+  hlavička se vymaže a použije se výchozí podoba (hláška „Hlavička linie
+  byla vymazána, použije se fallback.").
+- Obrázek: vyber soubor a klikni **Nahrát obrázek**. Podporované formáty
+  jsou JPG, PNG, WebP a GIF, maximální velikost 2 MB. U každé linie vidíš
+  náhled a stav (vlastní obrázek / fallback). Tlačítko **Smazat vlastní
+  obrázek** vrátí linii k výchozímu obrázku.
+
+## Loga sponzorů a partnerů
+
+Podstránka **Loga 🎨** spravuje čtyři skupiny log: **Loga sponzorů na
+titulce**, **Loga partnerů na titulce**, **Loga sponzorů v přehledu**
+a **Loga partnerů v přehledu**. V každé skupině vidíš nahraná loga
+s náhledem a odkazem, tlačítko **Smazat** (s potvrzením „Opravdu chcete
+smazat logo …?") a formulář pro nahrání nového.
+
+Nahrání: vyber soubor loga, vyplň **URL sponzora** / **URL partnera**
+(povinné — adresa, kam logo na webu odkazuje) a klikni **Nahrát logo**.
+Podporované formáty: JPG, PNG, GIF, WebP, SVG. Soubor se pojmenuje podle
+domény z URL, takže nahrání dalšího loga se stejnou doménou přepíše to
+původní.
+
+Pořadí log řídí soubor **RAZENI.csv**: nahraješ ho tlačítkem **Nahrát
+RAZENI.csv**, stáhnout si můžeš **Platné RAZENI.csv** i **vzor RAZENI.csv**.
+Loga se seřadí podle seznamu v souboru (velikost písmen a případné `www.`
+na začátku se ignorují — `www.Albi.cz` se bere jako `albi.cz`); loga, která
+v souboru nejsou, se připojí za ně seřazená podle abecedy.
+
+## Previews
+
+Podstránka **Previews** ukazuje seznam aktivních preview prostředí — to jsou
+zkušební kopie webu pro jednotlivé vyvíjené změny, kde si můžeš novou funkci
+vyzkoušet dřív, než se dostane na ostrý web. U každého preview vidíš jeho
+URL, odkaz **/admin**, odkaz na související PR a datum nasazení
+(**Deployed**).
+
+Preview jsou schovaná za heslem: přihlašovací údaje k bráně jsou na stránce
+vypsané jako kopírovatelný text, ale prokliky odsud obvykle projdou bez
+ptaní — a do adminu preview budeš rovnou přihlášený svým účtem. Nahoře je
+odkaz na sdílenou schránku **webmail.preview.gamecon.cz**, kam chodí všechny
+e-maily odeslané z preview (žádné se neposílají skutečným lidem).
+
+## Staré ročníky
+
+Podstránka **Staré ročníky** vypisuje archivy minulých ročníků na adresách
+`RRRR.gamecon.cz`, seřazené od nejnovějšího. Ročníky od 2012 jsou „živé" —
+mají funkční web i admin; starší jsou jen statické kopie (sekce **Pouze
+statické kopie** a **Věk Altaru**) a admin u nich není.
+
+I archivy jsou za heslem — přihlašovací údaje k bráně vidíš na stránce jako
+kopírovatelný text, proklik odsud ale většinou projde bez dialogu. U živých
+ročníků je odkaz do adminu (**RRRR /admin**): kliknutím jsi v archivu rovnou
+přihlášený svým účtem, nic dalšího vyplňovat nemusíš. Odkaz funguje jen
+tobě — když ho pošleš někomu jinému, nepřihlásí ho. Ročníky, které v seznamu
+nejsou, zatím žijí na staré infrastruktuře mimo tento přehled.
+
+## Medailonky vypravěčů
+
+Medailonky (krátké představení vypravěčů na webu) se spravují na kartičce
+**Aktivity → Medailonky** — přístup k nim ale patří ke správě webu. Nový
+medailonek vytvoříš zadáním **ID uživatele** a tlačítkem **vytvořit**.
+V tabulce vidíš u každého vypravěče ✅/❌ podle toho, zda má vyplněný obecný
+**Popis** a část pro **DrD** (najetím myší se text ukáže), a tužku pro
+editaci. Horní část medailonku je obecná, dolní část je pro DrD.
+
+## Typické postupy
+
+**Přidat novinku:** Web → **Přidat novinku** → vyplň **Typ**, **Vydat**,
+**Url**, **Nazev**, **Autor** a text v Markdownu → **Uložit**. Zkontroluj
+datum vydání — do té doby novinka na webu vidět není.
+
+**Upravit text stránky:** Web → **Editace stránek** → u stránky klikni
+**upravit** → uprav Markdown vlevo, náhled sleduj vpravo → **Uložit**.
+
+## Na co si dát pozor
+
+- **Smazat novinku ani stránku z adminu nejde** — formuláře umí jen
+  vytvářet a upravovat. Když potřebuješ něco odstranit, obrať se na správce.
+- Novinka se zveřejňuje **podle data v poli Vydat** — budoucí datum znamená
+  odložené vydání, ne chybu.
+- Ve stránkách **nemaž widgety a značky v procentech** — nahrazují se živým
+  obsahem z nastavení.
+- U log **přepíše nové logo se stejnou doménou to staré** — chceš-li logo
+  jen vyměnit, stačí nahrát nové se stejnou URL.
+- Pokud se uložení nepovede, formulář zobrazí hlášku **„Chyba: …"** —
+  oprav vstup a zkus to znovu.


### PR DESCRIPTION
Nová kartička Nápověda renderuje Markdown kapitoly z docs/napoveda/ (14 kapitol: úvod, veřejný web očima účastníka a po jedné pro každou sekci adminu). Uživatel vidí jen kapitoly k částem adminu, na které má právo.

Protože žádné jediné právo nemají všichni uživatelé adminu, umí teď AdminMenu volitelnou hlavičku `prava:` se seznamem práv — kartička se zobrazí (a stránka pustí) každého, kdo má kterékoli z nich. Moduly jen s `pravo:` fungují beze změny.