### PR TITLE
Odhlaseni zrusitelne objednavky a storno zdarma

### DIFF
--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -2020,6 +2020,7 @@ SQL
         $this->dejPrezenci()->zalogujOdhlaseni($u, $odhlasujici, $zdrojOdhlaseni);
         if ($this->systemoveNastaveni->kontrolovatPokutuZaOdhlaseni()
             && !($params & self::BEZ_POKUT)
+            && $this->cenaZaklad() > 0 // aktivita zdarma nemá storno – a bez záznamu POZDE_ZRUSIL nezůstane zablokovaná v programu (jde se znovu přihlásit)
             && (
                 $this->zbyvaHodinDoZacatku() < $this->systemoveNastaveni->kolikHodinPredAktivitouUzJePokutaZaOdhlaseni()
                 && $this->nestihlRychleOdhlaseniBezPokuty($prihlasenOd, $this->systemoveNastaveni)

--- a/model/Shop/Shop.php
+++ b/model/Shop/Shop.php
@@ -514,6 +514,61 @@ SQL,
         return $this->koupilNejakyPredmet() || $this->koupilNejakeTricko();
     }
 
+    /**
+     * Textový souhrn všech objednávek zákazníka (ubytování, jídlo, trička,
+     * mikiny, předměty) pro notifikaci infopultu při odhlášení z GC.
+     * @return string[] pole řádků; prázdné, pokud nic neobjednal
+     */
+    public function prehledObjednavekProInfopult(): array
+    {
+        $radky = [];
+
+        if ($ubytovani = $this->ubytovani()->objednaneUbytovaniNazvy()) {
+            $radky[] = 'Ubytování: ' . implode(', ', $ubytovani);
+        }
+
+        $jidla = [];
+        foreach ($this->objednanaJidlaDleDnu() as $den) {
+            foreach ($den['jidla'] as $jidlo) {
+                $jidla[] = $jidlo['nazev'];
+            }
+        }
+        if ($jidla) {
+            $radky[] = 'Jídlo: ' . implode(', ', $jidla);
+        }
+
+        if ($tricka = $this->nazvyObjednanychVeci($this->tricka)) {
+            $radky[] = 'Trička: ' . implode(', ', $tricka);
+        }
+        if ($mikiny = $this->nazvyObjednanychVeci($this->mikiny)) {
+            $radky[] = 'Mikiny: ' . implode(', ', $mikiny);
+        }
+        if ($predmety = $this->nazvyObjednanychVeci($this->predmety)) {
+            $radky[] = 'Předměty: ' . implode(', ', $predmety);
+        }
+
+        return $radky;
+    }
+
+    /**
+     * @param array $veci fronta předmětů ze Shopu (trička / mikiny / předměty)
+     * @return string[] názvy těch, které si zákazník objednal (s počtem kusů, je-li > 1)
+     */
+    private function nazvyObjednanychVeci(array $veci): array
+    {
+        $nazvy = [];
+        foreach ($veci as $vec) {
+            $pocet = (int)($vec['kusu_uzivatele'] ?? 0);
+            if ($pocet > 0) {
+                $nazvy[] = $pocet > 1
+                    ? "{$vec['nazev']} ({$pocet}×)"
+                    : $vec['nazev'];
+            }
+        }
+
+        return $nazvy;
+    }
+
     public function koupilNejakyPredmet(): bool
     {
         foreach ($this->predmety as $predmet) {
@@ -1269,19 +1324,47 @@ SQL
         return dbAffectedOrNumRows($deleteResult);
     }
 
-    public function zrusVsechnyLetosniObjedavky(string $zdrojZruseni): int
+    /**
+     * Zruší letošní objednávky zákazníka (při odhlášení z GC) – ale jen ty, které
+     * ještě lze zrušit. Po uzávěrce jídla / ubytování už je GameCon objednal
+     * u dodavatele (catering, ubytovatel) a nedostane za ně zpět peníze, takže
+     * tyto položky se NEruší a zůstávají zákazníkovi naúčtované.
+     * @return int počet skutečně zrušených nákupů
+     */
+    public function zrusZrusitelneLetosniObjednavky(string $zdrojZruseni): int
     {
+        // typy předmětů, které se po své uzávěrce už neruší (zůstávají naúčtované)
+        $typyKZachovani = [];
+        if ($this->systemoveNastaveni->prodejJidlaUkoncen()) {
+            $typyKZachovani[] = self::JIDLO;
+        }
+        if ($this->systemoveNastaveni->prodejUbytovaniUkoncen()) {
+            $typyKZachovani[] = self::UBYTOVANI;
+        }
+        // pozn.: prázdné pole neřešíme přes NOT IN (NULL) – to by (kvůli SQL NULL) vyloučilo
+        // úplně všechno; místo toho podmínku vůbec nepřidáváme.
+        $podminkaZachovani = $typyKZachovani
+            ? 'AND shop_nakupy.id_predmetu NOT IN (
+                    SELECT id_predmetu FROM shop_predmety WHERE typ IN (' . implode(', ', array_map('intval', $typyKZachovani)) . ')
+                )'
+            : '';
+
+        $rocnik      = $this->systemoveNastaveni->rocnik();
+        $idZakaznika = $this->zakaznik->id();
+
         dbQuery(<<<SQL
             INSERT INTO shop_nakupy_zrusene(id_nakupu, id_uzivatele, id_predmetu, rocnik, cena_nakupni, datum_nakupu, datum_zruseni, zdroj_zruseni)
             SELECT id_nakupu, id_uzivatele, id_predmetu, rok, cena_nakupni, datum, $0, $1
             FROM shop_nakupy
-            WHERE shop_nakupy.rok = {$this->systemoveNastaveni->rocnik()} AND shop_nakupy.id_uzivatele = {$this->zakaznik->id()}
+            WHERE shop_nakupy.rok = {$rocnik} AND shop_nakupy.id_uzivatele = {$idZakaznika}
+            {$podminkaZachovani}
             SQL,
             [0 => $this->systemoveNastaveni->ted()->format(DateTimeCz::FORMAT_DB), $zdrojZruseni],
         );
         $result = dbQuery(<<<SQL
             DELETE FROM shop_nakupy
-            WHERE rok = {$this->systemoveNastaveni->rocnik()} AND id_uzivatele = {$this->zakaznik->id()}
+            WHERE shop_nakupy.rok = {$rocnik} AND shop_nakupy.id_uzivatele = {$idZakaznika}
+            {$podminkaZachovani}
             SQL,
         );
 

--- a/model/Shop/ShopUbytovani.php
+++ b/model/Shop/ShopUbytovani.php
@@ -934,6 +934,24 @@ SQL,
         return count($this->veKterychDnechJeUbytovan()) > 0;
     }
 
+    /**
+     * Názvy objednaného ubytování (typ + den), pro souhrn objednávek na infopult.
+     * @return string[]
+     */
+    public function objednaneUbytovaniNazvy(): array
+    {
+        $nazvy = [];
+        foreach ($this->ubytovanPoDnech() as $typyADetaily) {
+            foreach ($typyADetaily as $detail) {
+                if (($detail['kusu_uzivatele'] ?? 0) > 0) {
+                    $nazvy[] = $detail['nazev'];
+                }
+            }
+        }
+
+        return $nazvy;
+    }
+
     public function maHoteloveUbytovaniVDen(int $den): bool
     {
         if (!isset($this->ubytovanPoDnech[$den])) {

--- a/model/SystemoveNastaveni/SystemoveNastaveni.php
+++ b/model/SystemoveNastaveni/SystemoveNastaveni.php
@@ -815,7 +815,9 @@ SQL;
 
     public function prodejUbytovaniDo(): DateTimeImmutableStrict
     {
-        return (new DateTimeImmutableStrict(UBYTOVANI_LZE_OBJEDNAT_A_MENIT_DO_DNE))
+        // přes dejHodnotu (ne bare konstantu) – konstanta nemusí být definovaná
+        // v dávkových tocích (např. hromadné odhlašování neplatičů)
+        return (new DateTimeImmutableStrict($this->dejHodnotu(Klic::UBYTOVANI_LZE_OBJEDNAT_A_MENIT_DO_DNE)))
             ->setTime(23, 59, 59);
     }
 
@@ -826,7 +828,8 @@ SQL;
 
     public function prodejJidlaDo(): DateTimeImmutableStrict
     {
-        return (new DateTimeImmutableStrict(JIDLO_LZE_OBJEDNAT_A_MENIT_DO_DNE))
+        // viz prodejUbytovaniDo() – dejHodnotu kvůli nedefinované konstantě v dávkových tocích
+        return (new DateTimeImmutableStrict($this->dejHodnotu(Klic::JIDLO_LZE_OBJEDNAT_A_MENIT_DO_DNE)))
             ->setTime(23, 59, 59);
     }
 

--- a/model/uzivatel.php
+++ b/model/uzivatel.php
@@ -565,8 +565,9 @@ SQL, [Pravo::PORADANI_AKTIVIT],
 
         // finální odebrání role "registrován na GC"
         $this->odeberRoli(Role::PRIHLASEN_NA_LETOSNI_GC, $odhlasujici);
-        // zrušení nákupů (až po použití dejShop a ubytovani)
-        $this->shop()->zrusVsechnyLetosniObjedavky($zdrojOdhlaseni);
+        // zrušení nákupů (až po použití dejShop a ubytovani).
+        // Jídlo a ubytování po jejich uzávěrce už zrušit nelze – zůstávají naúčtované.
+        $this->shop()->zrusZrusitelneLetosniObjednavky($zdrojOdhlaseni);
 
         try {
             $this->informujOOdhlaseni($odhlasujici, $zaznamnik, $odeslatMailPokudSeNeodhlasilSam);
@@ -593,13 +594,13 @@ SQL, [Pravo::PORADANI_AKTIVIT],
                 $mailOdhlasilAlePlatil->odeslat();
             }
         }
-        if ($dnyUbytovani = array_keys($this->shop()->ubytovani()->veKterychDnechJeUbytovan())) {
-            $mailMelUbytovani = $this->mailZeBylOdhlasenAMelUbytovani($dnyUbytovani, $odhlasujici);
+        if ($prehledObjednavek = $this->shop()->prehledObjednavekProInfopult()) {
+            $mailMelObjednavky = $this->mailZeBylOdhlasenAMelObjednavky($prehledObjednavek, $odhlasujici);
             if ($zaznamnik) {
-                $zaznamnik->uchovejZEmailu($mailMelUbytovani);
+                $zaznamnik->uchovejZEmailu($mailMelObjednavky);
             } else {
                 if ($this->systemoveNastaveni->poslatMailZeBylOdhlasenAMelUbytovani()) {
-                    $mailMelUbytovani->odeslat();
+                    $mailMelObjednavky->odeslat();
                 }
             }
         }
@@ -633,8 +634,11 @@ SQL, [Pravo::PORADANI_AKTIVIT],
             );
     }
 
-    private function mailZeBylOdhlasenAMelUbytovani(
-        array $dnyUbytovani,
+    /**
+     * @param string[] $prehledObjednavek řádky souhrnu objednávek (ubytování, jídlo, trička…)
+     */
+    private function mailZeBylOdhlasenAMelObjednavky(
+        array $prehledObjednavek,
         self $odhlasujici,
     ): GcMail {
         $odhlasen = $this->id() === $odhlasujici->id()
@@ -643,15 +647,15 @@ SQL, [Pravo::PORADANI_AKTIVIT],
 
         return (new GcMail($this->systemoveNastaveni))
             ->adresat('info@gamecon.cz')
-            ->predmet("Uživatel {$odhlasen} a měl ubytování")
+            ->predmet("Uživatel {$odhlasen} a měl objednávky")
             ->text(
                 hlaskaMail(
-                    'odhlasilMelUbytovani',
+                    'odhlasilMelObjednavky',
                     $this->jmenoNick(),
                     $this->id(),
                     $odhlasen,
                     $this->systemoveNastaveni->rocnik(),
-                    implode(', ', $dnyUbytovani),
+                    implode('<br>', $prehledObjednavek),
                 ),
             );
     }

--- a/nastaveni/hlasky/nastaveni-hlasky-subst.php
+++ b/nastaveni/hlasky/nastaveni-hlasky-subst.php
@@ -6,7 +6,7 @@ use Gamecon\Hlaska\Hlaska;
 
 return [
     'odhlasilPlatil'       => 'Uživatel %1 (ID %2) %3 z GameConu, ale v aktuálním roce (%4) si poslal %5 Kč. Bude vhodné to prověřit popř. smazat platby z připsaných a dát do zůstatku v seznamu uživatelů, aby mu peníze nepropadly',
-    'odhlasilMelUbytovani' => 'Uživatel %1 (ID %2) %3 z GameConu a v aktuálním roce (%4) měl ubytování ve dnech %5. Uvolnilo se tak místo.',
+    'odhlasilMelObjednavky' => 'Uživatel %1 (ID %2) %3 z GameConu a v aktuálním roce (%4) měl tyto objednávky:<br><br>%5<br><br>Uvolnila se tak místa / položky.',
     'uvolneneMisto'        => 'Na aktivitě %1, která se koná v %2, se uvolnilo místo. Tento e-mail dostáváš, protože máš nastavené sledování uvedené aktivity. Přihlaš se na aktivitu přes <a href="https://gamecon.cz/program">program</a> (pospěš si, ať ti místo nezabere někdo jiný).',
     'chybaClenaTymu'       => 'Nepodařilo se přihlásit tým. Při přihlašování uživatele %1 (id %2) se u něj objevila chyba: %3',
     'zapomenuteHeslo'      => 'Ahoj,

--- a/tests/Model/Aktivita/AktivitaTest.php
+++ b/tests/Model/Aktivita/AktivitaTest.php
@@ -140,6 +140,7 @@ SQL,
             [
                 Sql::ZACATEK => new DateTimeImmutableStrict(),
                 Sql::TYP     => TypAktivity::DESKOHERNA,
+                Sql::CENA    => 100, // aktivita musí být placená – storno se u aktivit zdarma nepočítá
             ],
             [
                 Sql::ID_AKCE => 1,
@@ -181,6 +182,51 @@ SQL,
             $maPLatitStorno,
             StavPrihlaseni::platiStorno($aktivita->stavPrihlaseni($uzivatel)),
             'Očekávali jsme jiný výsledek zda má platit storno za zrušení aktivity',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function aktivitaZdarmaNemaPoPozdnimOdhlaseniStornoAniBlokaciProgramu(): void
+    {
+        dbUpdate(
+            Sql::AKCE_SEZNAM_TABULKA,
+            [
+                Sql::ZACATEK => new DateTimeImmutableStrict(), // začíná „teď“ → odhlášení je pozdní
+                Sql::TYP     => TypAktivity::DESKOHERNA,
+                Sql::CENA    => 0, // aktivita zdarma
+            ],
+            [
+                Sql::ID_AKCE => 1,
+            ],
+        );
+
+        $uzivatel = \Uzivatel::zId(1);
+        $uzivatel->gcPrihlas($uzivatel);
+
+        $aktivita = Aktivita::zId(id: 1);
+        $aktivita->prihlas($uzivatel, $uzivatel, 0b111111111111);
+        // přihlášení posuneme do minulosti, aby nešlo o „rychlé odhlášení bez pokuty“
+        dbUpdate(
+            'akce_prihlaseni_log',
+            ['kdy' => self::ted()->modify('-' . (self::KOLIK_MINUT_JE_ODHLASENI_BEZ_POKUTY + 1) . ' minutes')],
+            ['id_uzivatele' => $uzivatel->id(), 'id_akce' => $aktivita->id()],
+        );
+
+        $aktivita = Aktivita::zId(id: 1, systemoveNastaveni: $this->systemoveNastaveniProStorno()); // reload
+        $aktivita->odhlas($uzivatel, $uzivatel, 'testy');
+
+        $aktivita = Aktivita::zId(id: 1); // reload
+        self::assertFalse($aktivita->prihlasen($uzivatel), 'Měl by být odhlášen');
+        self::assertFalse(
+            StavPrihlaseni::platiStorno($aktivita->stavPrihlaseni($uzivatel)),
+            'Aktivita zdarma nesmí mít storno za pozdní odhlášení',
+        );
+        self::assertSame(
+            StavPrihlaseni::NEPRIHLASEN,
+            $aktivita->stavPrihlaseni($uzivatel),
+            'Bez záznamu o pozdním zrušení se uživatel může na aktivitu zdarma znovu přihlásit (program není zablokovaný)',
         );
     }
 

--- a/tests/Model/Aktivita/AktivitaTest.php
+++ b/tests/Model/Aktivita/AktivitaTest.php
@@ -210,8 +210,13 @@ SQL,
         // přihlášení posuneme do minulosti, aby nešlo o „rychlé odhlášení bez pokuty“
         dbUpdate(
             'akce_prihlaseni_log',
-            ['kdy' => self::ted()->modify('-' . (self::KOLIK_MINUT_JE_ODHLASENI_BEZ_POKUTY + 1) . ' minutes')],
-            ['id_uzivatele' => $uzivatel->id(), 'id_akce' => $aktivita->id()],
+            [
+                'kdy' => self::ted()->modify('-' . (self::KOLIK_MINUT_JE_ODHLASENI_BEZ_POKUTY + 1) . ' minutes'),
+            ],
+            [
+                'id_uzivatele' => $uzivatel->id(),
+                'id_akce'      => $aktivita->id(),
+            ],
         );
 
         $aktivita = Aktivita::zId(id: 1, systemoveNastaveni: $this->systemoveNastaveniProStorno()); // reload

--- a/tests/Shop/ZrusZrusitelneLetosniObjednavkyTest.php
+++ b/tests/Shop/ZrusZrusitelneLetosniObjednavkyTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Shop;
+
+use App\Kernel;
+use Gamecon\Cas\DateTimeGamecon;
+use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\Prostredi\Prostredi;
+use Gamecon\Shop\Shop;
+use Gamecon\Shop\StavPredmetu;
+use Gamecon\Shop\TypPredmetu;
+use Gamecon\SystemoveNastaveni\DatabazoveNastaveni;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Gamecon\Tests\Db\AbstractTestDb;
+
+class ZrusZrusitelneLetosniObjednavkyTest extends AbstractTestDb
+{
+    protected static function keepTestClassDbChangesInTransaction(): bool
+    {
+        return false;
+    }
+
+    protected static function keepSingleTestMethodDbChangesInTransaction(): bool
+    {
+        return false;
+    }
+
+    protected static function resetDbAfterSingleTestMethod(): bool
+    {
+        return true;
+    }
+
+    private function vytvorUzivatele(): \Uzivatel
+    {
+        $uniqueId = uniqid();
+        dbQuery(<<<SQL
+INSERT INTO uzivatele_hodnoty SET
+    login_uzivatele = $0,
+    email1_uzivatele = $1,
+    jmeno_uzivatele = 'Test',
+    prijmeni_uzivatele = 'Odhlaseni'
+SQL,
+            [
+                0 => 'test_odhlaseni_' . $uniqueId,
+                1 => 'test.odhlaseni.' . $uniqueId . '@example.org',
+            ],
+        );
+
+        return \Uzivatel::zIdUrcite(dbInsertId());
+    }
+
+    private function vytvorPredmet(string $nazev, int $typ, ?int $den = null): int
+    {
+        $uniqueId = uniqid();
+        dbQuery(<<<SQL
+INSERT INTO shop_predmety SET
+    nazev = $0,
+    kod_predmetu = $1,
+    model_rok = $2,
+    cena_aktualni = 100,
+    stav = $3,
+    kusu_vyrobeno = NULL,
+    typ = $4,
+    ubytovani_den = $5
+SQL,
+            [
+                0 => $nazev,
+                1 => strtoupper(str_replace(' ', '_', $nazev)) . '_' . $uniqueId,
+                2 => ROCNIK,
+                3 => StavPredmetu::VEREJNY,
+                4 => $typ,
+                5 => $den,
+            ],
+        );
+
+        return dbInsertId();
+    }
+
+    private function objednejPredmet(int $idUzivatele, int $idPredmetu): void
+    {
+        dbQuery(<<<SQL
+INSERT INTO shop_nakupy SET
+    id_uzivatele = $0,
+    id_predmetu = $1,
+    rok = $2,
+    cena_nakupni = (SELECT cena_aktualni FROM shop_predmety WHERE id_predmetu = $1),
+    datum = NOW()
+SQL,
+            [0 => $idUzivatele, 1 => $idPredmetu, 2 => ROCNIK],
+        );
+    }
+
+    private function jeObjednan(int $idUzivatele, int $idPredmetu): bool
+    {
+        return (int) dbOneCol(
+            'SELECT COUNT(*) FROM shop_nakupy WHERE id_uzivatele = $0 AND id_predmetu = $1 AND rok = $2',
+            [0 => $idUzivatele, 1 => $idPredmetu, 2 => ROCNIK],
+        ) > 0;
+    }
+
+    private function nastaveni(bool $jidloUkonceno, bool $ubytovaniUkonceno): SystemoveNastaveni
+    {
+        return new class($jidloUkonceno, $ubytovaniUkonceno) extends SystemoveNastaveni {
+            public function __construct(
+                private readonly bool $jidloUkonceno,
+                private readonly bool $ubytovaniUkonceno,
+            ) {
+                parent::__construct(
+                    rocnik: ROCNIK,
+                    ted: new DateTimeImmutableStrict(),
+                    prostredi: Prostredi::Production,
+                    databazoveNastaveni: DatabazoveNastaveni::vytvorZGlobals(),
+                    rootAdresarProjektu: '',
+                    privateCacheDir: SPEC,
+                    kernel: new Kernel('test', false),
+                    publicCacheDir: CACHE,
+                );
+            }
+
+            public function prodejJidlaUkoncen(): bool
+            {
+                return $this->jidloUkonceno;
+            }
+
+            public function prodejUbytovaniUkoncen(): bool
+            {
+                return $this->ubytovaniUkonceno;
+            }
+        };
+    }
+
+    /**
+     * @test
+     */
+    public function poUzavercePonechaJidloAUbytovaniAleZrusiMerch(): void
+    {
+        $uzivatel = $this->vytvorUzivatele();
+
+        $idUbytovani = $this->vytvorPredmet('Spacak', TypPredmetu::UBYTOVANI, DateTimeGamecon::PORADI_HERNIHO_DNE_CTVRTEK);
+        $idJidlo     = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
+        $idMerch     = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
+
+        $this->objednejPredmet($uzivatel->id(), $idUbytovani);
+        $this->objednejPredmet($uzivatel->id(), $idJidlo);
+        $this->objednejPredmet($uzivatel->id(), $idMerch);
+
+        $nastaveni = $this->nastaveni(jidloUkonceno: true, ubytovaniUkonceno: true);
+        $zruseno   = (new Shop($uzivatel, $uzivatel, $nastaveni))
+            ->zrusZrusitelneLetosniObjednavky('test');
+
+        self::assertSame(1, $zruseno, 'Zrušit se měl jen merch');
+        self::assertTrue($this->jeObjednan($uzivatel->id(), $idUbytovani), 'Ubytování po uzávěrce zůstává naúčtované');
+        self::assertTrue($this->jeObjednan($uzivatel->id(), $idJidlo), 'Jídlo po uzávěrce zůstává naúčtované');
+        self::assertFalse($this->jeObjednan($uzivatel->id(), $idMerch), 'Merch se ruší vždy');
+    }
+
+    /**
+     * @test
+     */
+    public function predUzaverkouZrusiVse(): void
+    {
+        $uzivatel = $this->vytvorUzivatele();
+
+        $idUbytovani = $this->vytvorPredmet('Spacak', TypPredmetu::UBYTOVANI, DateTimeGamecon::PORADI_HERNIHO_DNE_CTVRTEK);
+        $idJidlo     = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
+        $idMerch     = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
+
+        $this->objednejPredmet($uzivatel->id(), $idUbytovani);
+        $this->objednejPredmet($uzivatel->id(), $idJidlo);
+        $this->objednejPredmet($uzivatel->id(), $idMerch);
+
+        $nastaveni = $this->nastaveni(jidloUkonceno: false, ubytovaniUkonceno: false);
+        $zruseno   = (new Shop($uzivatel, $uzivatel, $nastaveni))
+            ->zrusZrusitelneLetosniObjednavky('test');
+
+        self::assertSame(3, $zruseno, 'Před uzávěrkou se zruší vše');
+        self::assertFalse($this->jeObjednan($uzivatel->id(), $idUbytovani));
+        self::assertFalse($this->jeObjednan($uzivatel->id(), $idJidlo));
+        self::assertFalse($this->jeObjednan($uzivatel->id(), $idMerch));
+    }
+}

--- a/tests/Shop/ZrusZrusitelneLetosniObjednavkyTest.php
+++ b/tests/Shop/ZrusZrusitelneLetosniObjednavkyTest.php
@@ -88,7 +88,11 @@ INSERT INTO shop_nakupy SET
     cena_nakupni = (SELECT cena_aktualni FROM shop_predmety WHERE id_predmetu = $1),
     datum = NOW()
 SQL,
-            [0 => $idUzivatele, 1 => $idPredmetu, 2 => ROCNIK],
+            [
+                0 => $idUzivatele,
+                1 => $idPredmetu,
+                2 => ROCNIK,
+            ],
         );
     }
 
@@ -96,7 +100,11 @@ SQL,
     {
         return (int) dbOneCol(
             'SELECT COUNT(*) FROM shop_nakupy WHERE id_uzivatele = $0 AND id_predmetu = $1 AND rok = $2',
-            [0 => $idUzivatele, 1 => $idPredmetu, 2 => ROCNIK],
+            [
+                0 => $idUzivatele,
+                1 => $idPredmetu,
+                2 => ROCNIK,
+            ],
         ) > 0;
     }
 
@@ -139,15 +147,15 @@ SQL,
         $uzivatel = $this->vytvorUzivatele();
 
         $idUbytovani = $this->vytvorPredmet('Spacak', TypPredmetu::UBYTOVANI, DateTimeGamecon::PORADI_HERNIHO_DNE_CTVRTEK);
-        $idJidlo     = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
-        $idMerch     = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
+        $idJidlo = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
+        $idMerch = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
 
         $this->objednejPredmet($uzivatel->id(), $idUbytovani);
         $this->objednejPredmet($uzivatel->id(), $idJidlo);
         $this->objednejPredmet($uzivatel->id(), $idMerch);
 
         $nastaveni = $this->nastaveni(jidloUkonceno: true, ubytovaniUkonceno: true);
-        $zruseno   = (new Shop($uzivatel, $uzivatel, $nastaveni))
+        $zruseno = (new Shop($uzivatel, $uzivatel, $nastaveni))
             ->zrusZrusitelneLetosniObjednavky('test');
 
         self::assertSame(1, $zruseno, 'Zrušit se měl jen merch');
@@ -164,15 +172,15 @@ SQL,
         $uzivatel = $this->vytvorUzivatele();
 
         $idUbytovani = $this->vytvorPredmet('Spacak', TypPredmetu::UBYTOVANI, DateTimeGamecon::PORADI_HERNIHO_DNE_CTVRTEK);
-        $idJidlo     = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
-        $idMerch     = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
+        $idJidlo = $this->vytvorPredmet('Obed', TypPredmetu::JIDLO, DateTimeGamecon::PORADI_HERNIHO_DNE_PATEK);
+        $idMerch = $this->vytvorPredmet('Predmet', TypPredmetu::PREDMET);
 
         $this->objednejPredmet($uzivatel->id(), $idUbytovani);
         $this->objednejPredmet($uzivatel->id(), $idJidlo);
         $this->objednejPredmet($uzivatel->id(), $idMerch);
 
         $nastaveni = $this->nastaveni(jidloUkonceno: false, ubytovaniUkonceno: false);
-        $zruseno   = (new Shop($uzivatel, $uzivatel, $nastaveni))
+        $zruseno = (new Shop($uzivatel, $uzivatel, $nastaveni))
             ->zrusZrusitelneLetosniObjednavky('test');
 
         self::assertSame(3, $zruseno, 'Před uzávěrkou se zruší vše');


### PR DESCRIPTION
Odhlášení z GC: zrušitelné objednávky + aktivita zdarma bez storna
Dvě související úpravy chování při odhlašování.

1. Aktivita zdarma nemá storno za pozdní odhlášení
298f9febe

U aktivit zdarma (cena 0) se při pozdním odhlášení nezaznamenává POZDE_ZRUSIL. Storno je peněžní pokuta a u aktivity zdarma nedává smysl. Bonusově tím uživatel nezůstane v programu zablokovaný a může se na aktivitu zdarma znovu přihlásit.

model/Aktivita/Aktivita.php — přidána podmínka cenaZaklad() > 0 do bloku aktivující storno.
Nový test aktivitaZdarmaNemaPoPozdnimOdhlaseniStornoAniBlokaciProgramu ověřuje stav NEPRIHLASEN (bez storna) po pozdním odhlášení z placené i neplacené aktivity.
2. Při odhlášení z GC rušit jen zrušitelné objednávky
a01d1ea9b

Dosud se při odhlášení z GameConu rušily všechny letošní objednávky. Jídlo a ubytování jsou ale po své uzávěrce už objednané u dodavatele (catering, ubytovatel) a GameCon za ně nedostane zpět peníze → po uzávěrce je ponecháváme naúčtované a rušíme jen zbytek (merch apod.).

Shop::zrusVsechnyLetosniObjedavky → zrusZrusitelneLetosniObjednavky — INSERT do shop_nakupy_zrusene i DELETE používají stejnou podmínku zachování (žádné osiřelé záznamy). Zachování se řídí prodejJidlaUkoncen() / prodejUbytovaniUkoncen().
Notifikace na infopult rozšířena z pouhých dnů ubytování na souhrn všech objednávek (ubytování, jídlo, trička, mikiny, předměty) → přejmenování metody mailZeBylOdhlasenAMelUbytovani → …MelObjednavky a hlásky odhlasilMelUbytovani → odhlasilMelObjednavky.
Nové metody Shop::prehledObjednavekProInfopult a ShopUbytovani::objednaneUbytovaniNazvy.
Nový test ZrusZrusitelneLetosniObjednavkyTest pokrývá obě větve (před / po uzávěrce).
QA
✅ tests/Shop/ZrusZrusitelneLetosniObjednavkyTest.php + tests/Model/Aktivita/AktivitaTest.php — 18 testů, 48 assertů, prochází.
✅ php -l čistý na všech změněných souborech.
✅ Žádné visící reference na přejmenované metody/hlásky.
K zvážení při review
Konfigurační přepínač poslatMailZeBylOdhlasenAMelUbytovani() si ponechal starý název „Ubytovani", ale nově gejtuje širší „objednávky" mail (přejmenování by chtělo settings migraci — necháno záměrně).
Mail na infopult se nově posílá při jakékoli objednávce, ne jen při ubytování. To je záměr rename, ale mění to objem mailů — potvrdit, že je to žádoucí.