### PR TITLE
Teardown preview jako samostatný workflow, spustitelný ručně

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,16 +6,10 @@ on:
         branches-ignore:
             - main
             - beta
-    pull_request:
-        types:
-            - closed
-    # Branch deleted → tear down its preview. Covers the gap that
-    # `pull_request: closed` misses: a branch that got a preview (via push)
-    # but was deleted WITHOUT ever opening/closing a PR — no close event
-    # ever fires, so its container would otherwise run forever. Also a
-    # belt-and-suspenders for merged PRs (the branch delete that usually
-    # follows a merge re-triggers teardown idempotently).
-    delete:
+    # Teardown lives in teardown-preview.yml — that workflow owns the
+    # `pull_request: closed` and `delete` triggers. Keep them out of here:
+    # two workflows reacting to the same event would each SSH to the host
+    # and race.
     workflow_dispatch:
         inputs:
             branch:
@@ -31,8 +25,12 @@ permissions:
 # on parallel runners and race on the host — if teardown's SSH lands
 # after deploy's SSH, the container is correctly removed; if it lands
 # before, the deploy recreates a zombie preview that nothing will
-# clean up (the teardown workflow only fires on `pull_request: closed`,
-# which has already fired).
+# clean up (the teardown event has already fired).
+#
+# Teardown now lives in teardown-preview.yml, but concurrency groups are
+# REPO-GLOBAL, so the serialization still holds across the two files —
+# provided both keep the identical group expression below. Change one and
+# you must change the other, or the race above comes back.
 #
 # Keying on head_ref (PRs) / ref_name (push, delete, workflow_dispatch)
 # matches the slug derivation below — runs for the same branch queue, runs
@@ -53,8 +51,8 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
-    # Deploy on push to a feature branch (or workflow_dispatch). NOT on
-    # pull_request (closed → teardown) or delete (branch gone → teardown).
+    # Deploy on push to a feature branch (or workflow_dispatch). Closing a
+    # PR / deleting a branch is teardown-preview.yml's business.
     #
     # Skip Dependabot's branches: a `dependabot[bot]` push runs with a
     # read-only token and no access to the deploy secrets, so the SSH
@@ -189,59 +187,3 @@ jobs:
             -   name: Output preview URL
                 run: |
                     echo "::notice::Preview at https://${{ steps.slug.outputs.slug }}.preview.gamecon.cz/"
-
-    # Tear down the preview when its PR closes (merged or abandoned) OR when
-    # the branch is deleted. The two triggers overlap for the common
-    # merge-then-delete flow (teardown is idempotent — `--remove` of an
-    # already-gone preview is a no-op), and between them they close the gap:
-    # a branch deleted without a PR fires `delete` but never `pull_request`.
-    # Skip the `delete` of a tag (only branches get previews).
-    teardown:
-        if: >-
-            (github.event_name == 'pull_request' && github.event.action == 'closed') ||
-            (github.event_name == 'delete' && github.event.ref_type == 'branch')
-        runs-on: ubuntu-24.04
-        steps:
-            -   name: Derive slug from branch name
-                id: slug
-                # pull_request: branch is head.ref; delete: branch is event.ref.
-                run: |
-                    raw="${{ github.event.pull_request.head.ref || github.event.ref }}"
-                    slug=$(echo -n "$raw" \
-                        | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE \
-                        | tr '[:upper:]' '[:lower:]' \
-                        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
-                        | cut -c1-30 \
-                        | sed -E 's/-+$//')
-                    # Empty slug = branch name was all special chars. On a
-                    # closed PR we can reconstruct the same sha-fallback the
-                    # deploy used; on a delete event there is no SHA to
-                    # reconstruct from, so leave it empty and skip teardown
-                    # (nothing reliable to target).
-                    if [ -z "$slug" ]; then
-                        sha="${{ github.event.pull_request.head.sha }}"
-                        if [ -n "$sha" ]; then
-                            slug="sha-${sha}"
-                            slug="${slug:0:12}"
-                        fi
-                    fi
-                    echo "slug=$slug" >> "$GITHUB_OUTPUT"
-
-            -   name: Set up SSH
-                env:
-                    SSH_KEY: ${{ secrets.GAMECON_DEPLOY_SSH_KEY }}
-                    SSH_KNOWN_HOSTS: ${{ secrets.GAMECON_KNOWN_HOSTS }}
-                run: |
-                    mkdir -p ~/.ssh
-                    echo "$SSH_KEY" > ~/.ssh/id_ed25519
-                    chmod 0600 ~/.ssh/id_ed25519
-                    echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-                    chmod 0644 ~/.ssh/known_hosts
-
-            -   name: Tear down preview on gamecon.cz
-                # Skip when slug is empty (delete event for an all-special-char
-                # branch name — no reliable target). Normal slugs always run.
-                if: steps.slug.outputs.slug != ''
-                run: |
-                    ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
-                        "/usr/local/sbin/deploy-preview-branch.sh --remove '${{ steps.slug.outputs.slug }}'"

--- a/.github/workflows/teardown-preview.yml
+++ b/.github/workflows/teardown-preview.yml
@@ -1,0 +1,129 @@
+name: Tear down preview environment
+
+# yamllint disable-line rule:truthy
+on:
+    pull_request:
+        types:
+            - closed
+    # Branch deleted → tear down its preview. Covers the gap that
+    # `pull_request: closed` misses: a branch that got a preview (via push)
+    # but was deleted WITHOUT ever opening/closing a PR — no close event
+    # ever fires, so its container would otherwise run forever. Also a
+    # belt-and-suspenders for merged PRs (the branch delete that usually
+    # follows a merge re-triggers teardown idempotently).
+    delete:
+    # Manual teardown. The automatic triggers only fire on PR-close and
+    # branch-delete, so a preview left behind by any other route — a deploy
+    # that died half-way, an experiment on a branch still in use — had no
+    # way to be removed except SSHing to the host. `branch` (not `slug`) so
+    # the input matches the deploy workflow; the slug is derived from it by
+    # the exact same slugification, which is what keeps the two in step.
+    workflow_dispatch:
+        inputs:
+            branch:
+                description: 'Branch whose preview should be torn down'
+                required: true
+
+permissions:
+    contents: read
+
+# MUST stay byte-identical to the group in deploy-preview.yml — concurrency
+# groups are repo-global, so the deploy and the teardown of one branch only
+# serialize while both resolve to the SAME string. If they drift apart the
+# two run in parallel on separate runners and race on the host: a teardown
+# landing before a still-running deploy leaves a zombie preview that nothing
+# will ever clean up (the teardown event has already fired). That race is
+# the whole reason this block exists — see the long note in
+# deploy-preview.yml before touching either copy.
+#
+# `github.event.ref` is deliberately NOT in the list: on a push it is the
+# FULL ref (`refs/heads/foo`) while the PR event carries the short
+# `head.ref` (`foo`), so including it would put the two events in different
+# groups. `github.ref_name` already covers delete / workflow_dispatch with
+# the short name.
+concurrency:
+    group: deploy-preview-${{ github.event.pull_request.head.ref || github.event.inputs.branch || github.ref_name }}
+    cancel-in-progress: false
+
+jobs:
+    # Tear down the preview when its PR closes (merged or abandoned), when
+    # the branch is deleted, or on demand. The first two overlap for the
+    # common merge-then-delete flow — teardown is idempotent, `--remove` of
+    # an already-gone preview is a no-op — and between them they close the
+    # gap where a branch is deleted without a PR ever being opened.
+    # Skip the `delete` of a tag (only branches get previews).
+    teardown:
+        if: >-
+            (github.event_name == 'pull_request' && github.event.action == 'closed') ||
+            (github.event_name == 'delete' && github.event.ref_type == 'branch') ||
+            github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-24.04
+        steps:
+            -   name: Derive slug from branch name
+                id: slug
+                # pull_request: branch is head.ref; delete: branch is
+                # event.ref; workflow_dispatch: the typed-in branch input.
+                # Slugification is IDENTICAL to deploy-preview.yml — the two
+                # must agree or a teardown targets a different slug than the
+                # deploy created and silently removes nothing.
+                #
+                # The branch name reaches the shell via env, NOT string
+                # interpolation: a ref is attacker-controllable, and
+                # `${{ ... }}` is substituted before bash parses the script,
+                # so a crafted branch name could inject shell commands into
+                # the runner. Quoted "$RAW_REF" is inert.
+                env:
+                    RAW_REF: ${{ github.event.pull_request.head.ref || github.event.inputs.branch || github.event.ref }}
+                    PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                run: |
+                    raw="$RAW_REF"
+                    slug=$(echo -n "$raw" \
+                        | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE \
+                        | tr '[:upper:]' '[:lower:]' \
+                        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+                        | cut -c1-30 \
+                        | sed -E 's/-+$//')
+                    # Empty slug = branch name was all special chars. On a
+                    # closed PR we can reconstruct the same sha-fallback the
+                    # deploy used; on a delete event there is no SHA to
+                    # reconstruct from, so leave it empty and skip teardown
+                    # (nothing reliable to target).
+                    if [ -z "$slug" ]; then
+                        sha="$PR_HEAD_SHA"
+                        if [ -n "$sha" ]; then
+                            slug="sha-${sha}"
+                            slug="${slug:0:12}"
+                        fi
+                    fi
+                    echo "slug=$slug" >> "$GITHUB_OUTPUT"
+                    echo "Tearing down: ${slug:-(none — skipping)}"
+
+            -   name: Set up SSH
+                if: steps.slug.outputs.slug != ''
+                env:
+                    SSH_KEY: ${{ secrets.GAMECON_DEPLOY_SSH_KEY }}
+                    SSH_KNOWN_HOSTS: ${{ secrets.GAMECON_KNOWN_HOSTS }}
+                run: |
+                    mkdir -p ~/.ssh
+                    echo "$SSH_KEY" > ~/.ssh/id_ed25519
+                    chmod 0600 ~/.ssh/id_ed25519
+                    echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+                    chmod 0644 ~/.ssh/known_hosts
+
+            -   name: Tear down preview on gamecon.cz
+                # Skip when slug is empty (delete event for an all-special-char
+                # branch name — no reliable target). Normal slugs always run.
+                # `--remove` drops the container, the Caddy block, the
+                # deployment record, AND the per-slug DB + DB user.
+                #
+                # Slug via env rather than interpolation: it is already
+                # sanitised to ^[a-z0-9-]+$ by the step above (and the host
+                # wrapper re-validates), but keeping refs out of `run:`
+                # string-substitution means no future edit to the
+                # slugification can reopen an injection path.
+                if: steps.slug.outputs.slug != ''
+                env:
+                    SLUG: ${{ steps.slug.outputs.slug }}
+                run: |
+                    ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
+                        "/usr/local/sbin/deploy-preview-branch.sh --remove '$SLUG'"


### PR DESCRIPTION
## Problém

Teardown preview byl **druhý job uvnitř** `Deploy preview environment`. Jeho `if:` reagoval jen na zavření PR a smazání větve, takže **nešel spustit ručně** — preview, které zůstalo viset jinou cestou (deploy spadl v půlce, experiment na větvi, kterou ještě potřebuješ), se dalo uklidit jen SSH na host.

Přesně to nastalo včera: import DB spadl na OOM, zůstala `gc_preview_napoveda-ikona` s 8 z 64 tabulek. PR nebyl zavřený ani větev smazaná → teardown se nespustil → musel jsem databázi smazat ručně na serveru.

## Řešení

Rozdělení na dva workflow:

| Soubor | Triggery | Job |
|---|---|---|
| `deploy-preview.yml` | `push`, `workflow_dispatch` | `deploy` |
| **`teardown-preview.yml`** (nový) | `pull_request: closed`, `delete`, **`workflow_dispatch`** | `teardown` |

Ruční teardown se spouští z Actions → *Tear down preview environment* → *Run workflow*, se jménem větve (ne slugu — slug se odvodí stejnou slugifikací jako v deployi, což je to, co drží obě strany v souladu).

`--remove` na hostu maže **kontejner, Caddy blok, deployment záznam i DB + DB uživatele** (`deprovision_db()` dělá `DROP DATABASE` + `DROP USER`), takže ruční teardown uklidí i to, co po sobě nechal spadlý import.

## ⚠️ Co bylo potřeba ohlídat: concurrency

Původní soubor má u `concurrency` dlouhý komentář varující, že když deploy a teardown skončí v **různých skupinách**, běží paralelně a závodí na hostu — teardown doběhne dřív než deploy a vznikne zombie preview, které už nikdo neuklidí (událost teardownu už proběhla).

Rozdělení do dvou souborů tohle **neruší**: concurrency skupiny jsou v GitHubu **repo-globální**, ne per-workflow. Podmínkou je, že oba soubory mají *identický* výraz skupiny — ověřeno strojově, že se řetězce shodují znak po znaku. Do obou souborů jsem k tomu dopsal poznámku, aby to někdo omylem nerozpojil.

Z deploye jsem zároveň odebral triggery `pull_request` a `delete` — bez teardown jobu tam neměly co dělat a dvě workflow reagující na tutéž událost by na hostu závodila.

## Bonus: opravená shell injection

Semgrep při psaní upozornil, že název větve jde přímo do `run:` skriptu. Ref je útočníkem ovlivnitelný a `${{ ... }}` se dosazuje **před** tím, než bash skript parsuje — pokřivený název větve tak mohl injektovat příkazy do runneru. V novém souboru jde branch i slug přes `env:` a cituje se jako `"$RAW_REF"` / `'$SLUG'`.

Srovnání semgrepem (`p/github-actions`):

```
teardown-preview.yml (novy):        0 nalezu
deploy-preview.yml na main (puvodni): 6 nalezu, z toho 2× run-shell-injection (radky 82, 208)
```

Řádek 208 byla právě ta teardown injection — tímhle PR mizí. Zbylé nálezy v `deploy-preview.yml` (nepinované action tagy, injection na řádku 82) jsem **nechal být** — jsou předchozí a mimo zadání; ať je to samostatná úvaha, ne přílepek.

## Ověření

- Oba soubory parsují jako validní YAML; triggery a joby sedí podle tabulky výše.
- Concurrency skupiny ověřeny jako identické.
- Semgrep: nový soubor bez nálezů.

Chování v běžném toku (push → deploy, merge/smazání větve → teardown) se **nemění**, jen se přesouvá do vlastního souboru.

## Kde to vyzkoušet

Actions → **Tear down preview environment** → *Run workflow* → zadej název větve (např. `napoveda-ikona`) → mělo by zmizet preview i jeho databáze.

Ověřit pak na hostu: `docker ps | grep preview` a `SHOW DATABASES LIKE 'gc_preview%'`.
