### PR TITLE
1260 SSO do archivu přihlašuje admina, ne prohlíženého uživatele

### DIFF
--- a/admin/scripts/modules/uzivatel.php
+++ b/admin/scripts/modules/uzivatel.php
@@ -175,6 +175,8 @@ if ($uPracovni) {
         }
         $odkazNaArchiv = new OdkazDoArchivnihoAdmina(
             $archivy,
+            // Magické přihlášení patří přihlášenému adminovi, ne prohlíženému uživateli.
+            $u?->id() ?? 0,
             defined('GAMECON_SSO_SECRET') ? GAMECON_SSO_SECRET : '',
             defined('ARCHIVE_GATE_SECRET') ? ARCHIVE_GATE_SECRET : '',
             $ssoNonce,

--- a/docs/generated/odkazy-do-archivnich-rocniku.md
+++ b/docs/generated/odkazy-do-archivnich-rocniku.md
@@ -16,6 +16,8 @@ https://2023.gamecon.cz/admin/uzivatel?pracovni_uzivatel=102&gcsso=<token>&gate=
 |----------|--------|----------------|---------------|
 | `?gate=` | Caddy brána před archivy chce basic auth; vložené `user:heslo@host` prohlížeč při kliknutí zahodí. Gate-validator token vymění za session cookie. | `GateLink::podepis()`, `ARCHIVE_GATE_SECRET` | URL zůstane čistá → basic-auth dialog |
 | `?gcsso=` | Magické přihlášení do archivu. Token nese **číselné `id_uzivatele`** (stabilní napříč snapshoty; e-mail se může časem přiřadit jinému člověku). Párovací cookie `.gamecon.cz` zajistí, že *sdílený* odkaz nikoho nepřihlásí. | `CrossSiteLogin::podepis()` klíčem **odvozeným pro ročník** `hash_hmac('sha256', rok, GAMECON_SSO_SECRET)` | Nepřipojí se → přihlašovací obrazovka |
+
+⚠️ **Dvě různé identity na jedné URL.** `gcsso` nese id **operátora** (přihlášeného admina, který klikl — `$u`), `pracovni_uzivatel` nese id **prohlíženého** uživatele (`$uPracovni`). Záměna admina přihlásí do cizího účtu — reálně se to stalo, protože oba údaje šly do jedné metody jako jeden parametr. Regresní test: `testSsoPrihlasujeOperatoraNePracovnihoUzivatele`.
 | akční parametr | Až tenhle něco udělá (`?pracovni_uzivatel=` otevře uživatele) | — | — |
 
 Master `GAMECON_SSO_SECRET` žije **jen na ostré**; archiv dostane přes deploy jen svůj odvozený `GAMECON_SSO_KEY`. Popadnutý archiv tak umí podvrhnout přihlášení jen do sebe. Viz `docs/` + ansible role `year_archive_deployer`.

--- a/model/Dev/OdkazDoArchivnihoAdmina.php
+++ b/model/Dev/OdkazDoArchivnihoAdmina.php
@@ -21,6 +21,11 @@ namespace Gamecon\Dev;
  *                             zajistí, že sdílený odkaz nikoho nepřihlásí.
  *   3. `?pracovni_uzivatel=` — až tohle v archivu otevře konkrétního uživatele.
  *
+ * Pozor, jsou v tom **dvě různé identity** a splést je znamená přihlásit admina do
+ * cizího účtu: `gcsso` nese id **operátora** (přihlášeného admina, který klikl),
+ * kdežto `pracovni_uzivatel` nese id **prohlíženého** uživatele. Archiv tě přihlásí
+ * jako operátora a teprve pak ti otevře pracovního uživatele — stejně jako na ostré.
+ *
  * Pořadí zpracování v archivu: `admin/scripts/prihlaseni.php` vyřídí nejdřív
  * `gcsso` a přesměruje `back(getCurrentUrlWithQuery(['gcsso' => null]))`, což
  * ostatní parametry v query zachová — `pracovni_uzivatel` tedy přežije do druhého
@@ -61,13 +66,18 @@ final class OdkazDoArchivnihoAdmina
     private readonly array $urlPodleRocniku;
 
     /**
-     * @param list<Archive> $archivy    nasazené archivní ročníky
-     * @param string        $ssoMaster  master tajemství pro magické přihlášení; prázdné = SSO se nepřipojí
-     * @param string        $gateSecret tajemství pro bránu; prázdné = odkaz zůstane na čisté URL
-     * @param string|null   $ssoNonce   nonce spárovaný s cookie; null = SSO se nepřipojí
+     * @param list<Archive> $archivy     nasazené archivní ročníky
+     * @param int           $idOperatora id PŘIHLÁŠENÉHO admina, který na odkaz klikne — NE
+     *                                   pracovního uživatele, kterého odkaz otevírá. Magické
+     *                                   přihlášení přihlašuje operátora do jeho vlastního účtu;
+     *                                   koho si pak v archivu otevře, řeší `pracovni_uzivatel`.
+     * @param string        $ssoMaster   master tajemství pro magické přihlášení; prázdné = SSO se nepřipojí
+     * @param string        $gateSecret  tajemství pro bránu; prázdné = odkaz zůstane na čisté URL
+     * @param string|null   $ssoNonce    nonce spárovaný s cookie; null = SSO se nepřipojí
      */
     public function __construct(
         array $archivy,
+        private readonly int $idOperatora = 0,
         private readonly string $ssoMaster = '',
         private readonly string $gateSecret = '',
         private readonly ?string $ssoNonce = null,
@@ -89,7 +99,7 @@ final class OdkazDoArchivnihoAdmina
      *   2014–2021   do adminu, přihlášeného             (`gcsso`)
      *   2011–2013   do adminu na přihlašovací obrazovku (jen brána)
      */
-    public function proUzivatele(int $rocnik, int $idUzivatele): ?string
+    public function proUzivatele(int $rocnik, int $idPracovnihoUzivatele): ?string
     {
         if ($rocnik < self::PRVNI_ROCNIK_SE_ZIVYM_ADMINEM) {
             return null;
@@ -101,18 +111,18 @@ final class OdkazDoArchivnihoAdmina
 
         $url = rtrim($urlArchivu, '/') . '/admin';
         if ($rocnik >= self::PRVNI_ROCNIK_S_PRACOVNIM_UZIVATELEM) {
-            $url .= '/uzivatel?pracovni_uzivatel=' . $idUzivatele;
+            $url .= '/uzivatel?pracovni_uzivatel=' . $idPracovnihoUzivatele;
         }
 
         if ($rocnik >= self::PRVNI_ROCNIK_SE_SSO
             && $this->ssoNonce !== null
             && $this->ssoMaster !== ''
-            && $idUzivatele > 0
+            && $this->idOperatora > 0
         ) {
             // Klíč odvozený pro ročník — archiv nikdy nedostane master, takže
             // z popadnutého archivu nejde podvrhnout přihlášení do jiných ročníků.
             $klicRocniku = hash_hmac('sha256', (string) $rocnik, $this->ssoMaster);
-            $gcsso = CrossSiteLogin::podepis($idUzivatele, $this->ssoNonce, $klicRocniku);
+            $gcsso = CrossSiteLogin::podepis($this->idOperatora, $this->ssoNonce, $klicRocniku);
             if ($gcsso !== '') {
                 $oddelovac = str_contains($url, '?') ? '&' : '?';
                 $url .= $oddelovac . 'gcsso=' . $gcsso;

--- a/tests/Dev/OdkazDoArchivnihoAdminaTest.php
+++ b/tests/Dev/OdkazDoArchivnihoAdminaTest.php
@@ -15,6 +15,7 @@ class OdkazDoArchivnihoAdminaTest extends TestCase
     private const GATE_SECRET = 'test-gate-do-not-use-in-prod';
     private const NONCE = 'nonce-abc';
     private const ID_UZIVATELE = 102;
+    private const ID_OPERATORA = 4032;
 
     /**
      * @param list<int> $roky
@@ -24,6 +25,7 @@ class OdkazDoArchivnihoAdminaTest extends TestCase
         string $ssoMaster = self::SSO_MASTER,
         string $gateSecret = self::GATE_SECRET,
         ?string $nonce = self::NONCE,
+        int $idOperatora = self::ID_OPERATORA,
     ): OdkazDoArchivnihoAdmina {
         $archivy = [];
         foreach ($roky as $rok) {
@@ -36,7 +38,7 @@ class OdkazDoArchivnihoAdminaTest extends TestCase
             );
         }
 
-        return new OdkazDoArchivnihoAdmina($archivy, $ssoMaster, $gateSecret, $nonce);
+        return new OdkazDoArchivnihoAdmina($archivy, $idOperatora, $ssoMaster, $gateSecret, $nonce);
     }
 
     public function testOdkazVedeNaCestuAdminNeNaSubdomenu(): void
@@ -66,8 +68,33 @@ class OdkazDoArchivnihoAdminaTest extends TestCase
         $overene = CrossSiteLogin::over((string) $query['gcsso'], $klicRocniku);
 
         self::assertNotNull($overene, 'token musí projít ověřením klíčem odvozeným pro ročník');
-        self::assertSame(self::ID_UZIVATELE, $overene->idUzivatele);
         self::assertSame(self::NONCE, $overene->nonce);
+    }
+
+    public function testSsoPrihlasujeOperatoraNePracovnihoUzivatele(): void
+    {
+        // Dvě různé identity na jedné URL: gcsso = přihlášený admin, pracovni_uzivatel
+        // = kdo se má otevřít. Záměna přihlásí admina do cizího účtu.
+        $url = $this->odkaz()->proUzivatele(2023, self::ID_UZIVATELE);
+
+        parse_str((string) parse_url((string) $url, PHP_URL_QUERY), $query);
+        $klicRocniku = hash_hmac('sha256', '2023', self::SSO_MASTER);
+        $overene = CrossSiteLogin::over((string) $query['gcsso'], $klicRocniku);
+
+        self::assertNotNull($overene);
+        self::assertSame(self::ID_OPERATORA, $overene->idUzivatele, 'token musí nést operátora');
+        self::assertNotSame(self::ID_UZIVATELE, $overene->idUzivatele);
+        self::assertSame((string) self::ID_UZIVATELE, $query['pracovni_uzivatel']);
+    }
+
+    public function testBezOperatoraSeSsoNepripoji(): void
+    {
+        // Nepřihlášený operátor (id 0) → nemáme koho přihlásit, token nedává smysl.
+        $url = $this->odkaz(idOperatora: 0)->proUzivatele(2023, self::ID_UZIVATELE);
+
+        self::assertNotNull($url);
+        self::assertStringNotContainsString('gcsso=', $url);
+        self::assertStringContainsString('pracovni_uzivatel=', $url);
     }
 
     public function testTokenJednohoRocnikuNeprojdeVJinemRocniku(): void


### PR DESCRIPTION
[Trello 1260 — Vylepšováky v adminu](https://trello.com/c/y17H5K49/1260-vylep%C5%A1ov%C3%A1ky-v-adminu)

Oprava chyby zavlečené v [PR #1039](https://github.com/gamecon-cz/gamecon/pull/1039) (už na `main`, tedy i na ostré).

## Problém

Klik na ročník v bloku **Historie účasti** tě v archivu přihlásí **jako prohlíženého uživatele**, ne jako sebe.

Konkrétně: jsem přihlášený jako `4032`, mám otevřeného pracovního uživatele `53`, kliknu na 2024 — a v archivu 2024 jsem přihlášený jako `53`. Tedy **přihlášení do cizího účtu**.

Projeví se na ročnících **2014–2021** nejvýrazněji (tam odkaz nese jen `gcsso`), ale token je špatný pro všechny ročníky včetně 2022+.

## Příčina

`OdkazDoArchivnihoAdmina::proUzivatele()` dostávalo **jedno** id, které používalo pro **dvě různé identity**:

```php
// model/Dev/OdkazDoArchivnihoAdmina.php (před opravou)
$url .= '/uzivatel?pracovni_uzivatel=' . $idUzivatele;            // správně: prohlížený (53)
$gcsso = CrossSiteLogin::podepis($idUzivatele, ...);              // ŠPATNĚ: má být operátor (4032)
```

Volající pak posílal `$uPracovni->id()`, takže se do SSO tokenu podepsal prohlížený uživatel.

Vzor to má správně — `admin/scripts/modules/web/stare-rocniky.php:51` podepisuje `$u->id()`, tedy přihlášeného operátora. Při vytahování logiky do sdílené služby se ty dvě identity slily do jednoho parametru.

## Řešení

`idOperatora` je nově **samostatný parametr konstruktoru** (je per-session, ne per-odkaz), `proUzivatele()` má přejmenovaný parametr na `$idPracovnihoUzivatele`. Dvě identity = dvě jména, takže je nejde znovu splést:

- `gcsso` ← `idOperatora` (`$u->id()`, přihlášený admin)
- `pracovni_uzivatel` ← `$idPracovnihoUzivatele` (`$uPracovni->id()`)

Bez přihlášeného operátora (`id 0`) se `gcsso` nepřipojí vůbec — odkaz vede do adminu bez přihlášení, místo aby podepsal nesmysl.

## Ověření

| Ročník | Před | Po |
|---|---|---|
| 2024 | přihlásí jako **53** (prohlížený) ❌ | přihlásí jako **4032** (operátor) ✅ |
| `pracovni_uzivatel` | `53` | `53` (beze změny) ✅ |

**Testy: 49/49 v `tests/Dev` zelených.** Nový regresní test `testSsoPrihlasujeOperatoraNePracovnihoUzivatele` ověřuje, že token nese operátora a `pracovni_uzivatel` prohlíženého. Ověřil jsem, že chybu opravdu chytá — po dočasném vrácení původního kódu spadl (`Failed asserting that 102 is identical to 4032`). Přidán i `testBezOperatoraSeSsoNepripoji`.

## Pozor při review

- **Chyba je od včera na ostré** ([PR #1039](https://github.com/gamecon-cz/gamecon/pull/1039) mergnut 5. 8. 16:45). Dokud se tohle nenasadí, proklik z Historie účasti přihlašuje do cizího účtu — bezpečnostní dopad je omezený tím, že to zvládne jen admin s právem 101 a jen do zmrazeného archivu, ale je to skutečné přihlášení pod cizí identitou.
- Změnil se **pořadí parametrů konstruktoru** (`idOperatora` je druhý). Jediné volající místo je `admin/scripts/modules/uzivatel.php`, ale kdyby mezitím přibylo další, spadne na typu.
- Nesouvisí s SSO opravou ročníku 2025 z včerejška (ta byla na straně archivu, tahle je na straně ostré).

## Kde to naklikat

- **https://admin.gamecon.cz/uzivatel?pracovni_uzivatel=53** — otevři jako jiný admin (např. 4032) → v bloku **Historie účasti** klikni na **2024**.
  - **očekávej:** v archivu jsi přihlášený **jako ty sám**, s otevřeným pracovním uživatelem 53
  - **před opravou:** jsi přihlášený jako 53
- **Klik na 2021** (ročník bez `pracovni_uzivatel`) → přihlášený jako ty, bez otevřeného uživatele.

Pozn.: token má TTL 5 minut, klikni brzy po načtení stránky; uspaný archiv se probouzí pár sekund.
