### PR TITLE
Kontrola délky krátké anotace jen na jednom místě

### DIFF
--- a/admin/scripts/modules/aktivity/_Import/Activities/ImportValuesSanitizer.php
+++ b/admin/scripts/modules/aktivity/_Import/Activities/ImportValuesSanitizer.php
@@ -703,26 +703,19 @@ HTML;
     ): ImportStepResult {
         if (!empty($activityValues[ExportAktivitSloupce::KRATKA_ANOTACE])) {
             $kratkaAnotace = $activityValues[ExportAktivitSloupce::KRATKA_ANOTACE];
-            if (mb_strlen($kratkaAnotace) > Aktivita::LIMIT_POPIS_KRATKY) {
-                return ImportStepResult::error(sprintf(
-                    "Krátká anotace překračuje maximální povolenou délku %d znaků: '%s...'",
-                    Aktivita::LIMIT_POPIS_KRATKY,
-                    mb_substr($kratkaAnotace, 0, 50)
-                ));
-            }
-            return ImportStepResult::success($kratkaAnotace);
-        }
-        $sourceActivity = $this->getSourceActivity($originalActivity, $parentActivity);
+        } else {
+            $sourceActivity = $this->getSourceActivity($originalActivity, $parentActivity);
 
-        $kratkaAnotace = $sourceActivity
-            ? $sourceActivity->kratkyPopis()
-            : '';
+            $kratkaAnotace = $sourceActivity
+                ? $sourceActivity->kratkyPopis()
+                : '';
+        }
 
         if (mb_strlen($kratkaAnotace) > Aktivita::LIMIT_POPIS_KRATKY) {
             return ImportStepResult::error(sprintf(
                 "Krátká anotace překračuje maximální povolenou délku %d znaků: '%s...'",
                 Aktivita::LIMIT_POPIS_KRATKY,
-                mb_substr($kratkaAnotace, 0, 50)
+                mb_substr($kratkaAnotace, 0, 50),
             ));
         }
 

--- a/tests/Aktivity/ActivitiesImporterTest.php
+++ b/tests/Aktivity/ActivitiesImporterTest.php
@@ -187,12 +187,7 @@ class ActivitiesImporterTest extends AbstractTestDb
             ['', 'Deskoherna', 'Aktivita Reimport 3', 'url-reimport-3', 'Popis', '', '', 'Pátek', '16:00', '18:00', '', '', '10', '', '', '', '', '', '', '', '0', '', '', '1', ''],
         ]);
 
-        // Import odmítá editovat aktivitu, která už začala. Aktivity vzniklé z „Pátek“ spadnou
-        // na pevné datum letošního GameConu, takže po jeho skončení by druhý (aktualizační)
-        // import selhal. Čas proto ukotvíme před začátek ročníku, ať test nezávisí na dnešku.
-        $predZacatkemGameconu = $this->predZacatkemGameconu();
-
-        $importer = $this->createImporter($mockData, $predZacatkemGameconu);
+        $importer = $this->createImporter($mockData);
         $result1 = $importer->importActivities('fake-spreadsheet-id');
         self::assertSame(3, $result1->getImportedCount());
 
@@ -218,9 +213,9 @@ class ActivitiesImporterTest extends AbstractTestDb
             [(string) $aktivita3->id(), 'Deskoherna', 'Aktivita Reimport 3', 'url-reimport-3', 'Popis', '', '', 'Pátek', '16:00', '18:00', '', '', '10', '', '', '', '', '', '', '', '0', '', '', '1', ''],
         ]);
 
-        $importer2 = $this->createImporter($mockDataUpdate, $predZacatkemGameconu);
+        $importer2 = $this->createImporter($mockDataUpdate);
         $result2 = $importer2->importActivities('fake-spreadsheet-id');
-        self::assertSame(3, $result2->getImportedCount(), 'Opakovaný import měl projít, chyby: ' . print_r($result2->getErrorMessages(), true));
+        self::assertSame(3, $result2->getImportedCount());
 
         // Reload activities
         $aktivita1 = Aktivita::zId($aktivita1->id());
@@ -287,20 +282,9 @@ class ActivitiesImporterTest extends AbstractTestDb
     }
 
     /**
-     * Den před začátkem letošního GameConu. Importer si z předaného času bere i ročník,
-     * takže musí zůstat uvnitř ROCNIK — proto se odvozuje ze začátku ročníku, ne z „dneška“.
-     */
-    private function predZacatkemGameconu(): \DateTimeImmutable
-    {
-        $zacatek = SystemoveNastaveni::zGlobals()->spocitanyZacatekLetosnihoGameconu();
-
-        return (new \DateTimeImmutable($zacatek->format('Y-m-d H:i:s')))->modify('-1 day');
-    }
-
-    /**
      * Helper method to create ActivitiesImporter with mocked dependencies
      */
-    private function createImporter(array $mockSheetData, ?\DateTimeImmutable $now = null): ActivitiesImporter
+    private function createImporter(array $mockSheetData): ActivitiesImporter
     {
         // Create mocks
         $mockGoogleSheets = $this->createMock(GoogleSheetsService::class);
@@ -325,7 +309,7 @@ class ActivitiesImporterTest extends AbstractTestDb
             googleDriveService: $mockGoogleDrive,
             googleSheetsService: $mockGoogleSheets,
             editActivityUrlSkeleton: '/admin/aktivity/upravit?id=%d',
-            now: $now ?? new \DateTimeImmutable(),
+            now: new \DateTimeImmutable(),
             storytellersPermissionsUrl: '/permissions',
             logovac: $mockLogovac,
             mutexPattern: $mockMutex,

--- a/tests/Aktivity/ActivitiesImporterTest.php
+++ b/tests/Aktivity/ActivitiesImporterTest.php
@@ -187,7 +187,12 @@ class ActivitiesImporterTest extends AbstractTestDb
             ['', 'Deskoherna', 'Aktivita Reimport 3', 'url-reimport-3', 'Popis', '', '', 'Pátek', '16:00', '18:00', '', '', '10', '', '', '', '', '', '', '', '0', '', '', '1', ''],
         ]);
 
-        $importer = $this->createImporter($mockData);
+        // Import odmítá editovat aktivitu, která už začala. Aktivity vzniklé z „Pátek“ spadnou
+        // na pevné datum letošního GameConu, takže po jeho skončení by druhý (aktualizační)
+        // import selhal. Čas proto ukotvíme před začátek ročníku, ať test nezávisí na dnešku.
+        $predZacatkemGameconu = $this->predZacatkemGameconu();
+
+        $importer = $this->createImporter($mockData, $predZacatkemGameconu);
         $result1 = $importer->importActivities('fake-spreadsheet-id');
         self::assertSame(3, $result1->getImportedCount());
 
@@ -213,9 +218,9 @@ class ActivitiesImporterTest extends AbstractTestDb
             [(string) $aktivita3->id(), 'Deskoherna', 'Aktivita Reimport 3', 'url-reimport-3', 'Popis', '', '', 'Pátek', '16:00', '18:00', '', '', '10', '', '', '', '', '', '', '', '0', '', '', '1', ''],
         ]);
 
-        $importer2 = $this->createImporter($mockDataUpdate);
+        $importer2 = $this->createImporter($mockDataUpdate, $predZacatkemGameconu);
         $result2 = $importer2->importActivities('fake-spreadsheet-id');
-        self::assertSame(3, $result2->getImportedCount());
+        self::assertSame(3, $result2->getImportedCount(), 'Opakovaný import měl projít, chyby: ' . print_r($result2->getErrorMessages(), true));
 
         // Reload activities
         $aktivita1 = Aktivita::zId($aktivita1->id());
@@ -282,9 +287,20 @@ class ActivitiesImporterTest extends AbstractTestDb
     }
 
     /**
+     * Den před začátkem letošního GameConu. Importer si z předaného času bere i ročník,
+     * takže musí zůstat uvnitř ROCNIK — proto se odvozuje ze začátku ročníku, ne z „dneška“.
+     */
+    private function predZacatkemGameconu(): \DateTimeImmutable
+    {
+        $zacatek = SystemoveNastaveni::zGlobals()->spocitanyZacatekLetosnihoGameconu();
+
+        return (new \DateTimeImmutable($zacatek->format('Y-m-d H:i:s')))->modify('-1 day');
+    }
+
+    /**
      * Helper method to create ActivitiesImporter with mocked dependencies
      */
-    private function createImporter(array $mockSheetData): ActivitiesImporter
+    private function createImporter(array $mockSheetData, ?\DateTimeImmutable $now = null): ActivitiesImporter
     {
         // Create mocks
         $mockGoogleSheets = $this->createMock(GoogleSheetsService::class);
@@ -309,7 +325,7 @@ class ActivitiesImporterTest extends AbstractTestDb
             googleDriveService: $mockGoogleDrive,
             googleSheetsService: $mockGoogleSheets,
             editActivityUrlSkeleton: '/admin/aktivity/upravit?id=%d',
-            now: new \DateTimeImmutable(),
+            now: $now ?? new \DateTimeImmutable(),
             storytellersPermissionsUrl: '/permissions',
             logovac: $mockLogovac,
             mutexPattern: $mockMutex,


### PR DESCRIPTION
Navazuje na #809 a míří **do jeho větve**, ne do `main`.

V #809 je kontrola délky krátké anotace v `getValidatedShortAnnotation()` napsaná dvakrát doslova — jednou pro hodnotu z importovaného řádku, podruhé pro hodnotu zděděnou z původní/rodičovské aktivity. Obě větve přitom jen zjišťují, jaká anotace se má použít; kontrola limitu je pro obě stejná.

Tenhle PR nechá obě větve pouze určit `$kratkaAnotace` a limit ověří jednou, až nad výsledkem. Chování se nemění — dlouhá anotace skončí chybou v obou případech stejně jako dřív.

### Poznámka k padajícímu testu

`testReimportSameDataDoesNotChangeAnything` na větvi #809 padá, ale **tímto PR se to neřeší a řešit nemá**: jde o test závislý na aktuálním čase, který už je opravený na `main` commitem `1ba5b2950` („Testy importu aktivit nezávislé na aktuálním čase“, 17. 7. 2026). Větev #809 je jen starší než ten commit. Po jejím rebasu / mergi `main` selhávání zmizí samo.
