### PR TITLE
Last minute tabule: oprava nadpisů bloků

### DIFF
--- a/admin/scripts/zvlastni/last-minute-tabule.php
+++ b/admin/scripts/zvlastni/last-minute-tabule.php
@@ -1,48 +1,53 @@
 <?php
 
-use Gamecon\Cas\DateTimeCz;
+declare(strict_types=1);
+
 use Gamecon\Aktivita\Aktivita;
+use Gamecon\Cas\DateTimeCz;
 use Gamecon\XTemplate\XTemplate;
 
 $xtpl = new XTemplate(__DIR__ . '/last-minute-tabule.xtpl');
 
-$datum                     = (int)date('Y') !== (int)ROCNIK // fix pro datum ze špatných let
+$datum = (int) date('Y') !== (int) ROCNIK // fix pro datum ze špatných let
     ? new DateTimeImmutable(ROCNIK . '-01-01 01:00')
     : new DateTimeImmutable();
-$od                        = $datum->sub(new \DateInterval('PT15M'));
-$do                        = (int)$datum->format('G') < 20
-    ? $datum->add(new \DateInterval('PT3H45M')) // před 20:00 vypisovat 4h dopředu, potom už další den
-    : $datum->add(new \DateInterval('P1D'))->setTime(9, 0);
-$denPredchozihoBloku       = null;
+$od = $datum->sub(new DateInterval('PT15M'));
+$do = (int) $datum->format('G') < 20
+    ? $datum->add(new DateInterval('PT3H45M')) // před 20:00 vypisovat 4h dopředu, potom už další den
+    : $datum->add(new DateInterval('P1D'))->setTime(9, 0);
+$denPredchozihoBloku = null;
 $zacatekPrvniAktivityBloku = null;
-$zitra                     = null;
-$aktivity                  = Aktivita::zRozmezi(
+$zitraBloku = null;
+$aktivity = Aktivita::zRozmezi(
     $od,
     $do,
     Aktivita::JEN_VOLNE | Aktivita::VEREJNE | Aktivita::NEUZAVRENE,
 );
 usort($aktivity, static function (Aktivita $nejakaAktivita, Aktivita $dalsiAktivita) {
     $i = $nejakaAktivita->zacatek() <=> $dalsiAktivita->zacatek();
-    if ($i == 0)
-    {
-        $zaplnenost1 = $nejakaAktivita->pocetPrihlasenych() / ($nejakaAktivita->kapacita() == 0 ? 1000 : $nejakaAktivita->kapacita());
-        $zaplnenost2 = $dalsiAktivita->pocetPrihlasenych() / ($dalsiAktivita->kapacita() == 0 ? 1000 : $dalsiAktivita->kapacita());
+    if ($i === 0) {
+        $zaplnenost1 = $nejakaAktivita->pocetPrihlasenych() / ($nejakaAktivita->kapacita() === 0 ? 1000 : $nejakaAktivita->kapacita());
+        $zaplnenost2 = $dalsiAktivita->pocetPrihlasenych() / ($dalsiAktivita->kapacita() === 0 ? 1000 : $dalsiAktivita->kapacita());
+
         return -($zaplnenost1 <=> $zaplnenost2);
     }
+
     return $i;
 });
 foreach ($aktivity as $a) {
-    if (!$a->prihlasovatelna() || $a->jeToDalsiKolo())
-    {
+    if (! $a->prihlasovatelna() || $a->jeToDalsiKolo()) {
         continue;
     }
-    $zacatekPrvniAktivityBloku = $zacatekPrvniAktivityBloku ?: $a->zacatek()->format('G:i');
-    if ($denPredchozihoBloku && $denPredchozihoBloku != $a->zacatek()->format('z')) {
-        $zacatekPrvniAktivityBloku = $zacatekPrvniAktivityBloku ?: $a->zacatek()->format('G:i');
-        $zitra                     = $a->zacatek()->rozdilDni($od);
+    if ($denPredchozihoBloku !== null && $denPredchozihoBloku !== $a->zacatek()->format('z')) {
+        // den se změnil → uzavřít předchozí blok s jeho vlastním nadpisem
         $xtpl->assign('cas', $zacatekPrvniAktivityBloku);
-        $xtpl->assign('zitra', $zitra);
+        $xtpl->assign('zitra', $zitraBloku);
         $xtpl->parse('tabule.blok');
+        $zacatekPrvniAktivityBloku = null;
+    }
+    if ($zacatekPrvniAktivityBloku === null) {
+        $zacatekPrvniAktivityBloku = $a->zacatek()->format('G:i');
+        $zitraBloku = $a->zacatek()->rozdilDni($od);
     }
     $xtpl->assign([
         'nazev'      => $a->nazev(),
@@ -52,15 +57,17 @@ foreach ($aktivity as $a) {
     $xtpl->parse('tabule.blok.aktivita');
     $denPredchozihoBloku = $a->zacatek()->format('z');
 }
-if (!$denPredchozihoBloku) {
+if ($denPredchozihoBloku === null) {
     $xtpl->assign('cas', DateTimeCz::createFromInterface($od)->zaokrouhlitNaHodinyNahoru()->format('G:i'));
+    $xtpl->assign('zitra', '');
     $xtpl->parse('tabule.blok.nic');
+} else {
+    $xtpl->assign('cas', $zacatekPrvniAktivityBloku);
+    $xtpl->assign('zitra', $zitraBloku);
 }
-$xtpl->assign('cas', $zacatekPrvniAktivityBloku);
-$xtpl->assign('zitra', $zitra);
 $xtpl->parse('tabule.blok');
 
-$zoom = empty($_GET['zoom']) ? 100 : (int)$_GET['zoom'];
+$zoom = empty($_GET['zoom']) ? 100 : (int) $_GET['zoom'];
 $xtpl->assign('lupa', $zoom);
 $xtpl->assign('lupaPlus', $zoom + 10);
 $xtpl->assign('lupaMinus', $zoom - 10);


### PR DESCRIPTION
Oprava nadpisů bloků na `/last-minute-tabule` (infopanel „Nejbližší aktivity").

## Problém

Po 20:00 se výpis rozšíří do dalšího dne (do zítřejších 9:00) a nadpisy obou bloků se rozbily — dnešní blok se ukazoval jako „Volná místa **zítra** od 21:00" a zítřejší blok přebíral čas dnešního bloku (viz hlášení z infopultu, foto z 23. 7. večer). V 21:15 se to „samo spravilo", protože dnešní aktivity vypadly z okna (teď −15 min) a zbyl jediný blok.

Příčiny (dvě zatuchlé proměnné ve smyčce):

1. Při změně dne se uzavíral *předchozí* blok, ale popisek `{zitra}` se počítal z první aktivity *následujícího* bloku → dnešní blok dostal „zítra".
2. `$zacatekPrvniAktivityBloku` se nastavoval přes `?:` a nikdy se neresetoval → druhý blok zdědil čas prvního bloku.

Bonus: v režimu jediného bloku se zítřejšími aktivitami (včera po 21:15) chyběl popisek „zítra" úplně — teď se počítá pro každý blok z jeho vlastní první aktivity.

## Ověření

Reprodukováno a ověřeno proti dnešnímu dumpu ostré DB se simulovaným časem:

| Simulované „teď" | Před opravou | Po opravě |
|---|---|---|
| dnes 19:30 | „od 20:00" ✓ | „od 20:00" ✓ |
| **dnes 20:05** | oba bloky „zítra od 20:00" ✗ | „od 20:00" + „zítra od 9:00" ✓ |
| včera 21:20 | „od 9:00" (chybí „zítra") | „zítra od 9:00" ✓ |

Čtyřnásobný Warhammer v prvním bloku na fotce **není** chyba zobrazení — v DB opravdu existují 4 samostatné instance „Warhammer 40 000 : První bitva" ve čtvrtek 21:00 (id 7860–7863, každá s kapacitou 2).

⚠️ Bez nasazení se tabule dnes ve 20:00 rozbije znovu.
