### PR TITLE
Infopult: výběr dnů a jídel při tisku stravenek

### DIFF
--- a/admin/scripts/modules/infopult/infopult.php
+++ b/admin/scripts/modules/infopult/infopult.php
@@ -223,6 +223,17 @@ if ($uPracovni) {
         $x->assign('jidloHtml', $shop->jidloHtml(true));
         if ($shop->objednalNejakeJidlo()) {
             $x->assign('urlStravenky', URL_ADMIN . '/reporty/stravenky?format=html&id_uzivatele=' . $uPracovni->id());
+            foreach ($shop->objednanaJidlaDleDnu() as $denData) {
+                $x->assign('denStravenky', $denData['den']);
+                foreach ($denData['jidla'] as $jidloData) {
+                    $x->assign([
+                        'jidloStravenkyNazev' => $jidloData['nazev'],
+                        'jidloStravenkyDruh'  => $jidloData['druh'],
+                    ]);
+                    $x->parse('infopult.uzivatel.jidlo.odkazStravenky.den.jidlo');
+                }
+                $x->parse('infopult.uzivatel.jidlo.odkazStravenky.den');
+            }
             $x->parse('infopult.uzivatel.jidlo.odkazStravenky');
         }
         $x->parse('infopult.uzivatel.jidlo');

--- a/admin/scripts/modules/infopult/infopult.xtpl
+++ b/admin/scripts/modules/infopult/infopult.xtpl
@@ -209,6 +209,63 @@
   body.infopult-modal-je-otevreny {
     overflow: hidden;
   }
+
+  .stravenky-modal__uvod {
+    margin: 0 0 12px;
+    color: #4f5b67;
+  }
+
+  .stravenky-modal__dny {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  .stravenky-modal__den-skupina {
+    margin: 0;
+    padding: 8px 10px;
+    border: 1px solid #d7dde4;
+    border-radius: 8px;
+  }
+
+  .stravenky-modal__den {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    cursor: pointer;
+    text-transform: capitalize;
+  }
+
+  .stravenky-modal__jidla {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    margin: 8px 0 0 24px;
+  }
+
+  .stravenky-modal__jidlo {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+
+  .stravenky-modal__den input,
+  .stravenky-modal__jidlo input {
+    margin: 0;
+  }
+
+  .stravenky-modal__akce {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .stravenky-modal__akce .submit-btn {
+    float: none;
+    margin: 0;
+  }
 </style>
 
 
@@ -675,7 +732,122 @@
       <input type="submit" name="zpracujJidlo" value="Uložit" class="submit-btn">
     </form>
     <!-- begin:odkazStravenky -->
-    <a href="{urlStravenky}" target="_blank">Tisk stravenek</a>
+    <button type="button" id="otevritStravenky" class="submit-btn" style="margin-top: 8px;">Tisk stravenek</button>
+
+    <div id="modalStravenky" class="infopult-modal" role="dialog" aria-modal="true" aria-labelledby="modalStravenkyNadpis" hidden>
+      <div class="infopult-modal__obsah">
+        <div class="infopult-modal__hlavicka">
+          <h3 id="modalStravenkyNadpis">Tisk stravenek</h3>
+          <button type="button" class="infopult-modal__zavrit" aria-label="Zavřít modální okno s tiskem stravenek" data-zavrit-stravenky-modal>&times;</button>
+        </div>
+        <p class="stravenky-modal__uvod">Vyber dny a jídla, pro která se stravenky vytisknou.</p>
+        <div class="stravenky-modal__dny">
+          <!-- begin:den -->
+          <fieldset class="stravenky-modal__den-skupina">
+            <label class="stravenky-modal__den">
+              <input type="checkbox" class="stravenky-modal__den-vse" checked>
+              <span>{denStravenky}</span>
+            </label>
+            <div class="stravenky-modal__jidla">
+              <!-- begin:jidlo -->
+              <label class="stravenky-modal__jidlo">
+                <input type="checkbox" name="stravenkyJidlo" value="{jidloStravenkyNazev}" checked>
+                <span>{jidloStravenkyDruh}</span>
+              </label>
+              <!-- end:jidlo -->
+            </div>
+          </fieldset>
+          <!-- end:den -->
+        </div>
+        <div class="stravenky-modal__akce">
+          <button type="button" id="tisknoutStravenky" class="submit-btn" data-url-stravenky="{urlStravenky}">Tisk</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var modal = document.getElementById('modalStravenky');
+        var tlacitkoOtevrit = document.getElementById('otevritStravenky');
+        var tlacitkoTisk = document.getElementById('tisknoutStravenky');
+        var tlacitkoZavrit = modal ? modal.querySelector('[data-zavrit-stravenky-modal]') : null;
+        var posledniAktivniElement = null;
+
+        if (!modal || !tlacitkoOtevrit || !tlacitkoTisk || !tlacitkoZavrit) {
+          return;
+        }
+
+        var zavriModal = function () {
+          modal.hidden = true;
+          document.body.classList.remove('infopult-modal-je-otevreny');
+          if (posledniAktivniElement && typeof posledniAktivniElement.focus === 'function') {
+            posledniAktivniElement.focus();
+          }
+        };
+
+        var otevriModal = function () {
+          posledniAktivniElement = document.activeElement;
+          modal.hidden = false;
+          document.body.classList.add('infopult-modal-je-otevreny');
+          tlacitkoZavrit.focus();
+        };
+
+        tlacitkoOtevrit.addEventListener('click', otevriModal);
+        tlacitkoZavrit.addEventListener('click', zavriModal);
+
+        // Zaškrtávátko dne přepíná všechna jídla daného dne; stav dne odráží stav jídel.
+        Array.prototype.forEach.call(modal.querySelectorAll('.stravenky-modal__den-skupina'), function (skupina) {
+          var denVse = skupina.querySelector('.stravenky-modal__den-vse');
+          var jidla = skupina.querySelectorAll('input[name="stravenkyJidlo"]');
+          if (!denVse || !jidla.length) {
+            return;
+          }
+          var aktualizujStavDne = function () {
+            var zaskrtnutych = 0;
+            Array.prototype.forEach.call(jidla, function (jidlo) {
+              if (jidlo.checked) {
+                zaskrtnutych++;
+              }
+            });
+            denVse.checked = zaskrtnutych === jidla.length;
+            denVse.indeterminate = zaskrtnutych > 0 && zaskrtnutych < jidla.length;
+          };
+          denVse.addEventListener('change', function () {
+            Array.prototype.forEach.call(jidla, function (jidlo) {
+              jidlo.checked = denVse.checked;
+            });
+            denVse.indeterminate = false;
+          });
+          Array.prototype.forEach.call(jidla, function (jidlo) {
+            jidlo.addEventListener('change', aktualizujStavDne);
+          });
+        });
+
+        tlacitkoTisk.addEventListener('click', function () {
+          var zaskrtnute = modal.querySelectorAll('input[name="stravenkyJidlo"]:checked');
+          var jidla = Array.prototype.map.call(zaskrtnute, function (el) { return el.value; });
+          if (!jidla.length) {
+            alert('Vyber alespoň jedno jídlo.');
+            return;
+          }
+          var url = tlacitkoTisk.getAttribute('data-url-stravenky') + '&jidla=' + encodeURIComponent(jidla.join(','));
+          window.open(url, '_blank');
+          zavriModal();
+        });
+
+        modal.addEventListener('click', function (event) {
+          if (event.target === modal) {
+            zavriModal();
+          }
+        });
+
+        document.addEventListener('keydown', function (event) {
+          if (event.key === 'Escape' && !modal.hidden) {
+            zavriModal();
+          }
+        });
+      })();
+    </script>
     <!-- end:odkazStravenky -->
   </div>
   <!-- end:jidlo -->

--- a/admin/scripts/zvlastni/reporty/stravenky.php
+++ b/admin/scripts/zvlastni/reporty/stravenky.php
@@ -21,6 +21,22 @@ $idUzivatele              = (int)get('id_uzivatele')
 $uzivatelFiltrSql         = $idUzivatele
     ? "AND uzivatele.id_uzivatele = {$idUzivatele}"
     : '';
+// Volitelný filtr dnů (např. dny=středa,čtvrtek) – den je slovo za názvem jídla v predmety.nazev.
+$dnyFiltr                 = array_values(array_filter(array_map(
+    'trim',
+    explode(',', (string)get('dny')),
+)));
+$dnyFiltrSql              = $dnyFiltr
+    ? "AND SUBSTRING(TRIM(predmety.nazev), POSITION(' ' IN TRIM(predmety.nazev)) + 1) IN ($1)"
+    : '';
+// Volitelný filtr konkrétních jídel (např. jidla=Oběd středa,Večeře středa) – plný název predmety.nazev.
+$jidlaFiltr               = array_values(array_filter(array_map(
+    'trim',
+    explode(',', (string)get('jidla')),
+)));
+$jidlaFiltrSql            = $jidlaFiltr
+    ? "AND TRIM(predmety.nazev) IN ($2)"
+    : '';
 $typUbytovani             = Shop::UBYTOVANI;
 $o                        = dbQuery(<<<SQL
     SELECT
@@ -35,6 +51,8 @@ $o                        = dbQuery(<<<SQL
     JOIN shop_predmety AS predmety
         ON predmety.id_predmetu = nakupy.id_predmetu AND predmety.typ = {$typJidlo}
     WHERE TRUE {$uzivatelFiltrSql}
+      {$dnyFiltrSql}
+      {$jidlaFiltrSql}
       AND NOT (
         TRIM(predmety.nazev) LIKE 'Snídaně%'
         AND EXISTS (
@@ -55,7 +73,7 @@ $o                        = dbQuery(<<<SQL
              poradi_dne DESC,
              poradi_jidla DESC
 SQL,
-    [0 => PodtypPredmetu::HOTEL],
+    [0 => PodtypPredmetu::HOTEL, 1 => $dnyFiltr, 2 => $jidlaFiltr],
 );
 
 $res = [];

--- a/model/Shop/Shop.php
+++ b/model/Shop/Shop.php
@@ -553,6 +553,32 @@ SQL,
         return false;
     }
 
+    /**
+     * Objednaná jídla seskupená po dnech (středa … neděle) v pořadí.
+     * Slouží pro výběr dnů a konkrétních jídel při tisku stravenek na infopultu.
+     * Klíč `jidla` obsahuje `nazev` (plný název včetně dne, např. „Oběd středa“ – shodný
+     * s predmety.nazev a tedy použitelný jako filtr reportu) a `druh` (druh jídla bez dne, např. „Oběd“).
+     * @return array<int, array{den: string, jidla: array<int, array{nazev: string, druh: string}>}>
+     */
+    public function objednanaJidlaDleDnu(): array
+    {
+        $dny = [];
+        foreach ($this->jidlo['jidla'] ?? [] as $den => $druhyVDen) {
+            $jidlaVDen = [];
+            foreach ($druhyVDen as $druh => $jidloVDen) {
+                if (($jidloVDen['kusu_uzivatele'] ?? 0) > 0) {
+                    $jidlaVDen[] = ['nazev' => $jidloVDen['nazev'], 'druh' => $druh];
+                }
+            }
+            if ($jidlaVDen) {
+                $dny[$den] = ['den' => self::denNazev($den), 'jidla' => $jidlaVDen];
+            }
+        }
+        ksort($dny);
+
+        return array_values($dny);
+    }
+
     public function trickaObjednatelnaDoHtml(): string
     {
         return $this->systemoveNastaveni->prodejTricekDo()->format('j. n.');


### PR DESCRIPTION
Odkaz „Tisk stravenek" na infopultu nahrazen tlačítkem, které otevře pop-up ve stylu QR plateb. V modálu jsou objednaná jídla návštěvníka seskupená po dnech; hlavička dne přepíná celou skupinu, jednotlivá jídla lze vybírat samostatně (vše přednastaveno zaškrtnuté).

Report stravenek nově přijímá volitelný filtr `jidla` (přesné názvy z shop_predmety.nazev) – robustní i pro víceslovné názvy jako „Oběd čtvrtek levnější". Filtr `dny` ponechán pro zpětnou kompatibilitu.

Shop::objednanaJidlaDleDnu() vrací objednaná jídla (kusu_uzivatele > 0) seskupená po dnech pro naplnění modálu.