### PR TITLE
Oprava fatal erroru: přístup k chráněné $r přes rawDb()

### DIFF
--- a/admin/scripts/modules/_submoduly/osobni-udaje/osobni_udaje_ovladac.php
+++ b/admin/scripts/modules/_submoduly/osobni-udaje/osobni_udaje_ovladac.php
@@ -31,7 +31,7 @@ if (post('zmenitUdaj') && $uPracovni) {
             Uzivatel::zalogujZmenuOsobnichUdaju(
                 $uPracovni->id(),
                 $udaje,
-                $uPracovni->r,
+                $uPracovni->rawDb(),
                 $u?->id(),
                 'admin-osobni-udaje',
             );

--- a/admin/scripts/modules/infopult/_infopult_ovladac.php
+++ b/admin/scripts/modules/infopult/_infopult_ovladac.php
@@ -136,7 +136,7 @@ if (!empty($_POST['telefon']) && $uPracovni) {
     Uzivatel::zalogujZmenuOsobnichUdaju(
         $uPracovni->id(),
         ['telefon_uzivatele' => $_POST['telefon']],
-        ['telefon_uzivatele' => $uPracovni->r['telefon_uzivatele'] ?? null],
+        ['telefon_uzivatele' => $uPracovni->rawDb()['telefon_uzivatele'] ?? null],
         null,
         'infopult',
     );

--- a/model/pomoc.php
+++ b/model/pomoc.php
@@ -73,8 +73,8 @@ class Pomoc
             $this->u->id(),
             $novePomoc,
             [
-                Sql::POMOC_TYP  => $this->u->r[Sql::POMOC_TYP] ?? null,
-                Sql::POMOC_VICE => $this->u->r[Sql::POMOC_VICE] ?? null,
+                Sql::POMOC_TYP  => $this->u->rawDb()[Sql::POMOC_TYP] ?? null,
+                Sql::POMOC_VICE => $this->u->rawDb()[Sql::POMOC_VICE] ?? null,
             ],
             null,
             'web',

--- a/tests/Uzivatel/ZalogujZmenuOsobnichUdajuTest.php
+++ b/tests/Uzivatel/ZalogujZmenuOsobnichUdajuTest.php
@@ -13,6 +13,11 @@ use Gamecon\Uzivatel\SqlStruktura\UzivateleHodnotySqlStruktura as Sql;
  */
 class ZalogujZmenuOsobnichUdajuTest extends AbstractTestDb
 {
+    // vytvorUzivatele() vkládá do uzivatele_hodnoty jen pár sloupců; ostatní NOT NULL
+    // sloupce (ulice_a_cp_uzivatele, …) nemají default → bez tohoto by STRICT_TRANS_TABLES
+    // shodil INSERT na "Field '…' doesn't have a default value".
+    protected static bool $disableStrictTransTables = true;
+
     private function vytvorUzivatele(string $suffix): \Uzivatel
     {
         dbQuery(<<<SQL


### PR DESCRIPTION
Audit změn osobních údajů četl na třech místech chráněnou vlastnost Uzivatel::$r zvenčí objektu, což shodilo uložení fatal errorem 'Cannot access protected property Uzivatel::$r' — projevilo se to při uložení jména/příjmení na infopultu (osobni-udaje), u telefonu na infopultu a u přání pomoct (Pomoc). Nahrazeno veřejným přístupovým getterem rawDb().

Test ZalogujZmenuOsobnichUdajuTest navíc vypíná STRICT_TRANS_TABLES, protože fixture vkládá jen část NOT NULL sloupců uzivatele_hodnoty.