### PR TITLE
Týmovky se v PHP počítají po týmech, ne po hlavách

### DIFF
--- a/admin/scripts/zvlastni/last-minute-tabule.php
+++ b/admin/scripts/zvlastni/last-minute-tabule.php
@@ -39,6 +39,12 @@ foreach ($aktivity as $aktivita) {
     if (! $aktivita->prihlasovatelna() || $aktivita->jeToDalsiKolo()) {
         continue;
     }
+    // Týmovku plnou týmů nelze obsadit, i když podle hlav ještě volno vychází - Aktivita::JEN_VOLNE
+    // počítá jen hlavy, takže by ji tabule nabízela jako volnou.
+    $tymovaKapacita = $aktivita->tymovaKapacita();
+    if ($aktivita->tymova() && $tymovaKapacita !== null && $aktivita->pocetPrihlasenychTymu() >= $tymovaKapacita) {
+        continue;
+    }
     if ($denPredchozihoBloku !== null && $denPredchozihoBloku !== $aktivita->zacatek()->format('z')) {
         // den se změnil → uzavřít předchozí blok s jeho vlastním nadpisem
         $xtpl->assign('cas', $zacatekPrvniAktivityBloku);

--- a/model/Aktivita/Aktivita.php
+++ b/model/Aktivita/Aktivita.php
@@ -1921,6 +1921,14 @@ SQL
         if (!$kapacitaCelkova) {
             return '';
         }
+        if ($this->tymova() && $this->tymovaKapacita() !== null) {
+            // Týmová aktivita se plní po týmech, ne po hlavách - stejně jako obsazenostObj() pro program.
+            $obsazenostTymu = $this->pocetPrihlasenychTymu() . '/' . $this->tymovaKapacita();
+
+            return !$this->prihlasovatelna() && !$this->probehnuta()
+                ? " <span class=\"neprihlasovatelna\">($obsazenostTymu)</span>"
+                : " ($obsazenostTymu)";
+        }
         if (!$this->prihlasovatelna() && !$this->probehnuta()) { // u proběhnutých aktivit se zobrazí čísla. Možno měnit.
             return " <span class=\"neprihlasovatelna\">($prihlasenoCelkem/$kapacitaCelkova)</span>";
         }


### PR DESCRIPTION
[Trello 1480 – Týmovky: PHP nepozná zaplněnost podle týmů](https://trello.com/c/jCJtojDz) — navazuje na [1375](https://trello.com/c/tOAG7mkh) (tam se opravilo obarvení v programu, tohle je PHP protějšek).

PHP počítalo zaplněnost týmovek podle hlav, frontend podle týmů. Aktivita plná týmů tak v PHP vycházela jako volná.

```
7626 D&D/JaD turnaj 2. běh 1. kolo | hlav 21/25 | týmů 5/5 → PHP „volno", frontend „plno"
```

## Co se mění

**1. `obsazenostHtml()` ukazuje týmy místo hlav** — starý program u týmovky vypisoval `21/25` (hlavy), zatímco React program `5/5` (týmy). Nově obojí `5/5`.

**2. Last-minute tabule přestane nabízet plnou týmovku.** Filtr `Aktivita::JEN_VOLNE` zahazuje jen `volnoPro() === PLNO`, což je čistě hlavová logika — plná týmovka jím propadla a tabule ji inzerovala jako volnou (dokonce i se štítkem „poslední místa", protože `skoroPlno` se počítá z hlav).

**Tohle je změna chování, ne jen zobrazení: plná týmovka nově z tabule zmizí.** Je to záměr — tabule je seznam „na co se dá ještě přihlásit" a na plnou týmovku se přihlásit nedá (šestý tým odmítne `muzePridatDalsiTym()`, do existujícího týmu se leze jen přes kód od člena, ne z tabule).

## Co se NEmění

**`volnoPro()` zůstává nedotčené — schválně.** Je to jediná kapacitní pojistka uvnitř `prihlas()` pod zámkem řádku (`Aktivita.php:2497`) a `pocetPrihlasenychTymu()` jde přes `AktivitaTym::vsechnyTymyAktivity()` → boot Symfony kernelu → Doctrine dotaz (~0,8 s na studený boot). Tahat to do zamčené přihlašovací cesty by bylo riskantní.

Důsledek: **hláška u šestého týmu zůstává zatím špatná** (`'Na aktivitě je už maximální počet týmů'` místo `hlaska('plno')`). Sjednocení `volnoPro()` je na kartě jako navazující krok — chce to nejdřív zlevnit `pocetPrihlasenychTymu()` na prostý `COUNT(*)` nad `akce_tym_akce` bez kernelu.

Body 4 a 5 z karty (sémantika `team_kapacita = NULL`, mrtvý trigger) jsou po dohodě odložené — tenhle PR se jich nedotýká, aktivity s `team_kapacita = NULL` se chovají stejně jako dosud.

## `team_kapacita = NULL` = neomezeně týmů

Obě nové větve testují `tymovaKapacita() !== null`, takže týmovka bez limitu týmů nikdy nevyjde jako plná. `teamova` je samostatný sloupec nezávislý na kapacitě, takže „je to týmovka" a „kolik týmů se vejde" jdou rozlišit.

## Ověření

Na reálných datech ročníku 2026 lokálně. `obsazenostHtml()` má **tři volající** a ověřeny jsou všechny tři.

### 1. Přímé volání metody

| Aktivita | teamova | team_kapacita | Před | Po |
|---|---|---|---|---|
| 7626 D&D/JaD turnaj 2. běh 1. kolo | 1 | 5 | `21/25` (hlavy) | **`5/5`** (týmy) |
| 7623 D&D/JaD turnaj 1. běh 1. kolo | 1 | 5 | `13/25` | **`3/5`** |
| 7554 Koření zadupané v mlze | 1 | 1 | `5/5` | `1/1` |
| 7565 Druhé kolo Legend | 1 | NULL | `''` | `''` (beze změny) |
| 7076 Zneškodnění bomby | 0 | – | `6/6` | `6/6` (beze změny) |

### 2. Výpis aktivit podle typu — `web/moduly/aktivity.php:84`

Veřejné stránky typů aktivit (`url_typu_mn`), bez jakéhokoli zásahu do DB:

| Stránka | PŘED | PO |
|---|---|---|
| `/dnd` | `(13/25) (13/25) (12/25) (21/25) (21/25) (21/25)` | `(3/5) (3/5) (3/5) (5/5) (5/5) (5/5)` |
| `/legendy` | `(5/5) (0/5) (4/5) (4/5) (5/5) (4/5) (0/5) …` | `(1/1) (0/1) (1/1) (1/1) (1/1) (1/1) (0/1) …` |

Řádek `/legendy` je názorný: aktivita se dřív tvářila jako `(5/5)`, tedy plná, přestože reálně měla `1/1` týmu; a `(0/5)` místo `(0/1)`. Hlavy vypadaly věrohodně, ale popisovaly něco jiného.

**Pozor — týká se to všech stránek typů aktivit, kde jsou týmovky**, ne jen těch dvou. `/dnd` a `/legendy` jsou jen místa, kde týmovky ročníku 2026 leží.

### 3. Náhled aktivity (API) — `web/moduly/program-nahled-api.php:36`

Popup po kliknutí na aktivitu v programu; `program-nahled-api?idAktivity=…`:

| Aktivita | PŘED | PO |
|---|---|---|
| 7626 (5/5 týmů) | `(21/25)` | **`(5/5)`** |
| 7623 (3/5 týmů) | `(13/25)` | **`(3/5)`** |
| 7554 (1/1 týmů) | `(5/5)` | **`(1/1)`** |
| 7565 (`team_kapacita` NULL) | `''` | `''` (beze změny) |
| 7076 (netýmová) | `(6/6)` | `(6/6)` (beze změny) |

### 4. Last-minute tabule — `admin/scripts/zvlastni/last-minute-tabule.php:65`

**Ověřena end-to-end** — dočasně posunuto `GC_BEZI_DO` (otevření registrace) a časy tří aktivit do okna tabule, načteno `/admin/last-minute-tabule`, pak vše vráceno zpět. Porovnání proti verzi před opravou (`HEAD~1`):

| Aktivita | Týmy | PŘED | PO |
|---|---|---|---|
| (čt-od+pá-rá) Tajuplný ostrov | **1/1 (plno)** | `4/5` + štítek **„poslední místo"** | **zmizela** |
| D&D/JaD turnaj 1. běh 1. kolo | 3/5 | `13/25` (hlavy) | `3/5` (týmy) |
| (čt-od+pá-rá) LKD 1.3 | 0/1 | `0/5` (hlavy) | `0/1` (týmy) |

První řádek je jádro problému: tabule nabízela **úplně plnou** týmovku, a protože `skoroPlno` se počítá z hlav, ještě u ní svítil štítek **„poslední místo"**. Návštěvník tak byl aktivně posílán na aktivitu, kam se přihlásit nedá.

Celá sada testů prochází (845 testů, 3167 asercí, 0 chyb; 6 přeskočených je předchozí stav `AktivitaTymovePrihlasovaniTest`). PHPStan bez chyb.

### Preact program `/program` tenhle PR NEOVLIVŇUJE

Program čte `obsazenostObj()` (statické JSON `t`/`kt`), ne `obsazenostHtml()`. Diff je čistě aditivní uvnitř `obsazenostHtml()`, `obsazenostObj()` zůstává nedotčené — ověřeno, že JSON programu je beze změny (`7626: {… kt:5, t:5}`). Obarvení plné týmovky v programu řeší samostatný PR #1035.

Drobná asymetrie, která je v pořádku: `obsazenostObj()` posílá `tymovaKapacita() ?? 0`, takže u týmovky bez limitu jde do JSONu `kt: 0`, kdežto `obsazenostHtml()` se ptá na `!== null`. Výsledek je stejný — v TS je `if (kt)` pro `0` nepravdivé, takže se spadne na hlavovou logiku a týmovka bez limitu se nikdy neoznačí jako plná (aktivita 7565: `kt: 0, t: 3`).

## Bez automatického testu

Týmový stav se nedá v testu snadno připravit: `pocetPrihlasenychTymu()` jde přes Doctrine, kdežto fixtury přes legacy `dbInsert` — přesně ta kolize dvou spojení, kvůli které je celé `AktivitaTymovePrihlasovaniTest` (včetně `testOmezeniKapacity`) `markTestSkipped`. Odblokovat to je samostatný úkol; ověřeno tedy ručně proti reálným datům a přes reálné vykreslení tabule, viz tabulky výše.

## Jak si to ověřit lokálně

**Bez zásahu do DB** (stačí načíst):

- <http://localhost/dnd> a <http://localhost/legendy> — u týmovek musí být počty týmů (`3/5`, `1/1`), ne hlav (`13/25`, `5/5`)
- <http://localhost/program-nahled-api?idAktivity=7626> — pole `obsazenost` musí být ` (5/5)`

**Vyžaduje dočasnou úpravu DB:**

- Tabule je bez přihlášení: <http://localhost/admin/last-minute-tabule>. Aby na ní bylo co vidět, musí běžet registrace (`GC_BEZI_DO` v budoucnu) a aktivity musí mít `stav = 2` (AKTIVOVANA — pozor, `3` je UZAVRENA) a začátek v okně „teď + 4 h".

Pozn. k porovnávání před/po přes `git checkout HEAD~1 -- …`: opcache chvíli servíruje starý bytecode, takže hned po přepnutí souboru může přijít zastaralá odpověď. Chce to pár sekund prodlevy, jinak se dá naměřit nesmysl.

