### PR TITLE
Jméno uživatele a název role na tlačítkách

### DIFF
--- a/admin/scripts/modules/prava/_prava_jedne_role.php
+++ b/admin/scripts/modules/prava/_prava_jedne_role.php
@@ -83,16 +83,8 @@ foreach (Uzivatel::zRole($role) as $uz) {
     $t->parse('pravaJedneRole.uzivatel');
 }
 
-if ($u->maPravoNaPrirazeniRole((int)$role)) {
-// posazování
-    if ($uPracovni && !$uPracovni->maRoli($role)) {
-        $t->parse('pravaJedneRole.akceUzivatel.posad');
-    } elseif ($uPracovni) {
-        $t->parse('pravaJedneRole.akceUzivatel.sesad');
-    }
-    $t->parse('pravaJedneRole.akceUzivatel');
-}
-
+// Musí být před parse() tlačítek níž — XTemplate dosazuje hodnoty v okamžiku
+// parse, takže později přiřazený nazev_role by v nich zůstal nevyplněný.
 $detailyRole = dbFetchRow(<<<SQL
         SELECT nazev_role, IF(popis_role != '', popis_role, nazev_role) AS popis_role
         FROM role_seznam
@@ -101,6 +93,27 @@ $detailyRole = dbFetchRow(<<<SQL
     [$role]
 );
 $t->assign($detailyRole);
+
+if ($u->maPravoNaPrirazeniRole((int)$role)) {
+// posazování
+    if ($uPracovni) {
+        // Jméno i název role na tlačítku, ať je při práci s víc rolemi jasné,
+        // koho a čeho se týká. Escapujeme kvůli value="…" — obojí je uživatelský
+        // vstup a uvozovka v něm by atribut rozbila. Vlastní klíč pro název role,
+        // protože {nazev_role} se jinde na stránce vypisuje neescapovaný.
+        $t->assign('pracovniUzivatel', htmlspecialchars($uPracovni->jmenoNick(), ENT_QUOTES | ENT_HTML5));
+        $t->assign(
+            'nazevRoleProTlacitko',
+            htmlspecialchars((string)($detailyRole['nazev_role'] ?? ''), ENT_QUOTES | ENT_HTML5),
+        );
+    }
+    if ($uPracovni && !$uPracovni->maRoli($role)) {
+        $t->parse('pravaJedneRole.akceUzivatel.posad');
+    } elseif ($uPracovni) {
+        $t->parse('pravaJedneRole.akceUzivatel.sesad');
+    }
+    $t->parse('pravaJedneRole.akceUzivatel');
+}
 
 $t->parse('pravaJedneRole');
 $t->out('pravaJedneRole');

--- a/admin/scripts/modules/prava/_prava_jedne_role.xtpl
+++ b/admin/scripts/modules/prava/_prava_jedne_role.xtpl
@@ -59,13 +59,13 @@ Seznam uživatelů na této roli:
 <!-- begin:posad -->
 <form>
   <input type="hidden" name="posad" value="{id_role}">
-  <input type="submit" value="Posadit aktuálního uživatele na roli">
+  <input type="submit" value="Dát uživateli {pracovniUzivatel} roli {nazevRoleProTlacitko}">
 </form>
 <!-- end:posad -->
 <!-- begin:sesad -->
 <form>
   <input type="hidden" name="sesad" value="{id_role}">
-  <input type="submit" value="Sesadit aktuálního uživatele z role">
+  <input type="submit" value="Odebrat uživateli {pracovniUzivatel} roli {nazevRoleProTlacitko}">
 </form>
 <!-- end:sesad -->
 <!-- end:akceUzivatel -->


### PR DESCRIPTION
## Problém

Na detailu role je tlačítko **„Sesadit aktuálního uživatele z role"** (a protějšek „Posadit aktuálního uživatele na roli"). Z textu nejde poznat, **koho** ani **které role** se to týká — kdo je zrovna vybraný jako pracovní uživatel. Při procházení víc rolí za sebou nebo po přepnutí pracovního uživatele je snadné kliknout na špatného člověka nebo špatnou roli.

## Řešení

Tlačítka nesou jméno pracovního uživatele i název role:

| Před | Po |
|---|---|
| Sesadit aktuálního uživatele z role | **Odebrat uživateli Petr „Gandalf" Holub roli Prezenční admin** |
| Posadit aktuálního uživatele na roli | **Dát uživateli Petr „Gandalf" Holub roli Vypravěčská skupina** |

Formulace „Dát/Odebrat uživateli X roli Y" je zvolená kvůli **skloňování**: jméno i název role zůstávají v základním tvaru a věta je gramaticky správná pro libovolné jméno. Původní „Sesadit {jméno} z role" by vyžadovalo akuzativ („Sesadit Petra Holuba"), který z databáze nevyskloňujeme.

Jméno dodává `Uzivatel::jmenoNick()` — `Jméno „přezdívka" Příjmení`. Používá se v adminu i jinde (hlavička, program uživatele), takže je konzistentní a má ošetřené okrajové případy: chybí-li jméno nebo příjmení, vypíše se samotný login; je-li login e-mail, vypíše se jen celé jméno (do tlačítka se tak nedostane cizí e-mail).

## Ověření

Proklikáno lokálně headless Playwrightem jako operátor s právem přiřazovat role, s pracovním uživatelem 53:

```
role 16 (má ji):    ["Odebrat uživateli Petr „Gandalf“ Holub roli Prezenční admin"]
role 9  (nemá ji):  ["Dát uživateli Petr „Gandalf“ Holub roli Vypravěčská skupina"]
role 15 (nemá ji):  ["Dát uživateli Petr „Gandalf“ Holub roli Čestný organizátor"]
```

Obě větve šablony (`posad` i `sesad`) tedy vypisují jméno i název role.

## Pozor při review

- **Přesunul jsem načtení `$detailyRole` výš**, nad `parse()` tlačítek. XTemplate dosazuje hodnoty v okamžiku `parse()`, takže dřív přiřazený `nazev_role` (byl až za blokem) by v tlačítkách zůstal nevyplněný. Bez toho přesunu změna nefunguje — ověřeno v prohlížeči, ne odhadem.
- **Obě hodnoty jsou escapované** (`htmlspecialchars(..., ENT_QUOTES)`), protože jdou do `value="…"` a jméno i název role jsou uživatelský vstup — uvozovka by rozbila atribut. Pro název role je vlastní klíč `nazevRoleProTlacitko`, protože `{nazev_role}` se jinde na stránce vypisuje neescapovaný a nechtěl jsem měnit chování zbytku šablony.
- Nespouštěl jsem ECS na celý soubor — přeformátoval by ho celý (~47 řádků) a utopil by tím vlastní změnu.

## Kde to naklikat

Potřebuješ právo na přiřazování rolí a vybraného pracovního uživatele.

- **http://localhost/admin/uzivatel?pracovni_uzivatel=53** — otevři, ať máš koho vybraného
- **http://localhost/admin/prava/16** — role, kterou uživatel **má** → dole **„Odebrat uživateli … roli Prezenční admin"**
- **http://localhost/admin/prava/9** — role, kterou **nemá** → **„Dát uživateli … roli Vypravěčská skupina"**

Na ostré totéž pod https://admin.gamecon.cz/prava/16.

Pozn.: tlačítka se zobrazí jen uživateli s právem `maPravoNaPrirazeniRole` — bez něj se celý blok nerenderuje.
