### PR TITLE
Poslat mail sledujícím i u gender-plné aktivity

### DIFF
--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -1918,19 +1918,14 @@ SQL
         if (!$this->prihlasovatelna() && !$this->probehnuta()) { // u proběhnutých aktivit se zobrazí čísla. Možno měnit.
             return " <span class=\"neprihlasovatelna\">($prihlasenoCelkem/$kapacitaCelkova)</span>";
         }
-        switch ($this->volno()) {
-            case 'u':
-            case 'x':
-                return " ($prihlasenoCelkem/$kapacitaCelkova)";
-            case 'f':
-                return ' <span class="f">(' . $prihlasenoZen . '/' . $kapacitaZeny . ')</span>' .
-                       ' <span class="m">(' . $prihlasenoMuzu . '/' . ($kapacitaMuzi + $kapacitaUniverzalni) . ')</span>';
-            case 'm':
-                return ' <span class="f">(' . $prihlasenoZen . '/' . ($kapacitaZeny + $kapacitaUniverzalni) . ')</span>' .
-                       ' <span class="m">(' . $prihlasenoMuzu . '/' . $kapacitaMuzi . ')</span>';
-            default :
-                return '';
-        }
+        return match ($this->volnoPro()) {
+            VolnoProEnum::PRO_VSECHNY,
+            VolnoProEnum::PLNO     => " ({$prihlasenoCelkem}/{$kapacitaCelkova})",
+            VolnoProEnum::JEN_ZENY => ' <span class="f">(' . $prihlasenoZen . '/' . $kapacitaZeny . ')</span>' .
+                       ' <span class="m">(' . $prihlasenoMuzu . '/' . ($kapacitaMuzi + $kapacitaUniverzalni) . ')</span>',
+            VolnoProEnum::JEN_MUZI => ' <span class="f">(' . $prihlasenoZen . '/' . ($kapacitaZeny + $kapacitaUniverzalni) . ')</span>' .
+                       ' <span class="m">(' . $prihlasenoMuzu . '/' . $kapacitaMuzi . ')</span>',
+        };
     }
 
     /**
@@ -1985,6 +1980,10 @@ SQL
             return; // ignorovat pokud přihlášen není tak či tak
         }
 
+        // Stav zaplněnosti před odhlášením – zjistíme rozdíl oproti stavu po odhlášení,
+        // abychom sledujícím poslali mail jen o místě, které se opravdu nově uvolnilo.
+        $volnoProPredOdhlasenim = $this->volnoPro();
+
         $tym = $this->tymova()
             ? AktivitaTym::najdiPodleUzivateleAktivity($u->id(), $this->id())
             : null ;
@@ -2037,17 +2036,19 @@ SQL,
         if ($this->tymova()) {
             AktivitaTym::odhlasUzivateleOdTymu($idUzivatele, $idAktivity);
         }
-        // Poslání mailu lidem na watchlistu.
-        // volno() zde ještě odráží stav před odhlášením (DELETE výše neinvaliduje cache přihlášených).
-        // Sledovat lze i genderově plnou aktivitu, kde volno() vrací 'f'/'m' (plno jen pro jedno pohlaví),
-        // ne jen beznadějně plnou 'x' — mail proto posíláme, kdykoli byla aktivita před odhlášením
-        // plná alespoň pro jedno pohlaví.
-        $volnoPredOdhlasenim = $this->volno();
-        $bylaPlna            = in_array($volnoPredOdhlasenim, ['x', 'f', 'm'], true);
-        if ($bylaPlna && !($params & self::NEPOSILAT_MAILY_SLEDUJICIM)) {
-            $this->poslatMailSledujicim();
-        }
         $this->refresh();
+
+        // Poslání mailu lidem na watchlistu. Uvolnit se mohlo místo pro jedno pohlaví (genderové) i pro
+        // obě (univerzální), proto porovnáme zaplněnost před a po odhlášení a mailujeme jen sledující těch
+        // pohlaví, pro která volné místo předtím nebylo a teď je (jinak se pro ně nic nového neuvolnilo).
+        // Sledovat lze i genderově plnou aktivitu (volnoPro() === JEN_ZENY/JEN_MUZI), ne jen beznadějně plnou.
+        $pohlaviSNoveUvolnenymMistem = array_values(array_filter(
+            $this->volnoPro()->pohlaviSVolnymMistem(),
+            static fn (string $pohlavi): bool => ! $volnoProPredOdhlasenim->proPohlaviJeVolno($pohlavi),
+        ));
+        if ($pohlaviSNoveUvolnenymMistem && ! ($params & self::NEPOSILAT_MAILY_SLEDUJICIM)) {
+            $this->poslatMailSledujicim($pohlaviSNoveUvolnenymMistem);
+        }
 
         $this->touchDirtyFlag(ProgramStaticFileType::OBSAZENOSTI);
 
@@ -2378,16 +2379,21 @@ SQL
     }
 
     /**
-     * Pošle mail potenciálním náhradníkům o volném místě na aktivitě.
+     * Pošle sledujícím mail o uvolněném místě. Adresáty omezí na pohlaví, pro která se místo uvolnilo –
+     * ostatní se stejně nemají kam nově přihlásit.
+     *
+     * @param list<string> $pohlaviSVolnymMistem kódy pohlaví ({@see Pohlavi}), pro která se místo uvolnilo
      */
-    private function poslatMailSledujicim(): void
+    private function poslatMailSledujicim(array $pohlaviSVolnymMistem): void
     {
-        $emaily = dbOneArray("
-      SELECT u.email1_uzivatele
-      FROM akce_prihlaseni_spec a
-      JOIN uzivatele_hodnoty u ON u.id_uzivatele = a.id_uzivatele
-      WHERE a.id_akce = $0 AND a.id_stavu_prihlaseni = $1
-    ", [$this->id(), StavPrihlaseni::SLEDUJICI]);
+        $emaily = dbOneArray('
+      SELECT uzivatele_hodnoty.email1_uzivatele
+      FROM akce_prihlaseni_spec
+      JOIN uzivatele_hodnoty ON uzivatele_hodnoty.id_uzivatele = akce_prihlaseni_spec.id_uzivatele
+      WHERE akce_prihlaseni_spec.id_akce = $0
+        AND akce_prihlaseni_spec.id_stavu_prihlaseni = $1
+        AND uzivatele_hodnoty.pohlavi IN ($2)
+    ', [$this->id(), StavPrihlaseni::SLEDUJICI, $pohlaviSVolnymMistem]);
         foreach ($emaily as $email) {
             $mail = GcMail::vytvorZGlobals();
             $mail->predmet('Gamecon: Volné místo na aktivitě ' . $this->nazev());
@@ -2481,7 +2487,7 @@ SQL
 
             // Re-check capacity with fresh data inside the lock
             $this->refresh();
-            if (!(self::IGNOROVAT_LIMIT & $parametry) && $this->volno() !== 'u' && $this->volno() !== $uzivatel->pohlavi()) {
+            if (! (self::IGNOROVAT_LIMIT & $parametry) && ! $this->volnoPro()->proPohlaviJeVolno($uzivatel->pohlavi())) {
                 dbCommit();
                 throw new \Chyba(hlaska('plno'));
             }
@@ -2547,7 +2553,7 @@ SQL
         string $pohlavi = "",
         int $parametry = 0,
     ) {
-        if (!(self::IGNOROVAT_LIMIT & $parametry) && $this->volno() !== 'u' && $this->volno() !== $pohlavi) {
+        if (! (self::IGNOROVAT_LIMIT & $parametry) && ! $this->volnoPro()->proPohlaviJeVolno($pohlavi)) {
             throw new \Chyba(hlaska('plno'));
         }
     }
@@ -3183,17 +3189,17 @@ SQL
 HTML
                        . $this->formatujDuvodProTesting('Aktivita už je zamknutá');
             } else {
-                $volno = $this->volno();
-                if ($volno === 'u' || $volno == $u->pohlavi()) {
+                $volnoPro = $this->volnoPro();
+                if ($volnoPro->proPohlaviJeVolno($u->pohlavi())) {
                     $out =
                         '<form method="post" style="display:inline">' .
                         '<input type="hidden" name="prihlasit" value="' . $this->id() . '">' .
                         '<a href="#" onclick="this.parentNode.submit(); return false">přihlásit</a>' .
                         '</form>';
-                } elseif ($volno === 'f') {
+                } elseif ($volnoPro === VolnoProEnum::JEN_ZENY) {
                     // volno už je jen pro ženy → pro tohoto uživatele (muže) je plno, smí proto sledovat
                     $out = 'pouze ženská místa' . $this->prihlasovatkoSledovani($u, ' | ');
-                } elseif ($volno === 'm') {
+                } elseif ($volnoPro === VolnoProEnum::JEN_MUZI) {
                     $out = 'pouze mužská místa' . $this->prihlasovatkoSledovani($u, ' | ');
                 } else {
                     $out = $this->prihlasovatkoSledovani($u);
@@ -3710,7 +3716,7 @@ SQL,
     }
 
     /** Vrátí typ volných míst na aktivitě */
-    public function volno(?DataSourcesCollector $dataSourcesCollector = null)
+    public function volnoPro(?DataSourcesCollector $dataSourcesCollector = null): VolnoProEnum
     {
         $prihlasenoMuzu = $this->pocetPrihlasenychMuzu($dataSourcesCollector);
         $prihlasenoZen = $this->pocetPrihlasenychZen($dataSourcesCollector);
@@ -3718,20 +3724,20 @@ SQL,
         $kapacitaMuzu = $this->a[Sql::KAPACITA_M];
         $kapacitaZen = $this->a[Sql::KAPACITA_F];
         if (($unisexKapacita + $kapacitaMuzu + $kapacitaZen) <= 0) {
-            return 'u'; //aktivita bez omezení
+            return VolnoProEnum::PRO_VSECHNY; // aktivita bez omezení
         }
         if ($prihlasenoMuzu + $prihlasenoZen >= $unisexKapacita + $kapacitaMuzu + $kapacitaZen) {
-            return 'x'; //beznadějně plno
+            return VolnoProEnum::PLNO; // beznadějně plno
         }
         if ($prihlasenoMuzu >= $unisexKapacita + $kapacitaMuzu) {
-            return 'f'; //muži zabrali všechna univerzální i mužská místa
+            return VolnoProEnum::JEN_ZENY; // muži zabrali všechna univerzální i mužská místa
         }
         if ($prihlasenoZen >= $unisexKapacita + $kapacitaZen) {
-            return 'm'; //LIKE WTF? (opak předchozího)
+            return VolnoProEnum::JEN_MUZI; // ženy zabraly všechna univerzální i ženská místa
         }
 
-        //else
-        return 'u'; //je volno a žádné pohlaví nevyžralo limit míst
+        // else
+        return VolnoProEnum::PRO_VSECHNY; // je volno a žádné pohlaví nevyžralo limit míst
     }
 
     public function getKapacitaUnisex(): int
@@ -4335,8 +4341,8 @@ SQL,
             razeni: $razeni,
         );
         if ($flags & self::JEN_VOLNE) {
-            foreach ($aktivity as $i => $a) {
-                if ($a->volno() === 'x') {
+            foreach ($aktivity as $i => $aktivita) {
+                if ($aktivita->volnoPro() === VolnoProEnum::PLNO) {
                     unset($aktivity[$i]);
                 }
             }

--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -2037,8 +2037,14 @@ SQL,
         if ($this->tymova()) {
             AktivitaTym::odhlasUzivateleOdTymu($idUzivatele, $idAktivity);
         }
-        // Poslání mailu lidem na watchlistu
-        if ($this->volno() === "x" && !($params & self::NEPOSILAT_MAILY_SLEDUJICIM)) { // Před odhlášením byla aktivita plná
+        // Poslání mailu lidem na watchlistu.
+        // volno() zde ještě odráží stav před odhlášením (DELETE výše neinvaliduje cache přihlášených).
+        // Sledovat lze i genderově plnou aktivitu, kde volno() vrací 'f'/'m' (plno jen pro jedno pohlaví),
+        // ne jen beznadějně plnou 'x' — mail proto posíláme, kdykoli byla aktivita před odhlášením
+        // plná alespoň pro jedno pohlaví.
+        $volnoPredOdhlasenim = $this->volno();
+        $bylaPlna            = in_array($volnoPredOdhlasenim, ['x', 'f', 'm'], true);
+        if ($bylaPlna && !($params & self::NEPOSILAT_MAILY_SLEDUJICIM)) {
             $this->poslatMailSledujicim();
         }
         $this->refresh();

--- a/model/Aktivita/VolnoProEnum.php
+++ b/model/Aktivita/VolnoProEnum.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Aktivita;
+
+use Gamecon\Uzivatel\Pohlavi;
+
+/**
+ * Pro koho je na aktivitě volné místo.
+ *
+ * Hodnoty backingu odpovídají historickým řetězcům z {@see Aktivita::volnoPro()}
+ * a přímo pohlaví ({@see Pohlavi::ZENA_KOD} = 'f', {@see Pohlavi::MUZ_KOD} = 'm'),
+ * aby šly srovnávat s Uzivatel::pohlavi().
+ */
+enum VolnoProEnum: string
+{
+    /** Volno pro všechny (aktivita bez omezení nebo zbývají univerzální místa). */
+    case PRO_VSECHNY = 'u';
+
+    /** Beznadějně plno – volné místo není pro nikoho. */
+    case PLNO = 'x';
+
+    /** Volno už jen pro ženy (muži vyžrali všechna univerzální i mužská místa). */
+    case JEN_ZENY = 'f';
+
+    /** Volno už jen pro muže (ženy vyžraly všechna univerzální i ženská místa). */
+    case JEN_MUZI = 'm';
+
+    /**
+     * Má uživatel daného pohlaví na aktivitě volné místo?
+     */
+    public function proPohlaviJeVolno(string $kodPohlavi): bool
+    {
+        return $this === self::PRO_VSECHNY
+            || $this->value === $kodPohlavi;
+    }
+
+    /**
+     * Kódy pohlaví, pro která je na aktivitě volné místo (u PRO_VSECHNY obě, u PLNO žádné).
+     *
+     * @return list<string>
+     */
+    public function pohlaviSVolnymMistem(): array
+    {
+        return match ($this) {
+            self::PRO_VSECHNY => [Pohlavi::MUZ_KOD, Pohlavi::ZENA_KOD],
+            self::JEN_MUZI    => [Pohlavi::MUZ_KOD],
+            self::JEN_ZENY    => [Pohlavi::ZENA_KOD],
+            self::PLNO        => [],
+        };
+    }
+}

--- a/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
+++ b/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
@@ -10,6 +10,7 @@ use Gamecon\Aktivita\Aktivita;
 use Gamecon\Aktivita\SqlStruktura\AkceSeznamSqlStruktura as AktivitaSql;
 use Gamecon\Aktivita\StavAktivity;
 use Gamecon\Aktivita\TypAktivity;
+use Gamecon\Aktivita\VolnoProEnum;
 use Gamecon\Kanaly\MailLogger;
 use Gamecon\Role\Role;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
@@ -68,11 +69,11 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
 
     public function testUplnePlnaAktivitaNabidneSledovaniBeztextu(): void
     {
-        // regrese: u úplně plné aktivity (volno() === 'x') zůstává jen odkaz na sledování, bez textu „pouze … místa"
+        // regrese: u úplně plné aktivity (volnoPro() === PLNO) zůstává jen odkaz na sledování, bez textu „pouze … místa"
         $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 0);
         $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
-        self::assertSame('x', $aktivita->volno());
+        self::assertSame(VolnoProEnum::PLNO, $aktivita->volnoPro());
 
         $dalsiMuz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $out = $aktivita->prihlasovatko($dalsiMuz, 0);
@@ -88,8 +89,8 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
 
         $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
-        // Pro muže je aktivita plná (zbývá jen ženské místo), ale volno() vrací 'f', ne 'x'
-        self::assertSame('f', $aktivita->volno());
+        // Pro muže je aktivita plná (zbývá jen ženské místo), volnoPro() vrací JEN_ZENY, ne PLNO
+        self::assertSame(VolnoProEnum::JEN_ZENY, $aktivita->volnoPro());
 
         $sledujici = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $aktivita->prihlasSledujiciho($sledujici, $sledujici);
@@ -100,19 +101,93 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
         self::assertSame(
             $mailuPredOdhlasenim + 1,
             $this->pocetMailuOUvolnenemMiste($nazev),
-            'Po uvolnění mužského místa v gender-plné aktivitě má sledujícímu přijít mail o uvolněném místě',
+            'Po uvolnění mužského místa v gender-plné aktivitě má sledujícímu muži přijít mail o uvolněném místě',
+        );
+    }
+
+    public function testMailNedostaneSledujiciOpacnehoPohlaviNezSeUvolnilo(): void
+    {
+        // uvolní se mužské místo → sledující žena (pro kterou bylo volno už předtím) mail nedostane
+        $nazev = 'Sledovaná jen ženská ' . self::unikatniCislo();
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 5, nazev: $nazev);
+
+        $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        self::assertSame(VolnoProEnum::JEN_ZENY, $aktivita->volnoPro());
+
+        $sledujiciZena = $this->prihlasenyUzivatelNaGc(Pohlavi::ZENA_KOD);
+        $aktivita->prihlasSledujiciho($sledujiciZena, $sledujiciZena);
+
+        $mailuPredOdhlasenim = $this->pocetMailuOUvolnenemMiste($nazev);
+        $aktivita->odhlas($muzNaMiste, $muzNaMiste, 'test');
+
+        self::assertSame(
+            $mailuPredOdhlasenim,
+            $this->pocetMailuOUvolnenemMiste($nazev),
+            'Uvolnilo se mužské místo, sledující ženě (pro kterou volno bylo i předtím) mail chodit nemá',
+        );
+    }
+
+    public function testUvolneneUniverzalniMistoPosleMailSledujicimObouPohlavi(): void
+    {
+        // univerzální (unisex) místo → po odhlášení muže je volno pro obě pohlaví,
+        // takže mail má dostat i sledující žena, nejen muž
+        $nazev = 'Sledovaná unisex ' . self::unikatniCislo();
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 0, kapacitaZen: 0, kapacitaUnisex: 1, nazev: $nazev);
+
+        $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        self::assertSame(VolnoProEnum::PLNO, $aktivita->volnoPro());
+
+        $sledujiciMuz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $sledujiciZena = $this->prihlasenyUzivatelNaGc(Pohlavi::ZENA_KOD);
+        $aktivita->prihlasSledujiciho($sledujiciMuz, $sledujiciMuz);
+        $aktivita->prihlasSledujiciho($sledujiciZena, $sledujiciZena);
+
+        $mailuPredOdhlasenim = $this->pocetMailuOUvolnenemMiste($nazev);
+        $aktivita->odhlas($muzNaMiste, $muzNaMiste, 'test');
+
+        self::assertSame(
+            $mailuPredOdhlasenim + 2,
+            $this->pocetMailuOUvolnenemMiste($nazev),
+            'Uvolněné univerzální místo je pro obě pohlaví, mail mají dostat oba sledující',
+        );
+    }
+
+    public function testUvolneneUniverzalniMistoPoOdhlaseniZenyPosleMailObemaPohlavim(): void
+    {
+        // stejné jako výše, ale odhlašuje se žena – příjemci se řídí volným místem, ne pohlavím odhlašovaného
+        $nazev = 'Sledovaná unisex žena ' . self::unikatniCislo();
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 0, kapacitaZen: 0, kapacitaUnisex: 1, nazev: $nazev);
+
+        $zenaNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::ZENA_KOD);
+        $aktivita->prihlas($zenaNaMiste, $zenaNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        self::assertSame(VolnoProEnum::PLNO, $aktivita->volnoPro());
+
+        $sledujiciMuz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $sledujiciZena = $this->prihlasenyUzivatelNaGc(Pohlavi::ZENA_KOD);
+        $aktivita->prihlasSledujiciho($sledujiciMuz, $sledujiciMuz);
+        $aktivita->prihlasSledujiciho($sledujiciZena, $sledujiciZena);
+
+        $mailuPredOdhlasenim = $this->pocetMailuOUvolnenemMiste($nazev);
+        $aktivita->odhlas($zenaNaMiste, $zenaNaMiste, 'test');
+
+        self::assertSame(
+            $mailuPredOdhlasenim + 2,
+            $this->pocetMailuOUvolnenemMiste($nazev),
+            'Po odhlášení ženy z univerzálního místa je volno pro obě pohlaví, mail mají dostat oba sledující',
         );
     }
 
     public function testUvolneneMistoUUplnePlneAktivityPosleMailSledujicimu(): void
     {
-        // kontrola, že oprava nerozbila původní chování u „beznadějně plné" aktivity (volno() === 'x')
+        // kontrola, že oprava nerozbila původní chování u „beznadějně plné" aktivity (volnoPro() === PLNO)
         $nazev = 'Sledovaná úplně plná ' . self::unikatniCislo();
         $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 0, nazev: $nazev);
 
         $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
-        self::assertSame('x', $aktivita->volno());
+        self::assertSame(VolnoProEnum::PLNO, $aktivita->volnoPro());
 
         $sledujici = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
         $aktivita->prihlasSledujiciho($sledujici, $sledujici);
@@ -137,6 +212,7 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
     private function genderoveRozdelenaAktivita(
         int $kapacitaMuzu,
         int $kapacitaZen,
+        int $kapacitaUnisex = 0,
         string $nazev = 'Genderově rozdělená aktivita',
     ): Aktivita {
         dbInsert(AktivitaSql::AKCE_SEZNAM_TABULKA, [
@@ -146,7 +222,7 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
             AktivitaSql::STAV       => StavAktivity::AKTIVOVANA,
             AktivitaSql::ZACATEK    => ROCNIK . '-07-16 10:00:00',
             AktivitaSql::KONEC      => ROCNIK . '-07-16 13:00:00',
-            AktivitaSql::KAPACITA   => 0,
+            AktivitaSql::KAPACITA   => $kapacitaUnisex,
             AktivitaSql::KAPACITA_M => $kapacitaMuzu,
             AktivitaSql::KAPACITA_F => $kapacitaZen,
             AktivitaSql::CENA       => 0,
@@ -162,7 +238,7 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
             $muz = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
             $aktivita->prihlas($muz, $muz, Aktivita::UKAZAT_DETAILY_CHYBY);
         }
-        self::assertSame('f', $aktivita->volno(), 'Muži měli vyžrat všechna mužská místa');
+        self::assertSame(VolnoProEnum::JEN_ZENY, $aktivita->volnoPro(), 'Muži měli vyžrat všechna mužská místa');
     }
 
     private function prihlasenyUzivatelNaGc(string $pohlavi): \Uzivatel

--- a/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
+++ b/tests/Aktivity/SledovaniGenderoveRozdeleneAktivityTest.php
@@ -10,6 +10,7 @@ use Gamecon\Aktivita\Aktivita;
 use Gamecon\Aktivita\SqlStruktura\AkceSeznamSqlStruktura as AktivitaSql;
 use Gamecon\Aktivita\StavAktivity;
 use Gamecon\Aktivita\TypAktivity;
+use Gamecon\Kanaly\MailLogger;
 use Gamecon\Role\Role;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\Tests\Db\AbstractTestDb;
@@ -80,10 +81,66 @@ class SledovaniGenderoveRozdeleneAktivityTest extends AbstractTestDb
         self::assertStringContainsString('sledovat', $out);
     }
 
-    private function genderoveRozdelenaAktivita(int $kapacitaMuzu, int $kapacitaZen): Aktivita
+    public function testUvolneneMistoUGenderovePlneAktivityPosleMailSledujicimu(): void
     {
+        $nazev = 'Sledovaná gender-plná ' . self::unikatniCislo();
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 1, nazev: $nazev);
+
+        $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        // Pro muže je aktivita plná (zbývá jen ženské místo), ale volno() vrací 'f', ne 'x'
+        self::assertSame('f', $aktivita->volno());
+
+        $sledujici = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlasSledujiciho($sledujici, $sledujici);
+
+        $mailuPredOdhlasenim = $this->pocetMailuOUvolnenemMiste($nazev);
+        $aktivita->odhlas($muzNaMiste, $muzNaMiste, 'test');
+
+        self::assertSame(
+            $mailuPredOdhlasenim + 1,
+            $this->pocetMailuOUvolnenemMiste($nazev),
+            'Po uvolnění mužského místa v gender-plné aktivitě má sledujícímu přijít mail o uvolněném místě',
+        );
+    }
+
+    public function testUvolneneMistoUUplnePlneAktivityPosleMailSledujicimu(): void
+    {
+        // kontrola, že oprava nerozbila původní chování u „beznadějně plné" aktivity (volno() === 'x')
+        $nazev = 'Sledovaná úplně plná ' . self::unikatniCislo();
+        $aktivita = $this->genderoveRozdelenaAktivita(kapacitaMuzu: 1, kapacitaZen: 0, nazev: $nazev);
+
+        $muzNaMiste = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlas($muzNaMiste, $muzNaMiste, Aktivita::UKAZAT_DETAILY_CHYBY);
+        self::assertSame('x', $aktivita->volno());
+
+        $sledujici = $this->prihlasenyUzivatelNaGc(Pohlavi::MUZ_KOD);
+        $aktivita->prihlasSledujiciho($sledujici, $sledujici);
+
+        $mailuPredOdhlasenim = $this->pocetMailuOUvolnenemMiste($nazev);
+        $aktivita->odhlas($muzNaMiste, $muzNaMiste, 'test');
+
+        self::assertSame(
+            $mailuPredOdhlasenim + 1,
+            $this->pocetMailuOUvolnenemMiste($nazev),
+            'Po uvolnění místa v úplně plné aktivitě má sledujícímu přijít mail o uvolněném místě',
+        );
+    }
+
+    private function pocetMailuOUvolnenemMiste(string $nazevAktivity): int
+    {
+        // GcMail loguje každé odeslání do LOGY/maily.sqlite; předmět je unikátní podle názvu aktivity
+        return (new MailLogger(LOGY . '/maily.sqlite'))
+            ->spocitej('Volné místo na aktivitě ' . $nazevAktivity);
+    }
+
+    private function genderoveRozdelenaAktivita(
+        int $kapacitaMuzu,
+        int $kapacitaZen,
+        string $nazev = 'Genderově rozdělená aktivita',
+    ): Aktivita {
         dbInsert(AktivitaSql::AKCE_SEZNAM_TABULKA, [
-            AktivitaSql::NAZEV_AKCE => 'Genderově rozdělená aktivita',
+            AktivitaSql::NAZEV_AKCE => $nazev,
             AktivitaSql::TYP        => TypAktivity::LARP,
             AktivitaSql::ROK        => ROCNIK,
             AktivitaSql::STAV       => StavAktivity::AKTIVOVANA,

--- a/tests/Aktivity/VolnoProEnumTest.php
+++ b/tests/Aktivity/VolnoProEnumTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Aktivity;
+
+use Gamecon\Aktivita\VolnoProEnum;
+use Gamecon\Uzivatel\Pohlavi;
+use PHPUnit\Framework\TestCase;
+
+class VolnoProEnumTest extends TestCase
+{
+    public function testPohlaviSVolnymMistem(): void
+    {
+        self::assertSame(
+            [Pohlavi::MUZ_KOD, Pohlavi::ZENA_KOD],
+            VolnoProEnum::PRO_VSECHNY->pohlaviSVolnymMistem(),
+        );
+        self::assertSame([Pohlavi::MUZ_KOD], VolnoProEnum::JEN_MUZI->pohlaviSVolnymMistem());
+        self::assertSame([Pohlavi::ZENA_KOD], VolnoProEnum::JEN_ZENY->pohlaviSVolnymMistem());
+        self::assertSame([], VolnoProEnum::PLNO->pohlaviSVolnymMistem());
+    }
+
+    public function testProVsechnyJeVolnoProObePohlavi(): void
+    {
+        self::assertTrue(VolnoProEnum::PRO_VSECHNY->proPohlaviJeVolno(Pohlavi::MUZ_KOD));
+        self::assertTrue(VolnoProEnum::PRO_VSECHNY->proPohlaviJeVolno(Pohlavi::ZENA_KOD));
+    }
+
+    public function testPlnoNeniVolnoProNikoho(): void
+    {
+        self::assertFalse(VolnoProEnum::PLNO->proPohlaviJeVolno(Pohlavi::MUZ_KOD));
+        self::assertFalse(VolnoProEnum::PLNO->proPohlaviJeVolno(Pohlavi::ZENA_KOD));
+    }
+
+    public function testGenderoveOmezenyStavJeVolnoJenProSvePohlavi(): void
+    {
+        self::assertTrue(VolnoProEnum::JEN_ZENY->proPohlaviJeVolno(Pohlavi::ZENA_KOD));
+        self::assertFalse(VolnoProEnum::JEN_ZENY->proPohlaviJeVolno(Pohlavi::MUZ_KOD));
+
+        self::assertTrue(VolnoProEnum::JEN_MUZI->proPohlaviJeVolno(Pohlavi::MUZ_KOD));
+        self::assertFalse(VolnoProEnum::JEN_MUZI->proPohlaviJeVolno(Pohlavi::ZENA_KOD));
+    }
+
+    public function testBackingHodnotyOdpovidajiPohlaviKodum(): void
+    {
+        // odhlas() posílá volnoPro->value do SQL dotazu proti sloupci pohlaví – hodnoty musí sedět
+        self::assertSame(Pohlavi::ZENA_KOD, VolnoProEnum::JEN_ZENY->value);
+        self::assertSame(Pohlavi::MUZ_KOD, VolnoProEnum::JEN_MUZI->value);
+    }
+}


### PR DESCRIPTION
[Trello 1473](https://trello.com/c/AP2vlN3t) — sledujícím nechodil mail o uvolněném místě u genderově plné aktivity.

## Problém

Uživatel může *sledovat* aktivitu, která je plná jen genderově (zabraná všechna místa jednoho pohlaví, druhé má ještě volno). Když se pak v takové aktivitě uvolnilo místo, sledujícím **nepřišel mail** o uvolnění. Navíc – i kdyby chodil – dostali by ho všichni sledující bez ohledu na to, pro čí pohlaví se místo uvolnilo.

## Řešení

### 1. Oprava triggeru mailu (`Aktivita::odhlas()`)

- Stav zaplněnosti se **zjistí na začátku** `odhlas()` (před jakoukoli změnou), aktivita se **refreshne před odesíláním** a mail se pak posílá podle **aktuální** zaplněnosti — žádné spoléhání na to, že „DELETE neinvaliduje cache".
- Mail se pošle, jen když se místo pro pohlaví odhlašovaného **opravdu nově uvolnilo** (předtím pro něj volno nebylo, teď je).

### 2. `poslatMailSledujicim` cílí podle pohlaví

Nový parametr `VolnoProEnum $proKohoSeUvolnilo` — dotaz na příjemce filtruje `uzivatele_hodnoty.pohlavi`, takže mail dostanou **jen sledující toho pohlaví, pro které se místo uvolnilo** (ostatní se stejně nemají kam nově přihlásit).

### 3. Refaktor `volno()` → `volnoPro()` + enum

- Metoda `volno()` přejmenována na **`volnoPro()`** a její návratové řetězce `u`/`x`/`f`/`m` nahrazeny stringovým enumem **`VolnoProEnum`** (`PRO_VSECHNY`/`PLNO`/`JEN_ZENY`/`JEN_MUZI`).
- Backing hodnoty enumu zůstávají `u`/`x`/`f`/`m` (a `f`/`m` odpovídají `Pohlavi::ZENA_KOD`/`MUZ_KOD`), takže srovnání s pohlavím uživatele i SQL filtr fungují přímo.
- Nový helper `VolnoProEnum::proPohlaviJeVolno($kodPohlavi)` sjednocuje dřívější `volno() === 'u' || volno() === $pohlavi` roztroušené po kontrolách kapacity.
- Všechna volání aktualizována (obsazenost, kontrola kapacity při přihlášení, přihlašovátko, filtr „jen volné").

## Testy

Nejdřív test odhalující bug, pak oprava. Odesílací cesta předtím neměla žádné pokrytí:

- `testUvolneneMistoUGenderovePlneAktivityPosleMailSledujicimu` — před opravou **padal** (0 mailů místo 1), teď prochází.
- `testMailNedostaneSledujiciOpacnehoPohlaviNezSeUvolnilo` — ověřuje gender filtr: uvolní se mužské místo → sledující žena mail nedostane.
- `testUvolneneMistoUUplnePlneAktivityPosleMailSledujicimu` — hlídá původní chování u úplně plné aktivity.
- `VolnoProEnumTest` — kontrakt enumu (`proPohlavi`, `proPohlaviJeVolno`, backing hodnoty = kódy pohlaví).

Testy sledování čtou skutečný log odeslaných mailů (`LOGY/maily.sqlite`), takže ověřují celou cestu `odhlas()` → `poslatMailSledujicim()` → `GcMail`.

Celá sada (830 testů) prochází.

## Jak ověřit ručně

Na preview/betě:
1. Program → vyber genderově rozdělenou aktivitu (kapacita M i F > 0), zaplň všechna místa jednoho pohlaví.
2. Jako jiný uživatel **téhož (plného) pohlaví** klikni „sledovat". (A pro kontrolu ještě někdo opačného pohlaví.)
3. Odhlaš jednoho účastníka z plného pohlaví.
4. Mail „Gamecon: Volné místo na aktivitě …" má dorazit **jen sledujícímu plného pohlaví**, ne tomu opačného (na betě/preview v Mailpit / `webmail.preview.gamecon.cz`).
