### PR TITLE
Spustit CI testy jen jednou na commit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,11 +28,12 @@ on:
             - ready_for_review
 
 # Feature větve spouští testy přes oba triggery (push i pull_request),
-# takže po otevření PR by stejný commit běžel dvakrát. Skupina klíčovaná
-# na větev (head_ref na PR, jinak ref) je u obou běhů stejná, takže
+# takže po otevření PR by stejný commit běžel dvakrát. Klíčujeme na SHA
+# hlavičkového commitu – ten je u push i u odpovídajícího pull_request běhu
+# totožný (na PR je github.sha merge commit, proto bereme head.sha), takže
 # druhý běh ten první zruší a testy proběhnou jen jednou.
 concurrency:
-    group: run-tests-${{ github.head_ref || github.ref }}
+    group: run-tests-${{ github.event.pull_request.head.sha || github.sha }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,16 +2,15 @@ name: Run tests
 
 # yamllint disable-line rule:truthy
 on:
-    push:
-        branches:
-            # Filtr s negacemi musí mít aspoň jeden pozitivní vzor, jinak
-            # nematchuje NIC (GitHub Actions): bez '**' se testy na push do
-            # feature větví vůbec nespouští.
-            - '**'
-            # beta a main si pouští testy samy, před deployem,
-            # viz deploy-beta.yml a deploy-ostra.yml
-            - '!beta'
-            - '!main'
+    # Jen pull_request, žádný push. Kdyby testy spouštěly oba triggery,
+    # vznikly by na jednom commitu dva checky stejného jména „Run tests job“.
+    # Zrušit ten druhý přes concurrency nestačí: zrušený běh se v required
+    # status checks počítá jako selhání, takže PR zůstane blokovaný i s
+    # zelenými testy. Který z běhů zrušení potká je navíc závod, takže se to
+    # nedá obejít ani nastavením branch protection na konkrétní trigger.
+    #
+    # beta a main si pouští testy samy, před deployem,
+    # viz deploy-beta.yml a deploy-ostra.yml
     workflow_dispatch:
         inputs:
             branch:
@@ -27,13 +26,12 @@ on:
             - reopened
             - ready_for_review
 
-# Feature větve spouští testy přes oba triggery (push i pull_request),
-# takže po otevření PR by stejný commit běžel dvakrát. Klíčujeme na SHA
-# hlavičkového commitu – ten je u push i u odpovídajícího pull_request běhu
-# totožný (na PR je github.sha merge commit, proto bereme head.sha), takže
-# druhý běh ten první zruší a testy proběhnou jen jednou.
+# Nové pushnutí do PR ruší předchozí, ještě běžící testy téže větve –
+# na starší commit už stejně nikdo nečeká. Klíčujeme na větev, ne na SHA:
+# zrušen tak může být jen běh nad commitem, který byl mezitím přepsán, a
+# nikdy ne druhý běh nad tím samým commitem.
 concurrency:
-    group: run-tests-${{ github.event.pull_request.head.sha || github.sha }}
+    group: run-tests-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Workflow „Run tests" se spouští na `push` i `pull_request`, takže po otevření PR běžel stejný commit **dvakrát** (jednou z push eventu, jednou z pull_request eventu).

Concurrency guard tu už byl, ale klíč se mezi eventy lišil:
- `push`: `github.head_ref` je prázdný → fallback na `github.ref` = `refs/heads/<větev>`
- `pull_request`: `github.head_ref` = holý `<větev>`

Dvě různé group-name → `cancel-in-progress` nikdy jeden běh proti druhému nezrušil.

## Oprava

Klíčovat concurrency group na **SHA hlavičkového commitu**, který je u obou eventů pro tentýž commit totožný (`github.event.pull_request.head.sha` na PR — protože `github.sha` je tam merge commit — jinak `github.sha`). Druhý běh tak zruší první a testy proběhnou jen jednou. Push i PR trigger zůstávají (testy poběží i na push do větve bez PR).
