### PR TITLE
1378 Promlceni zustatku respektuje pohyb na uctu

### DIFF
--- a/admin/cron/jobs/promlceni_automaticke.php
+++ b/admin/cron/jobs/promlceni_automaticke.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-use Gamecon\Uzivatel\PromlceniZustatku;
 use Gamecon\Kanaly\GcMail;
-use Gamecon\Report\KonfiguraceReportu;
-use Gamecon\Uzivatel\UzivatelKPromlceni;
 use Gamecon\Logger\JobResultLogger;
+use Gamecon\Report\KonfiguraceReportu;
+use Gamecon\Uzivatel\PromlceniZustatku;
+use Gamecon\Uzivatel\UzivatelKPromlceni;
 
 /** @var bool $znovu */
 
 require_once __DIR__ . '/../_cron_zavadec.php';
 
 $cronNaCas = require __DIR__ . '/../_cron_na_cas.php';
-if (!$cronNaCas) {
+if (! $cronNaCas) {
     return;
 }
 
@@ -23,9 +23,9 @@ global $systemoveNastaveni;
 
 // Zkontroluj, jestli je správný čas (1 den po skončení GameConu)
 $gcBeziDo = $systemoveNastaveni->gcBeziDo();
-$denPoGc  = $gcBeziDo->modify('+1 day');
-$ted      = $systemoveNastaveni->ted();
-$output   = new JobResultLogger();
+$denPoGc = $gcBeziDo->modify('+1 day');
+$ted = $systemoveNastaveni->ted();
+$output = new JobResultLogger();
 
 // Spustit pouze pokud jsme v rozmezí 1 den po GC (s tolerancí 23 hodin)
 if ($ted < $denPoGc) {
@@ -40,11 +40,11 @@ if ($ted < $denPoGc) {
     return;
 }
 
-$rocnik            = $systemoveNastaveni->rocnik();
+$rocnik = $systemoveNastaveni->rocnik();
 $promlceniZustatku = new PromlceniZustatku($systemoveNastaveni, new JobResultLogger());
 
 // Zkontroluj, jestli už nebylo promlčení provedeno
-if (!$znovu && ($promlcenoKdy = $promlceniZustatku->automatickaPromlceniProvedenaKdy($rocnik))) {
+if (! $znovu && ($promlcenoKdy = $promlceniZustatku->automatickaPromlceniProvedenaKdy($rocnik))) {
     $output->logs(
         sprintf(
             'Automatické promlčení zůstatků: Promlčení po ročníku %d už bylo provedeno v %s',
@@ -67,9 +67,9 @@ if (count($uzivateleKPromlceni) === 0) {
     (new GcMail($systemoveNastaveni))
         ->adresati($cfosEmaily
             ?: ['info@gamecon.cz'])
-        ->predmet("Automatické promlčení zůstatků GC $rocnik: 0 promlčených")
+        ->predmet("Automatické promlčení zůstatků GC {$rocnik}: 0 promlčených")
         ->text(<<<TEXT
-Automatické promlčení zůstatků po skončení GameConu $rocnik bylo provedeno.
+Automatické promlčení zůstatků po skončení GameConu {$rocnik} bylo provedeno.
 
 Výsledek: Žádní uživatelé nesplňovali kritéria pro promlčení zůstatků.
 
@@ -83,11 +83,11 @@ TEXT,
 
 // 2. Pošli CFO report před promlčením
 $reportPredPromlcenim = $promlceniZustatku->vytvorCfoReport($uzivateleKPromlceni);
-$pocetUzivatelu       = count($reportPredPromlcenim);
-$celkovaSuma          = array_sum(array_column($reportPredPromlcenim, 'promlcena_castka'));
+$pocetUzivatelu = count($reportPredPromlcenim);
+$celkovaSuma = array_sum(array_column($reportPredPromlcenim, 'promlcena_castka'));
 
 // Vytvoř dočasný XLSX soubor s reportem
-$tempFile           = tempnam($systemoveNastaveni->privateCacheDir(), 'promlceni_report_') . '.xlsx';
+$tempFile = tempnam($systemoveNastaveni->privateCacheDir(), 'promlceni_report_') . '.xlsx';
 $konfiguraceReportu = (new KonfiguraceReportu())
     ->setRowToFreeze(1)
     ->setColumnsToFreezeUpTo('E')
@@ -96,57 +96,68 @@ $konfiguraceReportu = (new KonfiguraceReportu())
 
 Report::zPole($reportPredPromlcenim)->tFormat('xlsx', null, $konfiguraceReportu);
 
+// Snímek zůstatků všech uživatelů před promlčením, aby ho šlo porovnat s finálním reportem
+$reportVsechPredPromlcenim = $promlceniZustatku->vytvorCfoReportVsechZustatku();
+
+$tempFileVsechniPred = tempnam($systemoveNastaveni->privateCacheDir(), 'promlceni_report_vsichni_pred_') . '.xlsx';
+$konfiguraceReportuVsechniPred = (new KonfiguraceReportu())
+    ->setRowToFreeze(1)
+    ->setColumnsToFreezeUpTo('C')
+    ->setMaxGenericColumnWidth(50)
+    ->setDestinationFile($tempFileVsechniPred);
+
+Report::zPole($reportVsechPredPromlcenim)->tFormat('xlsx', null, $konfiguraceReportuVsechniPred);
+
+$pocetVsechUzivatelu = count($reportVsechPredPromlcenim);
+
 // Pošli CFO report o uživatelích, kteří budou promlčeni
 $cfosEmaily = Uzivatel::cfosEmaily();
 (new GcMail($systemoveNastaveni))
     ->adresati($cfosEmaily
         ?: ['info@gamecon.cz'])
-    ->predmet("Automatické promlčení zůstatků GC $rocnik: Report před promlčením")
+    ->predmet("Automatické promlčení zůstatků GC {$rocnik}: Report před promlčením")
     ->prilohaSoubor($tempFile)
-    ->prilohaNazev("promlceni-zustatku-gc-$rocnik-pred.xlsx")
+    ->prilohaNazev("promlceni-zustatku-gc-{$rocnik}-pred.xlsx")
+    ->prilohaSoubor($tempFileVsechniPred)
+    ->prilohaNazev("zustatky-vsech-uzivatelu-pred-promlcenim-gc-{$rocnik}.xlsx")
     ->text(<<<TEXT
-Automatické promlčení zůstatků po skončení GameConu $rocnik bude nyní provedeno.
+Automatické promlčení zůstatků po skončení GameConu {$rocnik} bude nyní provedeno.
 
 Přehled před promlčením:
-- Počet uživatelů: $pocetUzivatelu
-- Celková suma k promlčení: $celkovaSuma Kč
+- Počet uživatelů k promlčení: {$pocetUzivatelu}
+- Celková suma k promlčení: {$celkovaSuma} Kč
+- Uživatelů v databázi celkem: {$pocetVsechUzivatelu}
 
-V příloze najdete detailní report se všemi uživateli, jejich účastí na GC a částkami k promlčení.
+V příloze najdete dva reporty:
+- promlceni-zustatku-gc-{$rocnik}-pred.xlsx - uživatelé k promlčení, jejich účast na GC a částky
+- zustatky-vsech-uzivatelu-pred-promlcenim-gc-{$rocnik}.xlsx - zůstatky všech uživatelů v databázi
 
 GameCon skončil: {$gcBeziDo->format('d.m.Y H:i')}
 TEXT,
     )
     ->odeslat(GcMail::FORMAT_HTML);
 
-if (isset($tempFile) && file_exists($tempFile)) {
-    @unlink($tempFile);
+foreach ([$tempFile, $tempFileVsechniPred] as $docasnySoubor) {
+    if (file_exists($docasnySoubor)) {
+        @unlink($docasnySoubor);
+    }
 }
-unset($tempFile);
+unset($tempFile, $tempFileVsechniPred);
 
 // 3. Promlč zůstatky
-$idsUzivatelu = array_map(fn(
+$idsUzivatelu = array_map(fn (
     UzivatelKPromlceni $u,
 ) => $u->uzivatel->id(), $uzivateleKPromlceni);
-$vysledek     = $promlceniZustatku->promlcZustatky($idsUzivatelu, Uzivatel::SYSTEM);
+$vysledek = $promlceniZustatku->promlcZustatky($idsUzivatelu, Uzivatel::SYSTEM);
 
 // 4. Zaloguj automatické promlčení do databáze
 $promlceniZustatku->zalogujAutomatickePromlceni($rocnik, $vysledek['pocet'], $vysledek['suma']);
 
 // 5. Načti aktuální stav všech uživatelů v databázi pro finální report
-$reportPoPromlceni = dbFetchAll(<<<SQL
-SELECT
-    uzivatele_hodnoty.id_uzivatele,
-    uzivatele_hodnoty.login_uzivatele AS nick,
-    uzivatele_hodnoty.jmeno_uzivatele,
-    uzivatele_hodnoty.prijmeni_uzivatele,
-    uzivatele_hodnoty.email1_uzivatele AS email,
-    uzivatele_hodnoty.zustatek AS aktualni_zustatek
-FROM uzivatele_hodnoty
-SQL,
-);
+$reportPoPromlceni = $promlceniZustatku->vytvorCfoReportVsechZustatku();
 
 // Vytvoř XLSX s aktuálním stavem všech uživatelů
-$tempFileAktualni           = tempnam($systemoveNastaveni->privateCacheDir(), 'promlceni_report_aktualni_') . '.xlsx';
+$tempFileAktualni = tempnam($systemoveNastaveni->privateCacheDir(), 'promlceni_report_aktualni_') . '.xlsx';
 $konfiguraceReportuAktualni = (new KonfiguraceReportu())
     ->setRowToFreeze(1)
     ->setColumnsToFreezeUpTo('C')
@@ -159,11 +170,11 @@ Report::zPole($reportPoPromlceni)->tFormat('xlsx', null, $konfiguraceReportuAktu
 (new GcMail($systemoveNastaveni))
     ->adresati($cfosEmaily
         ?: ['info@gamecon.cz'])
-    ->predmet("Automatické promlčení zůstatků GC $rocnik: DOKONČENO")
+    ->predmet("Automatické promlčení zůstatků GC {$rocnik}: DOKONČENO")
     ->prilohaSoubor($tempFileAktualni)
-    ->prilohaNazev("zustatky-vsech-uzivatelu-po-promlceni-gc-$rocnik.xlsx")
+    ->prilohaNazev("zustatky-vsech-uzivatelu-po-promlceni-gc-{$rocnik}.xlsx")
     ->text(<<<TEXT
-Automatické promlčení zůstatků po skončení GameConu $rocnik bylo úspěšně dokončeno.
+Automatické promlčení zůstatků po skončení GameConu {$rocnik} bylo úspěšně dokončeno.
 
 Výsledek promlčení:
 - Promlčeno uživatelů: {$vysledek['pocet']}

--- a/model/Uzivatel/PromlceniZustatku.php
+++ b/model/Uzivatel/PromlceniZustatku.php
@@ -19,27 +19,28 @@ class PromlceniZustatku
 {
     use LogHomadnychAkciTrait;
 
-    private const ROK_NEPLATNOST    = 3; // Počet let bez účasti, po kterých se zůstatek promlčí
+    private const ROK_NEPLATNOST = 3; // Počet let bez účasti, po kterých se zůstatek promlčí
     private const SKUPINA_PROMLCENI = 'promlceni-zustatku';
 
     public function __construct(
-        private readonly SystemoveNastaveni       $systemoveNastaveni,
+        private readonly SystemoveNastaveni $systemoveNastaveni,
         private readonly JobResultLoggerInterface $jobResultLogger,
     ) {
     }
 
     /**
      * Najde uživatele, jejichž zůstatek má být promlčen
-     * (pozitivní zůstatek + neúčast na GC po dobu ROK_NEPLATNOST let)
+     * (pozitivní zůstatek + neúčast na GC po dobu ROK_NEPLATNOST let
+     * + žádný pohyb na účtu za stejnou dobu)
      *
      * @return UzivatelKPromlceni[] Pole uživatelů určených k promlčení
      */
     public function najdiUzivateleKPromlceni(): array
     {
         $aktualniRocnik = $this->systemoveNastaveni->rocnik();
-        $ucastDoRoku    = $aktualniRocnik - self::ROK_NEPLATNOST;
+        $ucastDoRoku = $aktualniRocnik - self::ROK_NEPLATNOST;
 
-        $ucast     = Role::TYP_UCAST;
+        $ucast = Role::TYP_UCAST;
         $prihlasen = Role::VYZNAM_PRIHLASEN;
 
         $result = dbQuery(<<<SQL
@@ -56,7 +57,7 @@ LEFT JOIN (
     COUNT(*) AS pocet
     FROM platne_role_uzivatelu
     JOIN role_seznam AS role ON platne_role_uzivatelu.id_role = role.id_role
-    WHERE role.typ_role = '$ucast' AND role.vyznam_role = '$prihlasen'
+    WHERE role.typ_role = '{$ucast}' AND role.vyznam_role = '{$prihlasen}'
     GROUP BY id_uzivatele
 ) AS prihlaseni ON prihlaseni.id_uzivatele = uzivatele_hodnoty.id_uzivatele
 LEFT JOIN (
@@ -77,37 +78,43 @@ WHERE
             FROM platne_role_uzivatelu
             JOIN role_seznam AS role ON platne_role_uzivatelu.id_role = role.id_role
             WHERE platne_role_uzivatelu.id_uzivatele = uzivatele_hodnoty.id_uzivatele
-                AND role.typ_role = '$ucast'
-                AND role.vyznam_role = '$prihlasen'
-            HAVING MAX(role.rocnik_role) <= $ucastDoRoku
+                AND role.typ_role = '{$ucast}'
+                AND role.vyznam_role = '{$prihlasen}'
+            HAVING MAX(role.rocnik_role) <= {$ucastDoRoku}
     )
         OR NOT EXISTS (
             SELECT 1
             FROM platne_role_uzivatelu
             JOIN role_seznam AS role ON platne_role_uzivatelu.id_role = role.id_role
             WHERE platne_role_uzivatelu.id_uzivatele = uzivatele_hodnoty.id_uzivatele
-                AND role.typ_role = '$ucast'
-                AND role.vyznam_role = '$prihlasen'
+                AND role.typ_role = '{$ucast}'
+                AND role.vyznam_role = '{$prihlasen}'
         )
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM platby
+        WHERE platby.id_uzivatele = uzivatele_hodnoty.id_uzivatele
+            AND YEAR(platby.provedeno) > {$ucastDoRoku}
     )
 SQL,
         );
 
         $uzivatele = [];
         while ($r = mysqli_fetch_assoc($result)) {
-            $uzivatel = Uzivatel::zId($r['id_uzivatele']);
+            $uzivatel = \Uzivatel::zId($r['id_uzivatele']);
 
             $uzivatele[] = new UzivatelKPromlceni(
                 uzivatel: $uzivatel,
                 prihlaseniNaRocniky: $r['prihlaseniNaRocniky'] ?? '',
                 rokPosledniPlatby: isset($r['rokPosledniPlatby'])
-                    ? (int)$r['rokPosledniPlatby']
+                    ? (int) $r['rokPosledniPlatby']
                     : null,
                 mesicPosledniPlatby: isset($r['mesicPosledniPlatby'])
-                    ? (int)$r['mesicPosledniPlatby']
+                    ? (int) $r['mesicPosledniPlatby']
                     : null,
                 denPosledniPlatby: isset($r['denPosledniPlatby'])
-                    ? (int)$r['denPosledniPlatby']
+                    ? (int) $r['denPosledniPlatby']
                     : null,
             );
         }
@@ -119,15 +126,16 @@ SQL,
      * Promlčí zůstatky pro zadané ID uživatelů
      *
      * @param int[] $idsUzivatelu
-     * @param int $idAdmina ID administrátora provádějícího promlčení (nebo Uzivatel::SYSTEM pro automatické)
+     * @param int   $idAdmina     ID administrátora provádějícího promlčení (nebo Uzivatel::SYSTEM pro automatické)
+     *
      * @return array ['pocet' => int, 'suma' => float] Počet promlčených uživatelů a celková suma
      */
     public function promlcZustatky(
         array $idsUzivatelu,
-        int   $idAdmina,
+        int $idAdmina,
     ): array {
         $pocet = 0;
-        $suma  = 0;
+        $suma = 0;
 
         foreach ($idsUzivatelu as $id) {
             $odpoved = dbOneLine('
@@ -136,69 +144,73 @@ SQL,
                 WHERE id_uzivatele = $0
             ', [$id]);
 
-            if (!$odpoved) {
+            if (! $odpoved) {
                 continue;
             }
 
             $zustatek = $odpoved['zustatek'];
-            $suma     += $zustatek;
+            $suma += $zustatek;
 
             dbQuery('UPDATE uzivatele_hodnoty SET zustatek = 0 WHERE id_uzivatele = $0', [$id]);
 
             // Logování
             $soubor = LOGY . '/promlceni-' . date('Y-m-d_H-i-s') . '.log';
-            $cas    = date('Y-m-d H:i:s');
-            $zprava = "Promlčení provedl admin s id:          $idAdmina";
-            file_put_contents($soubor, "$cas $zprava\n", FILE_APPEND);
-            $zprava = "Promlčení zůstatku pro uživatele s id: $id";
-            file_put_contents($soubor, "$cas $zprava\n", FILE_APPEND);
-            $zprava = "Promlčená částka:                      $zustatek Kč" . "\n";
-            file_put_contents($soubor, "$cas $zprava\n", FILE_APPEND);
+            $cas = date('Y-m-d H:i:s');
+            $zprava = "Promlčení provedl admin s id:          {$idAdmina}";
+            file_put_contents($soubor, "{$cas} {$zprava}\n", FILE_APPEND);
+            $zprava = "Promlčení zůstatku pro uživatele s id: {$id}";
+            file_put_contents($soubor, "{$cas} {$zprava}\n", FILE_APPEND);
+            $zprava = "Promlčená částka:                      {$zustatek} Kč\n";
+            file_put_contents($soubor, "{$cas} {$zprava}\n", FILE_APPEND);
 
-            $pocet++;
+            ++$pocet;
         }
 
-        return ['pocet' => $pocet, 'suma' => $suma];
+        return [
+            'pocet' => $pocet,
+            'suma'  => $suma,
+        ];
     }
 
     /**
      * Vytvoří data pro CFO report s informacemi o promlčených zůstatcích
      *
      * @param UzivatelKPromlceni[] $uzivatele Pole uživatelů určených k promlčení
+     *
      * @return array[] Data připravená pro Report::zPole()
      */
     public function vytvorCfoReport(array $uzivatele): array
     {
         $aktualniRocnik = $this->systemoveNastaveni->rocnik();
-        $maxRok         = $this->systemoveNastaveni->poPrihlasovaniUcastniku($aktualniRocnik)
+        $maxRok = $this->systemoveNastaveni->poPrihlasovaniUcastniku($aktualniRocnik)
             ? $aktualniRocnik
             : $aktualniRocnik - 1;
 
         $ucastPodleRoku = [];
-        for ($rokUcasti = 2009; $rokUcasti <= $maxRok; $rokUcasti++) {
+        for ($rokUcasti = 2009; $rokUcasti <= $maxRok; ++$rokUcasti) {
             $ucastPodleRoku[Role::pritomenNaRocniku($rokUcasti)] = 'účast ' . $rokUcasti;
         }
 
         $obsah = [];
         foreach ($uzivatele as $uzivatelKPromlceni) {
-            $ucastiHistorie   = [];
+            $ucastiHistorie = [];
             $idsRoliUcastnika = $uzivatelKPromlceni->prihlaseniNaRocniky
                 ? explode(';', $uzivatelKPromlceni->prihlaseniNaRocniky)
                 : [];
 
             foreach ($ucastPodleRoku as $nazevUcasti) {
-                $rocnik                       = (int)str_replace('účast ', '', $nazevUcasti);
-                $ucastiHistorie[$nazevUcasti] = in_array((string)$rocnik, $idsRoliUcastnika, true)
+                $rocnik = (int) str_replace('účast ', '', $nazevUcasti);
+                $ucastiHistorie[$nazevUcasti] = in_array((string) $rocnik, $idsRoliUcastnika, true)
                     ? 'ano'
                     : 'ne';
             }
 
             $obsah[] = [
-                'id_uzivatele'          => $uzivatelKPromlceni->uzivatel->id(),
-                'nick'                  => $uzivatelKPromlceni->uzivatel->login(),
-                'jmeno'                 => $uzivatelKPromlceni->uzivatel->krestniJmeno(),
-                'prijmeni'              => $uzivatelKPromlceni->uzivatel->prijmeni(),
-                'email'                 => $uzivatelKPromlceni->uzivatel->mail(),
+                'id_uzivatele' => $uzivatelKPromlceni->uzivatel->id(),
+                'nick'         => $uzivatelKPromlceni->uzivatel->login(),
+                'jmeno'        => $uzivatelKPromlceni->uzivatel->krestniJmeno(),
+                'prijmeni'     => $uzivatelKPromlceni->uzivatel->prijmeni(),
+                'email'        => $uzivatelKPromlceni->uzivatel->mail(),
                 ...$ucastiHistorie,
                 'rok_posledni_platby'   => $uzivatelKPromlceni->rokPosledniPlatby,
                 'mesic_posledni_platby' => $uzivatelKPromlceni->mesicPosledniPlatby,
@@ -208,6 +220,27 @@ SQL,
         }
 
         return $obsah;
+    }
+
+    /**
+     * Vytvoří data pro CFO report se zůstatky všech uživatelů v databázi.
+     * Posílá se před i po promlčení, aby šly oba snímky porovnat.
+     *
+     * @return array[] Data připravená pro Report::zPole()
+     */
+    public function vytvorCfoReportVsechZustatku(): array
+    {
+        return dbFetchAll(<<<SQL
+SELECT
+    uzivatele_hodnoty.id_uzivatele,
+    uzivatele_hodnoty.login_uzivatele AS nick,
+    uzivatele_hodnoty.jmeno_uzivatele,
+    uzivatele_hodnoty.prijmeni_uzivatele,
+    uzivatele_hodnoty.email1_uzivatele AS email,
+    uzivatele_hodnoty.zustatek AS aktualni_zustatek
+FROM uzivatele_hodnoty
+SQL,
+        );
     }
 
     /**
@@ -240,7 +273,7 @@ SQL,
             self::SKUPINA_PROMLCENI,
             $this->nazevAkceVarovaniMesic($rocnik),
             $pocetEmailu,
-            Uzivatel::zId(Uzivatel::SYSTEM, true),
+            \Uzivatel::zId(\Uzivatel::SYSTEM, true),
         );
     }
 
@@ -255,7 +288,7 @@ SQL,
             self::SKUPINA_PROMLCENI,
             $this->nazevAkceVarovaniTyden($rocnik),
             $pocetEmailu,
-            Uzivatel::zId(Uzivatel::SYSTEM, true),
+            \Uzivatel::zId(\Uzivatel::SYSTEM, true),
         );
     }
 
@@ -263,15 +296,15 @@ SQL,
      * Zaloguje provedení automatického promlčení
      */
     public function zalogujAutomatickePromlceni(
-        int   $rocnik,
-        int   $pocetUzivatelu,
+        int $rocnik,
+        int $pocetUzivatelu,
         float $celkovaSuma,
     ): void {
         $this->zalogujHromadnouAkci(
             self::SKUPINA_PROMLCENI,
             $this->nazevAkceAutomatickePromlceni($rocnik),
-            "$pocetUzivatelu uživatelů, $celkovaSuma Kč",
-            Uzivatel::zId(Uzivatel::SYSTEM, true),
+            "{$pocetUzivatelu} uživatelů, {$celkovaSuma} Kč",
+            \Uzivatel::zId(\Uzivatel::SYSTEM, true),
         );
     }
 
@@ -279,24 +312,25 @@ SQL,
      * Odešle varovné e-maily uživatelům o promlčení zůstatků
      *
      * @param TypVarovaniPromlceni $typVarovani Typ varovného e-mailu (měsíc/týden před registrací)
-     * @param bool $znovu Zda má být varovný e-mail odeslán znovu i když už byl odeslán
+     * @param bool                 $znovu       Zda má být varovný e-mail odeslán znovu i když už byl odeslán
+     *
      * @return int Počet odeslaných e-mailů, nebo -1 pokud se odeslání nespustilo
      */
     public function odesliVarovneEmaily(
         TypVarovaniPromlceni $typVarovani,
-        bool                 $znovu = false,
+        bool $znovu = false,
     ): int {
-        $rocnik  = $this->systemoveNastaveni->rocnik();
+        $rocnik = $this->systemoveNastaveni->rocnik();
         $regGcOd = $this->systemoveNastaveni->prihlasovaniUcastnikuOd($rocnik);
 
         // Zkontroluj, jestli je správný čas
-        $casovyOffset       = match ($typVarovani) {
+        $casovyOffset = match ($typVarovani) {
             TypVarovaniPromlceni::MESIC => '-1 month',
             TypVarovaniPromlceni::TYDEN => '-1 week',
         };
-        $ocekavanyTermin    = (clone $regGcOd)->modify($casovyOffset);
+        $ocekavanyTermin = (clone $regGcOd)->modify($casovyOffset);
         $ocekavanyTerminMax = (clone $ocekavanyTermin)->modify('+23 hours');
-        $ted                = $this->systemoveNastaveni->ted();
+        $ted = $this->systemoveNastaveni->ted();
 
         // Spustit pouze pokud jsme v rozmezí (s tolerancí 23 hodin)
         if ($ted < $ocekavanyTermin || $ted > $ocekavanyTerminMax) {
@@ -314,9 +348,9 @@ SQL,
             return -1;
         }
 
-        if (!$znovu && $this->jizOdeslano($typVarovani, $rocnik)) {
+        if (! $znovu && $this->jizOdeslano($typVarovani, $rocnik)) {
             $nazev = $this->dejNazevVarovani($typVarovani);
-            $this->jobResultLogger->logs("Varovné e-maily o promlčení ($nazev): E-maily už byly odeslány pro rocnik $rocnik");
+            $this->jobResultLogger->logs("Varovné e-maily o promlčení ({$nazev}): E-maily už byly odeslány pro rocnik {$rocnik}");
 
             return -1;
         }
@@ -325,25 +359,25 @@ SQL,
 
         if (count($uzivatele) === 0) {
             $nazev = $this->dejNazevVarovani($typVarovani);
-            $this->jobResultLogger->logs("Varovné e-maily o promlčení ($nazev): Žádní uživatelé k varování");
+            $this->jobResultLogger->logs("Varovné e-maily o promlčení ({$nazev}): Žádní uživatelé k varování");
 
             return -1;
         }
 
-        $pocetLet              = self::ROK_NEPLATNOST;
+        $pocetLet = self::ROK_NEPLATNOST;
         $pocetOdeslanychEmailu = 0;
 
         foreach ($uzivatele as $uzivatelKPromlceni) {
             $uzivatel = $uzivatelKPromlceni->uzivatel;
-            if (!$uzivatel->mail()) {
+            if (! $uzivatel->mail()) {
                 continue;
             }
 
-            $zustatek = (int)$uzivatel->finance()->stav();
-            $jmeno    = $uzivatel->jmenoNick();
+            $zustatek = (int) $uzivatel->finance()->stav();
+            $jmeno = $uzivatel->jmenoNick();
 
             $predmet = $this->dejEmailPredmet($typVarovani, $rocnik, $zustatek);
-            $zprava  = $this->dejEmailZpravu($typVarovani, $rocnik, $jmeno, $zustatek, $pocetLet, $regGcOd, $uzivatel);
+            $zprava = $this->dejEmailZpravu($typVarovani, $rocnik, $jmeno, $zustatek, $pocetLet, $regGcOd, $uzivatel);
 
             (new GcMail($this->systemoveNastaveni))
                 ->adresat($uzivatel->mail())
@@ -351,7 +385,7 @@ SQL,
                 ->text($zprava)
                 ->odeslat(GcMail::FORMAT_TEXT);
 
-            $pocetOdeslanychEmailu++;
+            ++$pocetOdeslanychEmailu;
             set_time_limit(10); // Prodloužit timeout pro každý e-mail
         }
 
@@ -365,7 +399,7 @@ SQL,
         $this->odesliInfoCfo($typVarovani, $rocnik, $pocetOdeslanychEmailu, $pocetLet, $regGcOd);
 
         $nazev = $this->dejNazevVarovani($typVarovani);
-        $this->jobResultLogger->logs("Varovné e-maily o promlčení ($nazev): Odesláno $pocetOdeslanychEmailu e-mailů");
+        $this->jobResultLogger->logs("Varovné e-maily o promlčení ({$nazev}): Odesláno {$pocetOdeslanychEmailu} e-mailů");
 
         return $pocetOdeslanychEmailu;
     }
@@ -380,73 +414,75 @@ SQL,
 
     private function dejEmailPredmet(
         TypVarovaniPromlceni $typVarovani,
-        int                  $rocnik,
-        int                  $zustatek,
+        int $rocnik,
+        int $zustatek,
     ): string {
         return match ($typVarovani) {
-            TypVarovaniPromlceni::MESIC => "GameCon $rocnik - Tvůj zůstatek {$zustatek} Kč bude promlčen",
-            TypVarovaniPromlceni::TYDEN => "PŘIPOMÍNKA: GameCon $rocnik - Tvůj zůstatek {$zustatek} Kč bude promlčen",
+            TypVarovaniPromlceni::MESIC => "GameCon {$rocnik} - Tvůj zůstatek {$zustatek} Kč bude promlčen",
+            TypVarovaniPromlceni::TYDEN => "PŘIPOMÍNKA: GameCon {$rocnik} - Tvůj zůstatek {$zustatek} Kč bude promlčen",
         };
     }
 
     private function dejEmailZpravu(
         TypVarovaniPromlceni $typVarovani,
-        int                  $rocnik,
-        string               $jmeno,
-        int                  $zustatek,
-        int                  $pocetLet,
-        \DateTimeInterface   $regGcOd,
-        \Uzivatel            $uzivatel,
+        int $rocnik,
+        string $jmeno,
+        int $zustatek,
+        int $pocetLet,
+        \DateTimeInterface $regGcOd,
+        \Uzivatel $uzivatel,
     ): string {
         // Formátování počtu let
-        $pattern      = <<<ICU
+        $pattern = <<<ICU
         {pocetLet, plural,
             one {poslední # rok}
             few {poslední # roky}
             other {posledních # let}
         }
         ICU;
-        $formatter    = new \MessageFormatter('cs_CZ', $pattern);
-        $posledniRoky = trim($formatter->format(['pocetLet' => $pocetLet]));
-        $a            = $uzivatel->koncovkaDlePohlavi();
+        $formatter = new \MessageFormatter('cs_CZ', $pattern);
+        $posledniRoky = trim($formatter->format([
+            'pocetLet' => $pocetLet,
+        ]));
+        $a = $uzivatel->koncovkaDlePohlavi();
 
         return match ($typVarovani) {
             TypVarovaniPromlceni::MESIC => <<<TEXT
-Ahoj $jmeno,
+Ahoj {$jmeno},
 
-máš na GameCon účtu zůstatek $zustatek Kč, ale {$posledniRoky} jsi se GameConu nezúčastnil{$a}.
+máš na GameCon účtu zůstatek {$zustatek} Kč, ale {$posledniRoky} jsi se GameConu nezúčastnil{$a}.
 
 Hrozí promlčení zůstatku na Tvém GameCon účtu kvůli tvé neaktivitě.
 
-Zůstatek bude promlčen krátce po skončení letošního GameConu $rocnik.
+Zůstatek bude promlčen krátce po skončení letošního GameConu {$rocnik}.
 
 Co můžeš proti tomu udělat:
-- Registrovat se na letošní GameCon $rocnik (registrace začnou {$regGcOd->format('d.m.Y')})
+- Registrovat se na letošní GameCon {$rocnik} (registrace začnou {$regGcOd->format('d.m.Y')})
 - Kontaktovat nás na info@gamecon.cz a domluvit se, kam chceš zůstatek vrátit
 
-Tvůj zůstatek: $zustatek Kč
+Tvůj zůstatek: {$zustatek} Kč
 
 Děkujeme za pochopení!
 Tvůj
 organizační tým GameConu
 TEXT,
             TypVarovaniPromlceni::TYDEN => <<<TEXT
-Ahoj $jmeno,
+Ahoj {$jmeno},
 
 toto je připomínka našeho předchozího e-mailu.
 
-Máš na GameCon účtu zůstatek $zustatek Kč, ale {$posledniRoky} jsi se GameConu nezúčastnil{$a}.
+Máš na GameCon účtu zůstatek {$zustatek} Kč, ale {$posledniRoky} jsi se GameConu nezúčastnil{$a}.
 
 REGISTRACE UŽ ZA TÝDEN!
-Registrace na GameCon $rocnik začínají {$regGcOd->formatCasZacatekUdalosti()}.
+Registrace na GameCon {$rocnik} začínají {$regGcOd->formatCasZacatekUdalosti()}.
 
 Pokud se nezaregistruješ a nezúčastníš se letošního GameConu, tvůj zůstatek bude promlčen krátce po skončení akce.
 
 Co můžeš udělat:
-- Registrovat se na letošní GameCon $rocnik
+- Registrovat se na letošní GameCon {$rocnik}
 - Kontaktovat nás na info@gamecon.cz, pokud máš dotazy
 
-Tvůj zůstatek: $zustatek Kč
+Tvůj zůstatek: {$zustatek} Kč
 
 Děkujeme!
 Tvůj
@@ -457,16 +493,16 @@ TEXT,
 
     private function odesliInfoCfo(
         TypVarovaniPromlceni $typVarovani,
-        int                  $rocnik,
-        int                  $pocetEmailu,
-        int                  $pocetLet,
-        \DateTimeInterface   $regGcOd,
+        int $rocnik,
+        int $pocetEmailu,
+        int $pocetLet,
+        \DateTimeInterface $regGcOd,
     ): void {
-        $cfosEmaily = Uzivatel::cfosEmaily();
+        $cfosEmaily = \Uzivatel::cfosEmaily();
 
         $predmet = match ($typVarovani) {
-            TypVarovaniPromlceni::MESIC => "Varovné e-maily o promlčení zůstatků: odesláno $pocetEmailu e-mailů",
-            TypVarovaniPromlceni::TYDEN => "Připomínka promlčení zůstatků: odesláno $pocetEmailu e-mailů",
+            TypVarovaniPromlceni::MESIC => "Varovné e-maily o promlčení zůstatků: odesláno {$pocetEmailu} e-mailů",
+            TypVarovaniPromlceni::TYDEN => "Připomínka promlčení zůstatků: odesláno {$pocetEmailu} e-mailů",
         };
 
         $typTextu = match ($typVarovani) {
@@ -477,13 +513,13 @@ TEXT,
         $nazev = $this->dejNazevVarovani($typVarovani);
 
         $zprava = <<<TEXT
-$typTextu e-maily o promlčení zůstatků ($nazev před otevřením registrací) byly odeslány.
+{$typTextu} e-maily o promlčení zůstatků ({$nazev} před otevřením registrací) byly odeslány.
 
-Počet uživatelů: $pocetEmailu
+Počet uživatelů: {$pocetEmailu}
 Registrace začínají: {$regGcOd->format('d.m.Y H:i')}
-Počet let neúčasti: $pocetLet
+Počet let neúčasti: {$pocetLet}
 
-Uživatelé byli {$this->varovani($typVarovani)}, že jejich zůstatky budou promlčeny po skončení GameConu $rocnik, pokud se nezúčastní.
+Uživatelé byli {$this->varovani($typVarovani)}, že jejich zůstatky budou promlčeny po skončení GameConu {$rocnik}, pokud se nezúčastní.
 TEXT;
 
         (new GcMail($this->systemoveNastaveni))
@@ -510,7 +546,6 @@ TEXT;
         } !== null;
     }
 
-
     /**
      * Zjistí, zda už bylo pro daný ročník odesláno varovné upozornění (1 měsíc před)
      */
@@ -535,17 +570,16 @@ TEXT;
 
     private function nazevAkceVarovaniMesic(int $rocnik): string
     {
-        return "varovani-mesic-$rocnik";
+        return "varovani-mesic-{$rocnik}";
     }
 
     private function nazevAkceVarovaniTyden(int $rocnik): string
     {
-        return "varovani-tyden-$rocnik";
+        return "varovani-tyden-{$rocnik}";
     }
 
     private function nazevAkceAutomatickePromlceni(int $rocnik): string
     {
-        return "automaticke-promlceni-$rocnik";
+        return "automaticke-promlceni-{$rocnik}";
     }
-
 }

--- a/tests/Model/Uzivatel/PromlceniZustatkuTest.php
+++ b/tests/Model/Uzivatel/PromlceniZustatkuTest.php
@@ -31,6 +31,9 @@ class PromlceniZustatkuTest extends AbstractTestDb
     private const ID_ZAPORNY_ZUSTATEK = 1004;
     private const ID_KLADNY_ZUSTATEK_NIKDY_NEMEL_UCAST = 1005;
     private const ID_KLADNY_ZUSTATEK_STARA_UCAST_2 = 1006;
+    private const ID_STARA_UCAST_NEDAVNA_PLATBA = 1007;
+    private const ID_STARA_UCAST_NEDAVNA_ZAPORNA_PLATBA = 1008;
+    private const ID_STARA_UCAST_NEDAVNY_NULOVY_POHYB = 1009;
 
     protected static bool $disableStrictTransTables = true;
 
@@ -90,7 +93,7 @@ class PromlceniZustatkuTest extends AbstractTestDb
             'Neúčastnil',
             250.0,
         );
-        $queries[] = self::platbaQuery(self::ID_KLADNY_ZUSTATEK_NIKDY_NEMEL_UCAST, 250.0, $rocnik - 2);
+        $queries[] = self::platbaQuery(self::ID_KLADNY_ZUSTATEK_NIKDY_NEMEL_UCAST, 250.0, $staryRocnik);
 
         // Druhý uživatel k promlčení pro testování více uživatelů najednou
         $queries[] = self::uzivatelQuery(
@@ -101,6 +104,37 @@ class PromlceniZustatkuTest extends AbstractTestDb
         );
         $queries[] = self::prihlasenNaRocnikQuery(self::ID_KLADNY_ZUSTATEK_STARA_UCAST_2, $staryRocnik);
         $queries[] = self::platbaQuery(self::ID_KLADNY_ZUSTATEK_STARA_UCAST_2, 100.0, $staryRocnik, 3, 15);
+
+        // Stará účast, ale poslal peníze v době promlčecí lhůty - NESMÍ být promlčen
+        $queries[] = self::uzivatelQuery(
+            self::ID_STARA_UCAST_NEDAVNA_PLATBA,
+            'Stará',
+            'Účast Nedávná Platba',
+            400.0,
+        );
+        $queries[] = self::prihlasenNaRocnikQuery(self::ID_STARA_UCAST_NEDAVNA_PLATBA, $staryRocnik);
+        $queries[] = self::platbaQuery(self::ID_STARA_UCAST_NEDAVNA_PLATBA, 400.0, $rocnik - 1);
+
+        // Stará účast a v promlčecí lhůtě jen záporný pohyb (vratka) - NESMÍ být promlčen,
+        // účet není nečinný
+        $queries[] = self::uzivatelQuery(
+            self::ID_STARA_UCAST_NEDAVNA_ZAPORNA_PLATBA,
+            'Stará',
+            'Účast Záporná Platba',
+            350.0,
+        );
+        $queries[] = self::prihlasenNaRocnikQuery(self::ID_STARA_UCAST_NEDAVNA_ZAPORNA_PLATBA, $staryRocnik);
+        $queries[] = self::platbaQuery(self::ID_STARA_UCAST_NEDAVNA_ZAPORNA_PLATBA, -50.0, $rocnik - 1);
+
+        // Stará účast a v promlčecí lhůtě jen nulový pohyb - NESMÍ být promlčen
+        $queries[] = self::uzivatelQuery(
+            self::ID_STARA_UCAST_NEDAVNY_NULOVY_POHYB,
+            'Stará',
+            'Účast Nulový Pohyb',
+            320.0,
+        );
+        $queries[] = self::prihlasenNaRocnikQuery(self::ID_STARA_UCAST_NEDAVNY_NULOVY_POHYB, $staryRocnik);
+        $queries[] = self::platbaQuery(self::ID_STARA_UCAST_NEDAVNY_NULOVY_POHYB, 0.0, $rocnik - 1);
 
         return $queries;
     }
@@ -337,6 +371,69 @@ SQL;
     /**
      * @test
      */
+    public function nenajdeUzivateleSNedavnouKladnouPlatbou()
+    {
+        $promlceniZustatku = $this->dejPromlceniZustatku();
+        $uzivatele = $promlceniZustatku->najdiUzivateleKPromlceni();
+
+        $idsUzivatelu = array_map(
+            fn (UzivatelKPromlceni $u) => $u->uzivatel->id(),
+            $uzivatele,
+        );
+
+        self::assertNotContains(
+            self::ID_STARA_UCAST_NEDAVNA_PLATBA,
+            $idsUzivatelu,
+            'Uživatel, který v promlčecí lhůtě poslal peníze, NESMÍ být nalezen k promlčení,'
+            . ' i když na GC dlouho nebyl',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function nenajdeUzivateleSNedavnymNulovymPohybem()
+    {
+        $promlceniZustatku = $this->dejPromlceniZustatku();
+        $uzivatele = $promlceniZustatku->najdiUzivateleKPromlceni();
+
+        $idsUzivatelu = array_map(
+            fn (UzivatelKPromlceni $u) => $u->uzivatel->id(),
+            $uzivatele,
+        );
+
+        self::assertNotContains(
+            self::ID_STARA_UCAST_NEDAVNY_NULOVY_POHYB,
+            $idsUzivatelu,
+            'Uživatel s nulovým pohybem v promlčecí lhůtě NESMÍ být nalezen k promlčení -'
+            . ' na účtu se něco dělo',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function nenajdeUzivateleSNedavnouZapornouPlatbou()
+    {
+        $promlceniZustatku = $this->dejPromlceniZustatku();
+        $uzivatele = $promlceniZustatku->najdiUzivateleKPromlceni();
+
+        $idsUzivatelu = array_map(
+            fn (UzivatelKPromlceni $u) => $u->uzivatel->id(),
+            $uzivatele,
+        );
+
+        self::assertNotContains(
+            self::ID_STARA_UCAST_NEDAVNA_ZAPORNA_PLATBA,
+            $idsUzivatelu,
+            'Uživatel se záporným pohybem (vratkou) v promlčecí lhůtě NESMÍ být nalezen'
+            . ' k promlčení - účet není nečinný',
+        );
+    }
+
+    /**
+     * @test
+     */
     public function nenajdeUzivateleSNedavnouUcasti()
     {
         $promlceniZustatku = $this->dejPromlceniZustatku();
@@ -421,6 +518,72 @@ SQL;
 
         // Zkontrolujeme informaci o účasti
         self::assertStringContainsString((string) $staryRocnik, $uzivatelDto->prihlaseniNaRocniky);
+    }
+
+    /**
+     * @test
+     */
+    public function reportVsechZustatkuObsahujeIUzivateleKteriSeNepromlcuji()
+    {
+        $promlceniZustatku = $this->dejPromlceniZustatku();
+        $report = $promlceniZustatku->vytvorCfoReportVsechZustatku();
+
+        $idsVReportu = array_column($report, 'id_uzivatele');
+        $idsVReportu = array_map('intval', $idsVReportu);
+
+        self::assertContains(
+            self::ID_KLADNY_ZUSTATEK_STARA_UCAST,
+            $idsVReportu,
+            'Report všech zůstatků musí obsahovat i uživatele určené k promlčení',
+        );
+        self::assertContains(
+            self::ID_KLADNY_ZUSTATEK_NEDAVNA_UCAST,
+            $idsVReportu,
+            'Report všech zůstatků musí obsahovat i uživatele s nedávnou účastí',
+        );
+        self::assertContains(
+            self::ID_NULOVY_ZUSTATEK,
+            $idsVReportu,
+            'Report všech zůstatků musí obsahovat i uživatele s nulovým zůstatkem',
+        );
+        self::assertContains(
+            self::ID_ZAPORNY_ZUSTATEK,
+            $idsVReportu,
+            'Report všech zůstatků musí obsahovat i dlužníky',
+        );
+
+        $pocetUzivateluKPromlceni = count($promlceniZustatku->najdiUzivateleKPromlceni());
+        self::assertGreaterThan(
+            $pocetUzivateluKPromlceni,
+            count($report),
+            'Report všech zůstatků musí být širší než seznam uživatelů k promlčení',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function reportVsechZustatkuObsahujeOcekavaneSloupce()
+    {
+        $promlceniZustatku = $this->dejPromlceniZustatku();
+        $report = $promlceniZustatku->vytvorCfoReportVsechZustatku();
+
+        self::assertNotEmpty($report);
+
+        $radekTestovacihoUzivatele = null;
+        foreach ($report as $radek) {
+            if ((int) $radek['id_uzivatele'] === self::ID_KLADNY_ZUSTATEK_STARA_UCAST) {
+                $radekTestovacihoUzivatele = $radek;
+                break;
+            }
+        }
+
+        self::assertNotNull($radekTestovacihoUzivatele);
+        self::assertSame(
+            ['id_uzivatele', 'nick', 'jmeno_uzivatele', 'prijmeni_uzivatele', 'email', 'aktualni_zustatek'],
+            array_keys($radekTestovacihoUzivatele),
+        );
+        self::assertSame(500.0, (float) $radekTestovacihoUzivatele['aktualni_zustatek']);
     }
 
     /**


### PR DESCRIPTION
[1378 Automatické promlčování zůstatků](https://trello.com/c/t20Zkf1J)

Dvě opravy v automatickém promlčování zůstatků, obě vůči zadání z [draftu procesu](https://trello.com/c/t20Zkf1J#comment-68fdef27e7659deb9e19fe8c) na kartě.

## 1. Nepromlčovat zůstatky při pohybu na účtu

Zadání říká „vylistovat všechny co letos+3 roky zpátky nebyli na GC **ani nemají pohyb na účtu**". Implementace ale pohyb na účtu jako podmínku výběru nepoužívala — datum poslední platby jen *vypisovala* do CFO reportu. Rozhodovalo se výhradně podle účasti na GC.

Prakticky to znamenalo, že člověk, který loni poslal peníze, o ně mohl přijít jen proto, že zrovna nedorazil na GC. Na produkčních datech se to týkalo **11 lidí / 7 373 Kč** — např. uživatel s platbou ze 7. 7. 2025 a zůstatkem 2 903 Kč.

Nově se vyřazuje každý, komu se za promlčecí lhůtu na účtu cokoli dělo — **jakýkoli pohyb bez ohledu na znaménko** (příchozí platba, vratka i nulový pohyb). Vratka znamená, že účet není nečinný, stejně jako platba.

## 2. CFO dostane zůstatky všech uživatelů i před promlčením

Zadání žádá report všech zůstatků **dvakrát — před i po** promlčení, aby šly porovnat. Mail „Report před promlčením" ale vezl jen užší seznam kandidátů; snímek všech zůstatků chodil až v mailu „DOKONČENO".

Mail před promlčením teď nese **dvě** přílohy:

| Příloha | Obsah |
|---|---|
| `promlceni-zustatku-gc-YYYY-pred.xlsx` | kandidáti na promlčení (beze změny) |
| `zustatky-vsech-uzivatelu-pred-promlcenim-gc-YYYY.xlsx` | zůstatky všech uživatelů v DB |

Dotaz na zůstatky všech uživatelů byl v cron jobu napsaný inline. Vytáhl jsem ho do `PromlceniZustatku::vytvorCfoReportVsechZustatku()`, kterou teď volají oba snímky — nemůžou se tak rozejít, když někdo časem přidá sloupec.

## Dopad na produkční data

Měřeno na lokální kopii produkční DB (6 135 uživatelů, 814 s kladným zůstatkem / 299 403 Kč):

| | Lidí | Částka |
|---|---:|---:|
| Před opravou | 274 | 84 078 Kč |
| **Po opravě** | **263** | **76 705 Kč** |

Rozšíření z „kladná platba" na „jakýkoli pohyb" nevyloučí na dnešních datech nikoho navíc — v DB neexistuje nikdo, kdo by po roce 2023 měl jen nekladný pohyb a žádný kladný. Změna je tedy korektnější vůči zadání, ale chová se zatím identicky. Ošetřuje případ, který nastat může (vratka bez následné platby), jen zrovna teď nenastává.

## Testy

`vendor/bin/phpunit tests/Model/Uzivatel/PromlceniZustatkuTest.php` → **26/26 OK**

Nové případy (všechny nejdřív ověřeny, že proti staré logice padají):

- `nenajdeUzivateleSNedavnouKladnouPlatbou` — stará účast + platba loni → nepromlčet
- `nenajdeUzivateleSNedavnouZapornouPlatbou` — jen vratka → nepromlčet
- `nenajdeUzivateleSNedavnymNulovymPohybem` — nulový pohyb → nepromlčet (v produkci je 19 takových řádků)
- `reportVsechZustatkuObsahujeIUzivateleKteriSeNepromlcuji` — snímek musí obsahovat i nulové zůstatky a dlužníky
- `reportVsechZustatkuObsahujeOcekavaneSloupce`

Upravil jsem i fixture `ID_KLADNY_ZUSTATEK_NIKDY_NEMEL_UCAST`, která měla platbu uvnitř nové ochranné lhůty — jinak by původní test tvrdil opak nového pravidla. Posunul jsem ji mimo lhůtu, čímž zůstal zachovaný jeho záměr.

Ověřil jsem i mimo testy, že se dvě přílohy na jednom `GcMail` nepřepíšou: `prilohaSoubor()` appenduje, ale `prilohaNazev()` přejmenovává *poslední* položku, takže na pořadí volání záleží.

## Poznámky k nasazení

Většina diffu je přeformátování od ECS (heredoc `{$var}`, mezery). Vlastní logická změna je 6 řádků SQL v `najdiUzivateleKPromlceni()` a nová metoda `vytvorCfoReportVsechZustatku()`.

**Tenhle PR sám o sobě nic nespustí.** Promlčení ani upomínky dlužníkům dosud nikdy neběžely, protože na console.cron-job.org chybí naplánované úlohy — je potřeba přidat **dvě**, obě denně:

```
?key=CRON_KEY&job=promlceni
?key=CRON_KEY&job=dluznici
```

Denní frekvence je u `dluznici` nutná — upomínky mají pevné 23hodinové okno, takže při delší periodě můžou okno minout úplně.

Před zapnutím je potřeba rozhodnout, jestli nechat doběhnout zpětně ročník 2026: guard v `hromadne_akce_log` je prázdný, takže první běh promlčí těch 263 lidí naráz a CFO reporty odejdou okamžitě.
