### PR TITLE
Kontakty účastníků až po potvrzení podmínek

### DIFF
--- a/admin/files/design/online-prezence.css
+++ b/admin/files/design/online-prezence.css
@@ -152,3 +152,43 @@ input[disabled]::placeholder {
     font-size: smaller;
   }
 }
+
+/*
+ * Zamčené kontakty: skutečná hodnota se do HTML vůbec nedostane, rozmazaná
+ * atrapa je jen zástupný text. Rozmazává se tedy atrapa, ne pravý kontakt –
+ * vypnutí CSS nic neodhalí.
+ */
+.kontakt-atrapa {
+  display: inline-block;
+  filter: blur(3px);
+  opacity: 0.6;
+  user-select: none;
+  letter-spacing: 1px;
+}
+
+/*
+ * Odlišené od atrapy schválně: atrapa slibuje "po potvrzení uvidíš", tohle
+ * říká "tady se nic neukáže ani po potvrzení". Splynout by nesměly, jinak
+ * uživatel odklikne souhlas kvůli kontaktu, který stejně nedostane.
+ *
+ * Proto zákazová ikona, ne přeškrtnuté oko: "skryto" platí pro oba stavy,
+ * kdežto "nepřístupné" jen pro tenhle. A na rozdíl od rozmazané atrapy je
+ * ikona ostrá – liší se i texturou, nejen tvarem.
+ */
+.kontakt-nedostupny {
+  color: #b0453b;
+  opacity: 0.5;
+  cursor: help;
+}
+
+.kontakty-zamcene-pruh {
+  color: #6c757d;
+}
+
+.kontakty-zamcene-pruh .fa-lock {
+  margin-right: 0.35em;
+}
+
+.kontakty-zamcene-pruh .odemknout-kontakty {
+  margin-left: 0.75em;
+}

--- a/admin/files/online-prezence/online-prezence-odemknuti-kontaktu.js
+++ b/admin/files/online-prezence/online-prezence-odemknuti-kontaktu.js
@@ -3,8 +3,12 @@
  *
  * Rozhodnutí drží server v session, ne cookie ani localStorage – jinak by si
  * odemčení nastavil i ten, kdo souhlas odklikat nechce, a do logu by se to
- * nepropsalo. Po potvrzení proto stránku znovu načteme a kontakty vykreslí
- * server; klient sám nic neodkrývá.
+ * nepropsalo.
+ *
+ * Kontakty se do HTML vůbec nedostanou, dokud není potvrzeno, takže je nejde
+ * jen odkrýt v prohlížeči – server musí řádky překreslit. Odpověď na potvrzení
+ * proto rovnou nese hotové HTML účastníků a klient jen vymění obsah tabulky.
+ * Reload stránky by uživatele odscrolloval pryč od aktivity, kterou zrovna řeší.
  */
 document.addEventListener('DOMContentLoaded', function () {
   const modalNode = document.getElementById('modalOdemknoutKontakty')
@@ -31,25 +35,76 @@ document.addEventListener('DOMContentLoaded', function () {
     potvrzovaciTlacitkoNode.disabled = true
   })
 
+  /**
+   * @param {string|number} idAktivity
+   * @param {Array<{id_uzivatele: number, html_ucastnika: string}>} ucastnici
+   * @param {Array<string>} emaily
+   */
+  function vymenRadkyUcastniku(idAktivity, ucastnici, emaily) {
+    const aktivitaNode = document.getElementById(`aktivita-${idAktivity}`)
+    if (!aktivitaNode) {
+      return
+    }
+
+    const ucastniciSeznam = aktivitaNode.querySelector('.ucastnici-seznam')
+    if (ucastniciSeznam && ucastnici) {
+      ucastniciSeznam.innerHTML = ''
+      ucastnici.forEach(function (ucastnikData) {
+        const htmlUcastnika = (ucastnikData.html_ucastnika || '').trim()
+        if (htmlUcastnika === '') {
+          return
+        }
+        const template = document.createElement('template')
+        template.innerHTML = htmlUcastnika
+        ucastniciSeznam.appendChild(template.content.firstChild)
+      })
+    }
+
+    // hromadný mailto odkaz je do potvrzení schovaný, teď ho odkryjeme a naplníme
+    const emailyNode = document.getElementById(`emaily-${idAktivity}`)
+    if (emailyNode) {
+      emailyNode.classList.remove('display-none')
+      const emailyAnchor = emailyNode.querySelector('a')
+      if (emailyAnchor && emaily) {
+        emailyAnchor.href = 'mailto:?bcc=' + emaily.join(',')
+        emailyAnchor.innerText = emaily.join(', ')
+      }
+    }
+
+    const zamykaciPruhNode = document.getElementById(`kontakty-zamcene-${idAktivity}`)
+    if (zamykaciPruhNode) {
+      zamykaciPruhNode.remove()
+    }
+
+    // stejná konvence jako u načtení počátečního stavu – naváže tooltipy,
+    // hlídání změn a ukazatele zaplněnosti na nově vložené řádky
+    document.dispatchEvent(new CustomEvent('aktivitaVyrenderovana', {detail: aktivitaNode}))
+  }
+
   potvrzovaciTlacitkoNode.addEventListener('click', function () {
     if (!checkboxNode.checked || !odemykanaAktivitaId) {
       return
     }
+    const odemykanaAktivitaIdProTentoKlik = odemykanaAktivitaId
     potvrzovaciTlacitkoNode.disabled = true
 
     const telo = new FormData()
     telo.append('ajax', '1')
     telo.append('akce', 'odemknout-kontakty')
-    telo.append('idAktivity', odemykanaAktivitaId)
+    telo.append('idAktivity', odemykanaAktivitaIdProTentoKlik)
 
     fetch(window.location.href, {method: 'POST', body: telo})
       .then(function (odpoved) {
-        if (!odpoved.ok) {
-          return odpoved.json().then(function (data) {
+        return odpoved.json().then(function (data) {
+          if (!odpoved.ok) {
             throw new Error((data.errors && data.errors[0]) || 'Kontakty se nepodařilo zobrazit')
-          })
-        }
-        window.location.reload()
+          }
+          return data
+        })
+      })
+      .then(function (data) {
+        vymenRadkyUcastniku(odemykanaAktivitaIdProTentoKlik, data.ucastnici, data.emaily)
+        jQuery(modalNode).modal('hide')
       })
       .catch(function (chyba) {
         potvrzovaciTlacitkoNode.disabled = false

--- a/admin/files/online-prezence/online-prezence-odemknuti-kontaktu.js
+++ b/admin/files/online-prezence/online-prezence-odemknuti-kontaktu.js
@@ -1,0 +1,59 @@
+/**
+ * Souhlas se zobrazením kontaktů účastníků (e-maily, telefony).
+ *
+ * Rozhodnutí drží server v session, ne cookie ani localStorage – jinak by si
+ * odemčení nastavil i ten, kdo souhlas odklikat nechce, a do logu by se to
+ * nepropsalo. Po potvrzení proto stránku znovu načteme a kontakty vykreslí
+ * server; klient sám nic neodkrývá.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  const modalNode = document.getElementById('modalOdemknoutKontakty')
+  if (!modalNode) {
+    return
+  }
+
+  const checkboxNode = document.getElementById('souhlasSPodminkamiKontaktu')
+  const potvrzovaciTlacitkoNode = document.getElementById('potvrditOdemceniKontaktu')
+  let odemykanaAktivitaId = null
+
+  Array.from(document.getElementsByClassName('odemknout-kontakty')).forEach(function (tlacitkoNode) {
+    tlacitkoNode.addEventListener('click', function () {
+      odemykanaAktivitaId = tlacitkoNode.dataset.idAktivity
+    })
+  })
+
+  checkboxNode.addEventListener('change', function () {
+    potvrzovaciTlacitkoNode.disabled = !checkboxNode.checked
+  })
+
+  jQuery(modalNode).on('hidden.bs.modal', function () {
+    checkboxNode.checked = false
+    potvrzovaciTlacitkoNode.disabled = true
+  })
+
+  potvrzovaciTlacitkoNode.addEventListener('click', function () {
+    if (!checkboxNode.checked || !odemykanaAktivitaId) {
+      return
+    }
+    potvrzovaciTlacitkoNode.disabled = true
+
+    const telo = new FormData()
+    telo.append('ajax', '1')
+    telo.append('akce', 'odemknout-kontakty')
+    telo.append('idAktivity', odemykanaAktivitaId)
+
+    fetch(window.location.href, {method: 'POST', body: telo})
+      .then(function (odpoved) {
+        if (!odpoved.ok) {
+          return odpoved.json().then(function (data) {
+            throw new Error((data.errors && data.errors[0]) || 'Kontakty se nepodařilo zobrazit')
+          })
+        }
+        window.location.reload()
+      })
+      .catch(function (chyba) {
+        potvrzovaciTlacitkoNode.disabled = false
+        window.alert(chyba.message)
+      })
+  })
+})

--- a/model/Aktivita/OnlinePrezence/OnlinePrezenceAjax.php
+++ b/model/Aktivita/OnlinePrezence/OnlinePrezenceAjax.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Gamecon\Aktivita\OnlinePrezence;
 
@@ -8,49 +10,60 @@ use Gamecon\Aktivita\RazitkoPosledniZmenyPrihlaseni;
 use Gamecon\Aktivita\StavPrihlaseni;
 use Gamecon\Aktivita\ZmenaPrihlaseni;
 use Gamecon\Aktivita\ZmenaStavuAktivity;
+use Gamecon\Logger\LogUdalosti;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Symfony\Component\Filesystem\Filesystem;
 
 class OnlinePrezenceAjax
 {
-    public const AJAX           = 'ajax';
-    public const KEEP_ALIVE     = 'keep-alive';
+    public const AJAX = 'ajax';
+    public const KEEP_ALIVE = 'keep-alive';
     public const POSLEDNI_ZMENY = 'posledni-zmeny';
     public const POCATECNI_STAV = 'pocatecni-stav';
+    public const ODEMKNOUT_KONTAKTY = 'odemknout-kontakty';
 
-    public const POSLEDNI_LOGY_AKTIVIT_AJAX_KLIC    = 'posledni_logy_aktivit_ajax_klic';
-    public const POSLEDNI_LOGY_UCASTNIKU_AJAX_KLIC  = 'posledni_logy_ucastniku_ajax_klic';
-    public const ID_AKTIVITY                        = 'id_aktivity';
-    public const ID_UZIVATELE                       = 'id_uzivatele';
-    public const ID_LOGU                            = 'id_logu';
-    public const CAS_ZMENY                          = 'cas_zmeny';
-    public const STAV_AKTIVITY                      = 'stav_aktivity';
-    public const STAV_PRIHLASENI                    = 'stav_prihlaseni';
-    public const HTML_UCASTNIKA                     = 'html_ucastnika';
-    public const ZMENY_STAVU_AKTIVIT                = 'zmeny_stavu_aktivit';
-    public const ZMENY_PRIHLASENI                   = 'zmeny_prihlaseni';
-    public const RAZITKO_POSLEDNI_ZMENY             = 'razitko_posledni_zmeny';
-    public const UCASTNICI_PRIDATELNI_DO_TIMESTAMP  = 'ucastnici_pridatelni_do_timestamp';
+    public const POSLEDNI_LOGY_AKTIVIT_AJAX_KLIC = 'posledni_logy_aktivit_ajax_klic';
+    public const POSLEDNI_LOGY_UCASTNIKU_AJAX_KLIC = 'posledni_logy_ucastniku_ajax_klic';
+    public const ID_AKTIVITY = 'id_aktivity';
+    public const ID_UZIVATELE = 'id_uzivatele';
+    public const ID_LOGU = 'id_logu';
+    public const CAS_ZMENY = 'cas_zmeny';
+    public const STAV_AKTIVITY = 'stav_aktivity';
+    public const STAV_PRIHLASENI = 'stav_prihlaseni';
+    public const HTML_UCASTNIKA = 'html_ucastnika';
+    public const ZMENY_STAVU_AKTIVIT = 'zmeny_stavu_aktivit';
+    public const ZMENY_PRIHLASENI = 'zmeny_prihlaseni';
+    public const RAZITKO_POSLEDNI_ZMENY = 'razitko_posledni_zmeny';
+    public const UCASTNICI_PRIDATELNI_DO_TIMESTAMP = 'ucastnici_pridatelni_do_timestamp';
     public const UCASTNICI_ODEBRATELNI_DO_TIMESTAMP = 'ucastnici_odebratelni_do_timestamp';
-    public const ERRORS                             = 'errors';
-    public const PRIHLASEN                          = 'prihlasen';
-    public const CAS_POSLEDNI_ZMENY_PRIHLASENI      = 'cas_posledni_zmeny_prihlaseni';
-    public const AKTIVITA                           = 'aktivita';
-    public const DORAZILI                           = 'dorazili';
+    public const ERRORS = 'errors';
+    public const PRIHLASEN = 'prihlasen';
+    public const CAS_POSLEDNI_ZMENY_PRIHLASENI = 'cas_posledni_zmeny_prihlaseni';
+    public const AKTIVITA = 'aktivita';
+    public const DORAZILI = 'dorazili';
 
     public static function dejUrlAkcePosledniZmeny(): string
     {
-        return getCurrentUrlWithQuery([self::AJAX => 1, 'akce' => self::POSLEDNI_ZMENY]);
+        return getCurrentUrlWithQuery([
+            self::AJAX => 1,
+            'akce'     => self::POSLEDNI_ZMENY,
+        ]);
     }
 
     public static function dejUrlAkceKeepAlive(): string
     {
-        return getCurrentUrlWithQuery([self::AJAX => 1, 'akce' => self::KEEP_ALIVE]);
+        return getCurrentUrlWithQuery([
+            self::AJAX => 1,
+            'akce'     => self::KEEP_ALIVE,
+        ]);
     }
 
     public static function dejUrlAkcePocatecniStav(): string
     {
-        return getCurrentUrlWithQuery([self::AJAX => 1, 'akce' => self::POCATECNI_STAV]);
+        return getCurrentUrlWithQuery([
+            self::AJAX => 1,
+            'akce'     => self::POCATECNI_STAV,
+        ]);
     }
 
     /**
@@ -72,110 +85,151 @@ class OnlinePrezenceAjax
 
     public function __construct(
         OnlinePrezenceHtml $onlinePrezenceHtml,
-        Filesystem         $filesystem,
+        Filesystem $filesystem,
         SystemoveNastaveni $systemoveNastaveni,
-        bool               $testujeme,
-    )
-    {
+        bool $testujeme,
+    ) {
         $this->onlinePrezenceHtml = $onlinePrezenceHtml;
-        $this->filesystem         = $filesystem;
+        $this->filesystem = $filesystem;
         $this->systemoveNastaveni = $systemoveNastaveni;
-        $this->testujeme          = $testujeme;
+        $this->testujeme = $testujeme;
     }
 
     public function odbavAjax(\Uzivatel $vypravec)
     {
-        if (!post(self::AJAX) && !get(self::AJAX)) {
+        if (! post(self::AJAX) && ! get(self::AJAX)) {
             return false;
         }
 
         if (get('akce') === self::KEEP_ALIVE) {
             $this->echoJson([]);
+
             return true;
         }
 
         if (get('akce') === self::POCATECNI_STAV) {
             $this->ajaxDejPocatecniStav($vypravec);
+
             return true;
         }
 
         if (get('akce') === self::POSLEDNI_ZMENY) {
             $this->ajaxDejPosledniZmeny(
-                (array)post(self::POSLEDNI_LOGY_AKTIVIT_AJAX_KLIC),
-                (array)post(self::POSLEDNI_LOGY_UCASTNIKU_AJAX_KLIC),
+                (array) post(self::POSLEDNI_LOGY_AKTIVIT_AJAX_KLIC),
+                (array) post(self::POSLEDNI_LOGY_UCASTNIKU_AJAX_KLIC),
                 $vypravec,
             );
+
+            return true;
+        }
+
+        if (post('akce') === self::ODEMKNOUT_KONTAKTY) {
+            $this->ajaxOdemknoutKontakty($vypravec, (int) post('idAktivity'));
+
             return true;
         }
 
         if (post('akce') === 'uzavrit') {
-            $this->ajaxUzavritAktivitu((int)post('id'), $vypravec);
+            $this->ajaxUzavritAktivitu((int) post('id'), $vypravec);
+
             return true;
         }
 
         if (post('akce') === 'zmenitPritomnostUcastnika') {
             $zdaDorazil = post('dorazil');
             if ($zdaDorazil !== null) {
-                $zdaDorazil = (bool)$zdaDorazil;
+                $zdaDorazil = (bool) $zdaDorazil;
             }
             $this->ajaxZmenitPritomnostUcastnika(
                 $vypravec,
-                (int)post('idUcastnika'),
-                (int)post('idAktivity'),
+                (int) post('idUcastnika'),
+                (int) post('idAktivity'),
                 $zdaDorazil,
             );
+
             return true;
         }
 
         if (post('prezenceAktivity')) {
             $this->ajaxUlozPrezenci(
-                (int)post('prezenceAktivity'),
+                (int) post('prezenceAktivity'),
                 array_keys(post('zdaDorazil') ?: []),
                 $vypravec,
             );
+
             return true;
         }
 
         if (get('omnibox')) {
             $this->ajaxOmnibox(
                 $vypravec,
-                (int)get('idAktivity'),
-                (string)get('term') ?: '',
-                (array)get('dataVOdpovedi') ?: [],
+                (int) get('idAktivity'),
+                (string) get('term') ?: '',
+                (array) get('dataVOdpovedi') ?: [],
                 get('labelSlozenZ'),
             );
+
             return true;
         }
 
         $this->echoErrorJson('Neznámý AJAX požadavek');
+
         return true;
+    }
+
+    private function ajaxOdemknoutKontakty(\Uzivatel $vypravec, int $idAktivity): void
+    {
+        $aktivita = Aktivita::zId($idAktivity, true);
+        if (! $aktivita) {
+            $this->echoErrorJson('Aktivita neexistuje');
+
+            return;
+        }
+
+        // Bez této kontroly by stačilo poslat cizí ID aktivity a odemknout si
+        // kontakty na akci, se kterou nemám nic společného.
+        if (! $aktivita->maOrganizatora($vypravec) && ! $vypravec->jeOrganizator()) {
+            $this->echoErrorJson('Nemáš oprávnění zobrazit kontakty této aktivity');
+
+            return;
+        }
+
+        $this->dejPotvrzeniZobrazeniKontaktu()->potvrd($vypravec, $idAktivity);
+        $this->echoJson([
+            self::ID_AKTIVITY => $idAktivity,
+        ]);
+    }
+
+    private function dejPotvrzeniZobrazeniKontaktu(): PotvrzeniZobrazeniKontaktu
+    {
+        return new PotvrzeniZobrazeniKontaktu(new LogUdalosti());
     }
 
     private function ajaxDejPocatecniStav(\Uzivatel $vypravec): void
     {
-        $idAktivit = (array)post('id_aktivit');
+        $idAktivit = (array) post('id_aktivit');
 
         $aktivitProJson = [];
         foreach ($idAktivit as $idAktivity) {
-            $aktivita = Aktivita::zId((int)$idAktivity, true);
-            if (!$aktivita) {
+            $aktivita = Aktivita::zId((int) $idAktivity, true);
+            if (! $aktivita) {
                 continue;
             }
 
-            $konec                  = $aktivita->konec();
-            $zmenaStavuAktivity     = $aktivita->posledniZmenaStavuAktivity();
+            $konec = $aktivita->konec();
+            $zmenaStavuAktivity = $aktivita->posledniZmenaStavuAktivity();
             $editovatelnaOdTimestamp = $this->dejEditovatelnaOdTimestamp($aktivita);
 
-            $ucastniciHtml  = [];
-            $emaily         = [];
-            $prihlaseni     = $aktivita->prihlaseni();
-            $sledujici      = $aktivita->seznamSledujicich();
+            $ucastniciHtml = [];
+            $emaily = [];
+            $prihlaseni = $aktivita->prihlaseni();
+            $sledujici = $aktivita->seznamSledujicich();
             $vsichniUcastnici = array_merge($prihlaseni, $sledujici);
 
             foreach ($vsichniUcastnici as $ucastnik) {
                 $ucastniciHtml[] = [
-                    self::ID_UZIVATELE    => (int)$ucastnik->id(),
-                    self::HTML_UCASTNIKA  => $this->onlinePrezenceHtml->sestavHmlUcastnikaAktivity(
+                    self::ID_UZIVATELE   => (int) $ucastnik->id(),
+                    self::HTML_UCASTNIKA => $this->onlinePrezenceHtml->sestavHmlUcastnikaAktivity(
                         $ucastnik,
                         $aktivita,
                         $vypravec,
@@ -185,15 +239,17 @@ class OnlinePrezenceAjax
                 ];
             }
 
-            foreach ($prihlaseni as $ucastnik) {
-                $email = trim((string)$ucastnik->mail());
-                if ($email !== '') {
-                    $emaily[] = $email;
+            if ($this->dejPotvrzeniZobrazeniKontaktu()->jePotvrzeno((int) $idAktivity)) {
+                foreach ($prihlaseni as $ucastnik) {
+                    $email = trim((string) $ucastnik->mail());
+                    if ($email !== '') {
+                        $emaily[] = $email;
+                    }
                 }
             }
 
             $aktivitProJson[] = [
-                self::ID_AKTIVITY                        => (int)$idAktivity,
+                self::ID_AKTIVITY                        => (int) $idAktivity,
                 'editovatelna_od_timestamp'              => $editovatelnaOdTimestamp,
                 'konec_aktivity_v_timestamp'             => $konec ? $konec->getTimestamp() : null,
                 self::UCASTNICI_PRIDATELNI_DO_TIMESTAMP  => $this->ucastniciPridatelniDoTimestamp($vypravec, $aktivita),
@@ -208,7 +264,7 @@ class OnlinePrezenceAjax
 
         $organizovaneAktivity = array_filter(
             array_map(
-                static fn($idAktivity) => Aktivita::zId((int)$idAktivity, true),
+                static fn ($idAktivity) => Aktivita::zId((int) $idAktivity, true),
                 $idAktivit,
             ),
         );
@@ -233,38 +289,37 @@ class OnlinePrezenceAjax
     private function dejStavPrihlaseniProJs(Aktivita $aktivita, \Uzivatel $ucastnik): string
     {
         $zmenaPrihlaseni = $aktivita->dejPrezenci()->posledniZmenaPrihlaseni($ucastnik);
+
         return $zmenaPrihlaseni ? $zmenaPrihlaseni->typPrezenceProJs() : '';
     }
 
     private function dejEditovatelnaOdTimestamp(Aktivita $aktivita): int
     {
         $zacatek = $aktivita->zacatek();
-        if (!$zacatek) {
+        if (! $zacatek) {
             return 0;
         }
         $hnedEditovatelnaSeZacatkemDo = (clone $zacatek)
             ->modify("-{$this->systemoveNastaveni->aktivitaEditovatelnaXMinutPredJejimZacatkem()} minutes");
+
         return $hnedEditovatelnaSeZacatkemDo <= $this->systemoveNastaveni->ted()
             ? 0
             : time() + ($hnedEditovatelnaSeZacatkemDo->getTimestamp() - $this->systemoveNastaveni->ted()->getTimestamp());
     }
 
     /**
-     * @param string[] $posledniZnameStavyAktivit
+     * @param string[]     $posledniZnameStavyAktivit
      * @param string[][][] $idsPoslednichZnamychLoguUcastniku
-     * @param \Uzivatel $vypravec
-     * @return void
      */
     private function ajaxDejPosledniZmeny(
-        array     $posledniZnameStavyAktivit,
-        array     $idsPoslednichZnamychLoguUcastniku,
+        array $posledniZnameStavyAktivit,
+        array $idsPoslednichZnamychLoguUcastniku,
         \Uzivatel $vypravec,
-    )
-    {
-        $zmenyStavuAktivitProJson    = [];
+    ) {
+        $zmenyStavuAktivitProJson = [];
         $nejnovejsiZmenyStavuAktivit = Aktivita::dejPosledniZmenyStavuAktivit($posledniZnameStavyAktivit);
         foreach ($nejnovejsiZmenyStavuAktivit->zmenyStavuAktivit() as $zmenaStavuAktivity) {
-            $aktivita                   = Aktivita::zId($zmenaStavuAktivity->idAktivity(), true);
+            $aktivita = Aktivita::zId($zmenaStavuAktivity->idAktivity(), true);
             $zmenyStavuAktivitProJson[] = [
                 self::ID_AKTIVITY                        => $zmenaStavuAktivity->idAktivity(),
                 self::ID_LOGU                            => $zmenaStavuAktivity->idLogu(),
@@ -275,12 +330,12 @@ class OnlinePrezenceAjax
             ];
         }
 
-        $zmenyPrihlaseniProJson    = [];
+        $zmenyPrihlaseniProJson = [];
         $nejnovejsiZmenyPrihlaseni = AktivitaPrezence::dejPosledniZmenyPrezence($idsPoslednichZnamychLoguUcastniku);
         foreach ($nejnovejsiZmenyPrihlaseni->zmenyPrihlaseni() as $zmenaPrihlaseni) {
             $aktivita = Aktivita::zId($zmenaPrihlaseni->idAktivity(), true);
-            if (!$aktivita) { // Stává se na betě, když se natvrdo odebírají aktivity
-                if (!defined('TESTING') || !TESTING) {
+            if (! $aktivita) { // Stává se na betě, když se natvrdo odebírají aktivity
+                if (! defined('TESTING') || ! TESTING) {
                     trigger_error(
                         "Nelze načíst aktivitu s ID {$zmenaPrihlaseni->idAktivity()}: " . var_export($zmenaPrihlaseni, true),
                         E_USER_WARNING,
@@ -318,8 +373,9 @@ class OnlinePrezenceAjax
     private function ajaxUzavritAktivitu(int $idAktivity, \Uzivatel $vypravec)
     {
         $aktivita = Aktivita::zId($idAktivity, true, $this->systemoveNastaveni);
-        if (!$aktivita) {
+        if (! $aktivita) {
             $this->echoErrorJson('Chybné ID aktivity ' . $idAktivity);
+
             return;
         }
         $aktivita->zamkni();
@@ -347,8 +403,10 @@ class OnlinePrezenceAjax
 
     private function echoErrorJson(string $error): void
     {
-        header("HTTP/1.1 400 Bad Request");
-        $this->echoJson([self::ERRORS => [$error]]);
+        header('HTTP/1.1 400 Bad Request');
+        $this->echoJson([
+            self::ERRORS => [$error],
+        ]);
     }
 
     private function echoJson(array $data): void
@@ -358,33 +416,30 @@ class OnlinePrezenceAjax
     }
 
     /**
-     * @param \Uzivatel $vypravec
-     * @param int $idUcastnika
-     * @param int $idAktivity
-     * @param bool|null $dorazil
-     * @return void
      * @throws \JsonException
      */
     private function ajaxZmenitPritomnostUcastnika(
         \Uzivatel $vypravec,
-        int       $idUcastnika,
-        int       $idAktivity,
-        ?bool     $dorazil,
-    )
-    {
+        int $idUcastnika,
+        int $idAktivity,
+        ?bool $dorazil,
+    ) {
         $ucastnik = \Uzivatel::zId($idUcastnika);
-        if (!$ucastnik) {
+        if (! $ucastnik) {
             $this->echoErrorJson('Chybné ID účastníka');
+
             return;
         }
         $aktivita = Aktivita::zId($idAktivity, true);
-        if (!$aktivita) {
+        if (! $aktivita) {
             $this->echoErrorJson('Chybné ID aktivity');
+
             return;
         }
 
         if ($dorazil === null) {
             $this->echoErrorJson('Chybějící příznak zda dorazil');
+
             return;
         }
         $vypravec = $this->dejVypravecePodleTestu($aktivita, $vypravec);
@@ -405,6 +460,7 @@ class OnlinePrezenceAjax
                 );
             } catch (\Chyba $chyba) {
                 $this->echoErrorJson($chyba->getMessage());
+
                 return;
             }
             $posledniZmenaPrihlaseni = $prezence->ulozZeDorazil($ucastnik, $vypravec);
@@ -414,11 +470,12 @@ class OnlinePrezenceAjax
                 $posledniZmenaPrihlaseni = $prezence->zrusZeDorazil($ucastnik, $vypravec);
             } catch (\Chyba $chyba) {
                 $this->echoErrorJson($chyba->getMessage());
+
                 return;
             }
         }
 
-        if (!$posledniZmenaPrihlaseni) {
+        if (! $posledniZmenaPrihlaseni) {
             $posledniZmenaPrihlaseni = $prezence->posledniZmenaPrihlaseni($ucastnik);
         }
 
@@ -439,12 +496,11 @@ class OnlinePrezenceAjax
     }
 
     private function dejPotvrzeneRazitkoPosledniZmeny(
-        \Uzivatel           $vypravec,
+        \Uzivatel $vypravec,
         ?ZmenaStavuAktivity $posledniZmenaStavuAktivity,
-        ?ZmenaPrihlaseni    $posledniZmenaPrihlaseni,
-        bool                $prepsatStare,
-    ): string
-    {
+        ?ZmenaPrihlaseni $posledniZmenaPrihlaseni,
+        bool $prepsatStare,
+    ): string {
         return (new RazitkoPosledniZmenyPrihlaseni(
             $vypravec,
             $posledniZmenaStavuAktivity,
@@ -456,10 +512,11 @@ class OnlinePrezenceAjax
 
     public function dejVypravecePodleTestu(Aktivita $aktivita, \Uzivatel $vypravec): \Uzivatel
     {
-        if (!$this->testujeme) {
+        if (! $this->testujeme) {
             return $vypravec;
         }
         $organizatori = $aktivita->organizatori();
+
         return count($organizatori) > 0
             ? reset($organizatori) // první organizátor co padne pod ruku
             : $vypravec;
@@ -468,27 +525,31 @@ class OnlinePrezenceAjax
     private function ajaxUlozPrezenci(int $idAktivity, array $idDorazivsich, \Uzivatel $vypravec)
     {
         $aktivita = Aktivita::zId($idAktivity, true);
-        if (!$aktivita) {
+        if (! $aktivita) {
             $this->echoErrorJson('Chybné ID aktivity' . $idAktivity);
+
             return;
         }
         $dorazili = \Uzivatel::zIds($idDorazivsich);
         $aktivita->dejPrezenci()->uloz($dorazili, $vypravec);
 
-        $this->echoJson([self::AKTIVITA => $aktivita->rawDb(), self::DORAZILI => $dorazili]);
+        $this->echoJson([
+            self::AKTIVITA => $aktivita->rawDb(),
+            self::DORAZILI => $dorazili,
+        ]);
     }
 
     private function ajaxOmnibox(
         \Uzivatel $vypravec,
-        int       $idAktivity,
-        string    $term,
-        array     $dataVOdpovedi,
-        ?array    $labelSlozenZ,
-    )
-    {
+        int $idAktivity,
+        string $term,
+        array $dataVOdpovedi,
+        ?array $labelSlozenZ,
+    ) {
         $aktivita = Aktivita::zId($idAktivity, true);
-        if (!$aktivita) {
+        if (! $aktivita) {
             $this->echoErrorJson('Chybné ID aktivity ' . $idAktivity);
+
             return;
         }
         $omniboxData = omnibox(
@@ -498,7 +559,7 @@ class OnlinePrezenceAjax
             $labelSlozenZ,
             array_map(
                 static function (\Uzivatel $prihlaseny) {
-                    return (int)$prihlaseny->id();
+                    return (int) $prihlaseny->id();
                 }, $aktivita->prihlaseni(),
             ),
             true,
@@ -506,10 +567,10 @@ class OnlinePrezenceAjax
         );
         foreach ($omniboxData as &$prihlasenyUzivatelOmnibox) {
             $prihlasenyUzivatel = \Uzivatel::zId($prihlasenyUzivatelOmnibox['value']);
-            if (!$prihlasenyUzivatel) {
+            if (! $prihlasenyUzivatel) {
                 continue;
             }
-            $ucastnikHtml                      = $this->onlinePrezenceHtml->sestavHmlUcastnikaAktivity(
+            $ucastnikHtml = $this->onlinePrezenceHtml->sestavHmlUcastnikaAktivity(
                 $prihlasenyUzivatel,
                 $aktivita,
                 $vypravec,

--- a/model/Aktivita/OnlinePrezence/OnlinePrezenceAjax.php
+++ b/model/Aktivita/OnlinePrezence/OnlinePrezenceAjax.php
@@ -195,8 +195,36 @@ class OnlinePrezenceAjax
         }
 
         $this->dejPotvrzeniZobrazeniKontaktu()->potvrd($vypravec, $idAktivity);
+
+        // Řádky se překreslují až tady, po potvrzení – v týž request už session
+        // příznak platí, takže vzniknou rovnou s odemčenými kontakty a klient
+        // je jen vymění. Kdyby se posílaly jen "ok", musel by se reload.
+        $prihlaseni = $aktivita->prihlaseni();
+        $ucastniciHtml = [];
+        foreach (array_merge($prihlaseni, $aktivita->seznamSledujicich()) as $ucastnik) {
+            $ucastniciHtml[] = [
+                self::ID_UZIVATELE   => (int) $ucastnik->id(),
+                self::HTML_UCASTNIKA => $this->onlinePrezenceHtml->sestavHmlUcastnikaAktivity(
+                    $ucastnik,
+                    $aktivita,
+                    $vypravec,
+                    $aktivita->stavPrihlaseni($ucastnik),
+                ),
+            ];
+        }
+
+        $emaily = [];
+        foreach ($prihlaseni as $ucastnik) {
+            $email = trim((string) $ucastnik->mail());
+            if ($email !== '') {
+                $emaily[] = $email;
+            }
+        }
+
         $this->echoJson([
             self::ID_AKTIVITY => $idAktivity,
+            'ucastnici'       => $ucastniciHtml,
+            'emaily'          => $emaily,
         ]);
     }
 

--- a/model/Aktivita/OnlinePrezence/OnlinePrezenceHtml.php
+++ b/model/Aktivita/OnlinePrezence/OnlinePrezenceHtml.php
@@ -1,14 +1,17 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Gamecon\Aktivita\OnlinePrezence;
 
 use Gamecon\Aktivita\Aktivita;
 use Gamecon\Aktivita\AktivitaPrezence;
 use Gamecon\Aktivita\RazitkoPosledniZmenyPrihlaseni;
+use Gamecon\Logger\LogUdalosti;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\Web\Info;
-use Symfony\Component\Filesystem\Filesystem;
 use Gamecon\XTemplate\XTemplate;
+use Symfony\Component\Filesystem\Filesystem;
 
 class OnlinePrezenceHtml
 {
@@ -17,34 +20,37 @@ class OnlinePrezenceHtml
         return implode(' – ', array_filter([$aktivita->nazev(), $aktivita->orgJmena(), $aktivita->popisLokaci()]));
     }
 
-    private ?XTemplate                  $onlinePrezenceTemplate     = null;
+    private ?XTemplate $onlinePrezenceTemplate = null;
     private ?OnlinePrezenceUcastnikHtml $onlinePrezenceUcastnikHtml = null;
-    private bool                        $testujeme;
+    private ?PotvrzeniZobrazeniKontaktu $potvrzeniZobrazeniKontaktu = null;
+    private bool $testujeme;
 
     public function __construct(
-        private readonly string             $jsVyjimkovac,
+        private readonly string $jsVyjimkovac,
         private readonly SystemoveNastaveni $systemoveNastaveni,
-        private readonly Filesystem         $filesystem,
-        private readonly bool               $muzemeTestovat = false,
-        bool                                $testujeme = false,
-    )
-    {
+        private readonly Filesystem $filesystem,
+        private readonly bool $muzemeTestovat = false,
+        bool $testujeme = false,
+    ) {
         $this->testujeme = $muzemeTestovat && $testujeme;
     }
 
     public function dejHtmlOnlinePrezence(
         \Uzivatel $editujici,
-        array     $organizovaneAktivity,
-    ): string
-    {
+        array $organizovaneAktivity,
+    ): string {
         $template = $this->dejOnlinePrezenceTemplate();
 
         if ($this->muzemeTestovat) {
             if ($this->testujeme) {
-                $template->assign('urlBezTestu', getCurrentUrlWithQuery(['test' => 0]));
+                $template->assign('urlBezTestu', getCurrentUrlWithQuery([
+                    'test' => 0,
+                ]));
                 $template->parse('onlinePrezence.test.odkazBezTestu');
             } else {
-                $template->assign('urlTest', getCurrentUrlWithQuery(['test' => 1]));
+                $template->assign('urlTest', getCurrentUrlWithQuery([
+                    'test' => 1,
+                ]));
                 $template->parse('onlinePrezence.test.odkazNaTest');
             }
             $template->parse('onlinePrezence.test');
@@ -68,6 +74,7 @@ class OnlinePrezenceHtml
         }
 
         $template->parse('onlinePrezence');
+
         return $template->text('onlinePrezence');
     }
 
@@ -80,7 +87,7 @@ class OnlinePrezenceHtml
                 __DIR__ . '/../../../admin/files/design/online-prezence.css',
             ],
             'javascripts' => [
-                'text'   => [
+                'text' => [
                     __DIR__ . '/../../../admin/files/omnibox-1.1.4.js',
                     __DIR__ . '/../../../admin/files/zablikej-1.0.js',
                     __DIR__ . '/../../../admin/files/online-prezence/online-prezence-heat-colors.js',
@@ -88,6 +95,7 @@ class OnlinePrezenceHtml
                     __DIR__ . '/../../../admin/files/online-prezence/online-prezence-prepinani-viditelnosti.js',
                     __DIR__ . '/../../../admin/files/online-prezence/online-prezence-ukazatele-zaplnenosti.js',
                     __DIR__ . '/../../../admin/files/online-prezence/online-prezence-potvrzovaci-modal.js',
+                    __DIR__ . '/../../../admin/files/online-prezence/online-prezence-odemknuti-kontaktu.js',
                     __DIR__ . '/../../../admin/files/online-prezence/online-prezence-keep-alive.js',
                 ],
                 /*
@@ -130,28 +138,29 @@ class OnlinePrezenceHtml
                 (new Info($this->systemoveNastaveni))->pridejPrefixPodleVyvoje('Online prezence'),
             );
         }
+
         return $this->onlinePrezenceTemplate;
     }
 
     /**
-     * @param XTemplate $template
-     * @param \Uzivatel $vypravec
      * @param Aktivita[] $organizovaneAktivity
-     * @return void
      */
     private function sestavHtmlOnlinePrezence(
         XTemplate $template,
         \Uzivatel $vypravec,
-        array     $organizovaneAktivity,
-    )
-    {
+        array $organizovaneAktivity,
+    ) {
         foreach ($organizovaneAktivity as $aktivita) {
             $template->assign(
                 'omniboxUrl',
-                getCurrentUrlWithQuery(['ajax' => 1, 'omnibox' => 1, 'idAktivity' => $aktivita->id()]),
+                getCurrentUrlWithQuery([
+                    'ajax'       => 1,
+                    'omnibox'    => 1,
+                    'idAktivity' => $aktivita->id(),
+                ]),
             );
             $template->assign('minutNaPosledniChvili', $this->systemoveNastaveni->prihlaseniNaPosledniChviliXMinutPredZacatkemAktivity());
-            $template->assign('kapacita', (int)$aktivita->kapacita());
+            $template->assign('kapacita', (int) $aktivita->kapacita());
             $template->assign('idAktivity', $aktivita->id());
             $template->assign('urlAktivity', $aktivita->url());
             $template->parse('onlinePrezence.aktivity.aktivita.form.pridatUcastnika');
@@ -162,7 +171,13 @@ class OnlinePrezenceHtml
 
             $jePrezenceRozbalena = $this->jePrezenceRozbalena($aktivita);
             $template->assign('showMinimize', $this->cssZobrazitKdyz($jePrezenceRozbalena));
-            $template->assign('showMaximize', $this->cssZobrazitKdyz(!$jePrezenceRozbalena));
+            $template->assign('showMaximize', $this->cssZobrazitKdyz(! $jePrezenceRozbalena));
+
+            if ($this->dejPotvrzeniZobrazeniKontaktu()->jePotvrzeno((int) $aktivita->id())) {
+                $template->parse('onlinePrezence.aktivity.aktivita.hromadnyMail');
+            } else {
+                $template->parse('onlinePrezence.aktivity.aktivita.kontaktyZamcene');
+            }
 
             $template->parse('onlinePrezence.aktivity.aktivita.form');
 
@@ -192,7 +207,7 @@ class OnlinePrezenceHtml
     private function jePrezenceRozbalena(Aktivita $aktivita): bool
     {
         return $aktivita->cenaZaklad() > 0 // u aktivit zadarmo nás prezence tolik nezajímá a ještě k tomu mívají strašně moc účastníků, přednášky třeba
-            || !$aktivita->uzavrena();
+            || ! $aktivita->uzavrena();
     }
 
     private function cssZobrazitKdyz(bool $zobrazit): string
@@ -205,11 +220,12 @@ class OnlinePrezenceHtml
     private function dejEditovatelnaOdTimestamp(Aktivita $aktivita): int
     {
         $zacatek = $aktivita->zacatek();
-        if (!$zacatek) {
+        if (! $zacatek) {
             return 0;
         }
         $hnedEditovatelnaSeZacatkemDo = (clone $zacatek)
             ->modify("-{$this->systemoveNastaveni->aktivitaEditovatelnaXMinutPredJejimZacatkem()} minutes");
+
         return $hnedEditovatelnaSeZacatkemDo <= $this->systemoveNastaveni->ted()
             ? 0
             : time() + ($hnedEditovatelnaSeZacatkemDo->getTimestamp() - $this->systemoveNastaveni->ted()->getTimestamp());
@@ -218,6 +234,7 @@ class OnlinePrezenceHtml
     private function ucastniciOdebratelniDoTimestamp(\Uzivatel $odhlasujici, Aktivita $aktivita): int
     {
         $ucastniciOdebratelniDo = $aktivita->ucastniciOdebratelniDo($odhlasujici);
+
         return $ucastniciOdebratelniDo <= $this->systemoveNastaveni->ted()
             ? 0
             : $ucastniciOdebratelniDo->getTimestamp();
@@ -226,6 +243,7 @@ class OnlinePrezenceHtml
     private function ucastniciPridatelniDoTimestamp(\Uzivatel $prihlasujici, Aktivita $aktivita): int
     {
         $ucastniciPridatelniDo = $aktivita->ucastniciPridatelniDo($prihlasujici);
+
         return $ucastniciPridatelniDo <= $this->systemoveNastaveni->ted()
             ? 0
             : $ucastniciPridatelniDo->getTimestamp();
@@ -233,25 +251,37 @@ class OnlinePrezenceHtml
 
     private function dejOnlinePrezenceUcastnikHtml(): OnlinePrezenceUcastnikHtml
     {
-        if (!$this->onlinePrezenceUcastnikHtml) {
-            $this->onlinePrezenceUcastnikHtml = new OnlinePrezenceUcastnikHtml($this->systemoveNastaveni);
+        if (! $this->onlinePrezenceUcastnikHtml) {
+            $this->onlinePrezenceUcastnikHtml = new OnlinePrezenceUcastnikHtml(
+                $this->systemoveNastaveni,
+                $this->dejPotvrzeniZobrazeniKontaktu(),
+            );
         }
+
         return $this->onlinePrezenceUcastnikHtml;
+    }
+
+    private function dejPotvrzeniZobrazeniKontaktu(): PotvrzeniZobrazeniKontaktu
+    {
+        if (! $this->potvrzeniZobrazeniKontaktu) {
+            $this->potvrzeniZobrazeniKontaktu = new PotvrzeniZobrazeniKontaktu(new LogUdalosti());
+        }
+
+        return $this->potvrzeniZobrazeniKontaktu;
     }
 
     public function sestavHmlUcastnikaAktivity(
         \Uzivatel $ucastnik,
-        Aktivita  $aktivita,
+        Aktivita $aktivita,
         \Uzivatel $vypravec,
-        int       $stavPrihlaseni,
-    ): string
-    {
+        int $stavPrihlaseni,
+    ): string {
         // i při "Testovat" (bool $this->testujeme) tohle vrací skutečný čas namísto potřebného testovacího, takže to často vrátí zablokvaný checkbox
-        $editovatelnaOdTimestamp         = $this->dejEditovatelnaOdTimestamp($aktivita);
-        $ucastniciPridatelniDoTimestamp  = $this->ucastniciPridatelniDoTimestamp($vypravec, $aktivita);
+        $editovatelnaOdTimestamp = $this->dejEditovatelnaOdTimestamp($aktivita);
+        $ucastniciPridatelniDoTimestamp = $this->ucastniciPridatelniDoTimestamp($vypravec, $aktivita);
         $ucastniciOdebratelniDoTimestamp = $this->ucastniciOdebratelniDoTimestamp($vypravec, $aktivita);
-        $pridatelnyHned                  = $editovatelnaOdTimestamp <= 0 && $ucastniciPridatelniDoTimestamp > 0;
-        $odebratelnyHned                 = $editovatelnaOdTimestamp <= 0 && $ucastniciOdebratelniDoTimestamp > 0;
+        $pridatelnyHned = $editovatelnaOdTimestamp <= 0 && $ucastniciPridatelniDoTimestamp > 0;
+        $odebratelnyHned = $editovatelnaOdTimestamp <= 0 && $ucastniciOdebratelniDoTimestamp > 0;
 
         return $this->dejOnlinePrezenceUcastnikHtml()
             ->sestavHmlUcastnikaAktivity($ucastnik, $aktivita, $vypravec, $stavPrihlaseni, $pridatelnyHned, $odebratelnyHned);

--- a/model/Aktivita/OnlinePrezence/OnlinePrezenceHtml.php
+++ b/model/Aktivita/OnlinePrezence/OnlinePrezenceHtml.php
@@ -173,9 +173,11 @@ class OnlinePrezenceHtml
             $template->assign('showMinimize', $this->cssZobrazitKdyz($jePrezenceRozbalena));
             $template->assign('showMaximize', $this->cssZobrazitKdyz(! $jePrezenceRozbalena));
 
-            if ($this->dejPotvrzeniZobrazeniKontaktu()->jePotvrzeno((int) $aktivita->id())) {
-                $template->parse('onlinePrezence.aktivity.aktivita.hromadnyMail');
-            } else {
+            $kontaktyOdemcene = $this->dejPotvrzeniZobrazeniKontaktu()->jePotvrzeno((int) $aktivita->id());
+            // Blok zůstává v HTML i zamčený (odkaz je prázdný, žádný kontakt
+            // neuniká), jen skrytý – aby ho po potvrzení stačilo odkrýt bez reloadu.
+            $template->assign('cssTridaHromadnyMail', $this->cssZobrazitKdyz($kontaktyOdemcene));
+            if (! $kontaktyOdemcene) {
                 $template->parse('onlinePrezence.aktivity.aktivita.kontaktyZamcene');
             }
 

--- a/model/Aktivita/OnlinePrezence/OnlinePrezenceUcastnikHtml.php
+++ b/model/Aktivita/OnlinePrezence/OnlinePrezenceUcastnikHtml.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Gamecon\Aktivita\OnlinePrezence;
 
@@ -6,27 +8,27 @@ use Gamecon\Aktivita\Aktivita;
 use Gamecon\Aktivita\StavPrihlaseni;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\XTemplate\XTemplate;
-use Uzivatel;
 
 class OnlinePrezenceUcastnikHtml
 {
     private ?XTemplate $onlinePrezenceUcastnikTemplate = null;
-    private int        $naPosledniChviliXMinutPredZacatkem;
+    private int $naPosledniChviliXMinutPredZacatkem;
 
-    public function __construct(private readonly SystemoveNastaveni $systemoveNastaveni)
-    {
+    public function __construct(
+        private readonly SystemoveNastaveni $systemoveNastaveni,
+        private readonly PotvrzeniZobrazeniKontaktu $potvrzeniZobrazeniKontaktu,
+    ) {
         $this->naPosledniChviliXMinutPredZacatkem = $systemoveNastaveni->prihlaseniNaPosledniChviliXMinutPredZacatkemAktivity();
     }
 
     public function sestavHmlUcastnikaAktivity(
-        Uzivatel $ucastnik,
+        \Uzivatel $ucastnik,
         Aktivita $aktivita,
-        Uzivatel $vypravec,
-        int      $stavPrihlaseni,
-        bool     $ucastnikMuzeBytPridan,
-        bool     $ucastnikMuzeBytOdebran,
-    ): string
-    {
+        \Uzivatel $vypravec,
+        int $stavPrihlaseni,
+        bool $ucastnikMuzeBytPridan,
+        bool $ucastnikMuzeBytOdebran,
+    ): string {
         $ucastnikTemplate = $this->dejOnlinePrezenceUcastnikTemplate();
 
         $ucastnikTemplate->assign('u', $ucastnik);
@@ -36,7 +38,7 @@ class OnlinePrezenceUcastnikHtml
         $ucastnikTemplate->assign('checkedUcastnik', $dorazil ? 'checked' : '');
         $ucastnikTemplate->assign(
             'disabledUcastnik',
-            ($dorazil && !$ucastnikMuzeBytOdebran) || (!$dorazil && !$ucastnikMuzeBytPridan)
+            ($dorazil && ! $ucastnikMuzeBytOdebran) || (! $dorazil && ! $ucastnikMuzeBytPridan)
                 ? 'disabled'
                 : '',
         );
@@ -48,10 +50,39 @@ class OnlinePrezenceUcastnikHtml
             $ucastnikTemplate->parse('ucastnik.nepritomen');
         }
 
-        if ($ucastnik->telefon() && $this->smiZobrazitTelefon($vypravec)) {
+        $kontaktyOdemcene = $this->potvrzeniZobrazeniKontaktu->jePotvrzeno((int) $aktivita->id());
+
+        if ($kontaktyOdemcene) {
+            $ucastnikTemplate->parse('ucastnik.email');
+        } else {
+            $ucastnikTemplate->parse('ucastnik.emailZamceny');
+        }
+
+        /*
+         * Telefon má nad rámec souhlasu ještě vlastní GDPR bránu, takže na něj
+         * nestačí dvoustavové "zamčeno/odemčeno": kdyby se neorganizátorovi mimo
+         * běh GC ukázala rozmazaná atrapa, slibovala by mu něco, co po odsouhlasení
+         * stejně neuvidí – a on by souhlas odklikl zbytečně. Proto se rozlišuje
+         * "po potvrzení uvidíš" od "tady se nic neukáže, a proto".
+         */
+        $maTelefon = (bool) $ucastnik->telefon();
+        $smiVidetTelefon = $this->smiZobrazitTelefon($vypravec);
+
+        if ($kontaktyOdemcene && $maTelefon && $smiVidetTelefon) {
             $ucastnikTemplate->assign('telefonHtml', $ucastnik->telefon(true));
             $ucastnikTemplate->assign('telefonRaw', $ucastnik->telefon(false));
             $ucastnikTemplate->parse('ucastnik.telefon');
+        } elseif (! $maTelefon) {
+            $ucastnikTemplate->assign('duvodSkrytiTelefonu', 'Účastník nemá vyplněný telefon.');
+            $ucastnikTemplate->parse('ucastnik.telefonNedostupny');
+        } elseif (! $smiVidetTelefon) {
+            $ucastnikTemplate->assign(
+                'duvodSkrytiTelefonu',
+                'Telefony účastníků jsou mimo konání GameConu viditelné jen organizátorům.',
+            );
+            $ucastnikTemplate->parse('ucastnik.telefonNedostupny');
+        } else {
+            $ucastnikTemplate->parse('ucastnik.telefonZamceny');
         }
 
         if ($this->jeToNaPosledniChvili($ucastnik, $aktivita)) {
@@ -71,9 +102,13 @@ class OnlinePrezenceUcastnikHtml
         $ucastnikTemplate->assign('casPosledniZmenyPrihlaseni', $zmenaPrihlaseni ? $zmenaPrihlaseni->casZmenyProJs() : '');
         $ucastnikTemplate->assign('stavPrihlaseni', $zmenaPrihlaseni ? $zmenaPrihlaseni->typPrezenceProJs() : '');
         $ucastnikTemplate->assign('idPoslednihoLogu', $zmenaPrihlaseni ? $zmenaPrihlaseni->idLogu() : 0);
-        $ucastnikTemplate->assign('email', $ucastnik->mail());
+        // Prázdné do potvrzení: z tohohle atributu skládá online-prezence.js
+        // hromadný "mailto:?bcc=" na všechny účastníky, což je přesně ta cesta,
+        // kterou se dají kontakty vytěžit jedním kliknutím.
+        $ucastnikTemplate->assign('email', $kontaktyOdemcene ? $ucastnik->mail() : '');
 
         $ucastnikTemplate->parse('ucastnik');
+
         return $ucastnikTemplate->text('ucastnik');
     }
 
@@ -84,7 +119,7 @@ class OnlinePrezenceUcastnikHtml
      * bez organizátorské role) jen po dobu běhu GameConu – ochrana osobních
      * údajů, aby se čísla nedala hromadně vytáhnout před akcí ani po ní.
      */
-    private function smiZobrazitTelefon(Uzivatel $vypravec): bool
+    private function smiZobrazitTelefon(\Uzivatel $vypravec): bool
     {
         return $vypravec->jeOrganizator()
             || $this->gcBeziPodleInjektovanehoCasu();
@@ -101,6 +136,7 @@ class OnlinePrezenceUcastnikHtml
     private function gcBeziPodleInjektovanehoCasu(): bool
     {
         $ted = $this->systemoveNastaveni->ted()->getTimestamp();
+
         return $this->systemoveNastaveni->gcBeziOd()->getTimestamp() <= $ted
             && $ted <= $this->systemoveNastaveni->gcBeziDo()->getTimestamp();
     }
@@ -112,19 +148,21 @@ class OnlinePrezenceUcastnikHtml
             : 'display-none';
     }
 
-    private function jeToNaPosledniChvili(Uzivatel $ucastnik, Aktivita $aktivita): bool
+    private function jeToNaPosledniChvili(\Uzivatel $ucastnik, Aktivita $aktivita): bool
     {
-        $prihlasenOd               = $aktivita->prihlasenOd($ucastnik);
+        $prihlasenOd = $aktivita->prihlasenOd($ucastnik);
         $odKdyJeToNaPosledniChvili = $this->odKdyJeToNaPosledniChvili($aktivita);
+
         return $prihlasenOd && $odKdyJeToNaPosledniChvili && $prihlasenOd >= $odKdyJeToNaPosledniChvili;
     }
 
     private function odKdyJeToNaPosledniChvili(Aktivita $aktivita): ?\DateTimeInterface
     {
         $zacatek = $aktivita->zacatek();
-        if (!$zacatek) {
+        if (! $zacatek) {
             return null;
         }
+
         return (clone $zacatek)->modify('-' . $this->naPosledniChviliXMinutPredZacatkem . ' minutes');
     }
 
@@ -133,6 +171,7 @@ class OnlinePrezenceUcastnikHtml
         if ($this->onlinePrezenceUcastnikTemplate === null) {
             $this->onlinePrezenceUcastnikTemplate = new XTemplate(__DIR__ . '/templates/online-prezence-ucastnik.xtpl');
         }
+
         return $this->onlinePrezenceUcastnikTemplate;
     }
 }

--- a/model/Aktivita/OnlinePrezence/PotvrzeniZobrazeniKontaktu.php
+++ b/model/Aktivita/OnlinePrezence/PotvrzeniZobrazeniKontaktu.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Aktivita\OnlinePrezence;
+
+use Gamecon\Logger\LogUdalosti;
+
+/**
+ * Stav se drží v session, ne v cookie: cookie si nastaví i ten, kdo souhlas
+ * odklikat nechce, takže by se odemčení neprojevilo v logu a záznam by
+ * zachytil jen ty poctivé. Session drží rozhodnutí na serveru, kde zápis do
+ * logu proběhne na stejné cestě, která kontakty odemyká.
+ */
+class PotvrzeniZobrazeniKontaktu
+{
+    public const ZPRAVA_LOGU = 'odemcení kontaktů účastníků';
+
+    private const KLIC_SESSION = 'potvrzeneZobrazeniKontaktu';
+
+    public function __construct(
+        private readonly LogUdalosti $logUdalosti,
+    ) {
+    }
+
+    public function jePotvrzeno(int $idAktivity): bool
+    {
+        return ! empty($_SESSION[self::KLIC_SESSION][$idAktivity]);
+    }
+
+    public function potvrd(\Uzivatel $vypravec, int $idAktivity): void
+    {
+        if ($this->jePotvrzeno($idAktivity)) {
+            return;
+        }
+
+        $_SESSION[self::KLIC_SESSION][$idAktivity] = true;
+
+        $this->logUdalosti->zalogovatUdalost(
+            $vypravec,
+            self::ZPRAVA_LOGU,
+            [
+                'idAktivity' => $idAktivity,
+            ],
+        );
+    }
+}

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
@@ -67,11 +67,27 @@
         <!-- end:checkbox -->
     </td>
     <td>{u.jmenoVolitelnyNick}</td>
-    <td class="text-center"><a href="mailto:{u.mail}" title="{u.mail}"><i class="far fa-envelope"></i></a></td>
-    <td>
+    <td class="text-center kontakt">
+        <!-- begin:email -->
+        <a href="mailto:{u.mail}" title="{u.mail}"><i class="far fa-envelope"></i></a>
+        <!-- end:email -->
+        <!-- begin:emailZamceny -->
+        <span class="kontakt-atrapa" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="E-mail se zobrazí po potvrzení podmínek použití kontaktů.">••••</span>
+        <!-- end:emailZamceny -->
+    </td>
+    <td class="kontakt">
         <!-- begin:telefon -->
         <a href="tel:{telefonRaw}" class="text-nowrap"><i class="fas fa-phone"></i> {telefonHtml}</a>
         <!-- end:telefon -->
+        <!-- begin:telefonZamceny -->
+        <span class="kontakt-atrapa" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="Telefon se zobrazí po potvrzení podmínek použití kontaktů.">••• ••• •••</span>
+        <!-- end:telefonZamceny -->
+        <!-- begin:telefonNedostupny -->
+        <span class="kontakt-nedostupny" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="{duvodSkrytiTelefonu}"><i class="fa-solid fa-ban"></i></span>
+        <!-- end:telefonNedostupny -->
     </td>
 </tr>
 <!-- end:ucastnik -->

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -236,15 +236,13 @@
           </span>
                     </div>
 
-                    <!-- begin:hromadnyMail -->
-                    <div id="emaily-{idAktivity}" style="padding: 0.5em 0" class="row">
+                    <div id="emaily-{idAktivity}" style="padding: 0.5em 0" class="row {cssTridaHromadnyMail}">
                         <div class="col-xl col-md col-sm text-sm-center text-md-start align-self-center">
                             <i class="far fa-envelope hinted" data-bs-toggle="tooltip" data-bs-placement="top"
                                title="Emaily přihlášených (ne sledujících)"></i>
                             <a href="mailto:"></a>
                         </div>
                     </div>
-                    <!-- end:hromadnyMail -->
 
                     <!-- begin:kontaktyZamcene -->
                     <div class="row kontakty-zamcene-pruh" id="kontakty-zamcene-{idAktivity}" style="padding: 0.5em 0">

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -236,6 +236,7 @@
           </span>
                     </div>
 
+                    <!-- begin:hromadnyMail -->
                     <div id="emaily-{idAktivity}" style="padding: 0.5em 0" class="row">
                         <div class="col-xl col-md col-sm text-sm-center text-md-start align-self-center">
                             <i class="far fa-envelope hinted" data-bs-toggle="tooltip" data-bs-placement="top"
@@ -243,6 +244,23 @@
                             <a href="mailto:"></a>
                         </div>
                     </div>
+                    <!-- end:hromadnyMail -->
+
+                    <!-- begin:kontaktyZamcene -->
+                    <div class="row kontakty-zamcene-pruh" id="kontakty-zamcene-{idAktivity}" style="padding: 0.5em 0">
+                        <div class="col-xl col-md col-sm text-sm-center text-md-start align-self-center">
+                            <i class="fas fa-lock"></i>
+                            Kontakty účastníků jsou skryté.
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-secondary odemknout-kontakty"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#modalOdemknoutKontakty"
+                                    data-id-aktivity="{idAktivity}"
+                            >Zobrazit kontakty
+                            </button>
+                        </div>
+                    </div>
+                    <!-- end:kontaktyZamcene -->
 
                     <!-- begin:form -->
                     <form class="formAktivita">
@@ -388,6 +406,47 @@
                         </button>
                         <button type="button" class="btn btn-primary" onclick="potvrdModal()">
                             Uzavřít aktivitu
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade" id="modalOdemknoutKontakty" tabindex="-1" aria-labelledby="odemknoutKontaktyNadpis"
+             aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="odemknoutKontaktyNadpis">
+                            <i class="fas fa-lock"></i> Kontakty jsou jen pro organizaci GameConu
+                        </h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>
+                            E-maily a telefony účastníků slouží <strong>výhradně</strong> ke komunikaci ohledně této
+                            aktivity na GameConu – domluvě času, změnám v programu, řešení účasti.
+                        </p>
+                        <p>
+                            Nesmí se použít k rozesílání pozvánek na jiné akce, k reklamě, k nabídkám ani k ničemu
+                            dalšímu, co s GameConem nesouvisí – a to ani jednorázově, ani „jen pár lidem“.
+                            Předávat je dál někomu dalšímu nelze vůbec.
+                        </p>
+                        <p class="text-muted">
+                            Zobrazení kontaktů se zaznamenává.
+                        </p>
+                        <div>
+                            <input type="checkbox" name="souhlasSPodminkamiKontaktu" id="souhlasSPodminkamiKontaktu">
+                            <label for="souhlasSPodminkamiKontaktu" class="d-inline">
+                                Beru na vědomí a zavazuji se kontakty použít jen pro potřeby této aktivity na
+                                GameConu.
+                            </label>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Zpět</button>
+                        <button type="button" class="btn btn-primary" id="potvrditOdemceniKontaktu" disabled>
+                            Zobrazit kontakty
                         </button>
                     </div>
                 </div>

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -422,22 +422,14 @@
                     </div>
                     <div class="modal-body">
                         <p>
-                            E-maily a telefony účastníků slouží <strong>výhradně</strong> ke komunikaci ohledně této
-                            aktivity na GameConu – domluvě času, změnám v programu, řešení účasti.
-                        </p>
-                        <p>
-                            Nesmí se použít k rozesílání pozvánek na jiné akce, k reklamě, k nabídkám ani k ničemu
-                            dalšímu, co s GameConem nesouvisí – a to ani jednorázově, ani „jen pár lidem“.
-                            Předávat je dál někomu dalšímu nelze vůbec.
-                        </p>
-                        <p class="text-muted">
-                            Zobrazení kontaktů se zaznamenává.
+                            Kontakty slouží výhradně k organizaci této aktivity na GameConu. Nesmí být použity
+                            k rozesílání pozvánek na jiné akce, reklamy ani k jiným účelům nesouvisejícím
+                            s GameConem. Je zakázáno kontakty komukoliv předávat.
                         </p>
                         <div>
                             <input type="checkbox" name="souhlasSPodminkamiKontaktu" id="souhlasSPodminkamiKontaktu">
                             <label for="souhlasSPodminkamiKontaktu" class="d-inline">
-                                Beru na vědomí a zavazuji se kontakty použít jen pro potřeby této aktivity na
-                                GameConu.
+                                Beru na vědomí a zavazuji se tyto podmínky dodržovat.
                             </label>
                         </div>
                     </div>

--- a/tests/Aktivity/OnlinePrezenceUcastnikTelefonTest.php
+++ b/tests/Aktivity/OnlinePrezenceUcastnikTelefonTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Gamecon\Tests\Aktivity;
 
 use Gamecon\Aktivita\OnlinePrezence\OnlinePrezenceUcastnikHtml;
+use Gamecon\Aktivita\OnlinePrezence\PotvrzeniZobrazeniKontaktu;
 use Gamecon\Cas\DateTimeGamecon;
 use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\Logger\LogUdalosti;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\Tests\Db\AbstractUzivatelTestDb;
 
@@ -43,7 +45,10 @@ class OnlinePrezenceUcastnikTelefonTest extends AbstractUzivatelTestDb
         string $ted,
         bool $ocekavanoBezi,
     ): void {
-        $ucastnikHtml = new OnlinePrezenceUcastnikHtml($this->nastaveniSCasem($ted));
+        $ucastnikHtml = new OnlinePrezenceUcastnikHtml(
+            $this->nastaveniSCasem($ted),
+            $this->potvrzeniKontaktu(),
+        );
 
         $metoda = new \ReflectionMethod($ucastnikHtml, 'gcBeziPodleInjektovanehoCasu');
         $metoda->setAccessible(true);
@@ -75,7 +80,10 @@ class OnlinePrezenceUcastnikTelefonTest extends AbstractUzivatelTestDb
         bool $ocekavanaViditelnost,
     ): void {
         $ted = $gcBezi ? '2099-06-20 12:00:00' : '2099-06-01 12:00:00';
-        $ucastnikHtml = new OnlinePrezenceUcastnikHtml($this->nastaveniSCasem($ted));
+        $ucastnikHtml = new OnlinePrezenceUcastnikHtml(
+            $this->nastaveniSCasem($ted),
+            $this->potvrzeniKontaktu(),
+        );
 
         $vypravec = $this->createMock(\Uzivatel::class);
         $vypravec->method('jeOrganizator')->willReturn($divakJeOrganizator);
@@ -87,6 +95,11 @@ class OnlinePrezenceUcastnikTelefonTest extends AbstractUzivatelTestDb
             $ocekavanaViditelnost,
             $metoda->invoke($ucastnikHtml, $vypravec),
         );
+    }
+
+    private function potvrzeniKontaktu(): PotvrzeniZobrazeniKontaktu
+    {
+        return new PotvrzeniZobrazeniKontaktu(new LogUdalosti());
     }
 
     private function nastaveniSCasem(string $ted): SystemoveNastaveni

--- a/tests/Aktivity/PotvrzeniZobrazeniKontaktuTest.php
+++ b/tests/Aktivity/PotvrzeniZobrazeniKontaktuTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Aktivity;
+
+use Gamecon\Aktivita\OnlinePrezence\PotvrzeniZobrazeniKontaktu;
+use Gamecon\Logger\LogUdalosti;
+use Gamecon\Tests\Db\AbstractUzivatelTestDb;
+
+class PotvrzeniZobrazeniKontaktuTest extends AbstractUzivatelTestDb
+{
+    private const ID_AKTIVITY = 123456;
+
+    protected static function resetDbAfterClass(): bool
+    {
+        return true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($_SESSION['potvrzeneZobrazeniKontaktu']);
+    }
+
+    public function testVychoziStavJeZamceno(): void
+    {
+        self::assertFalse($this->potvrzeni()->jePotvrzeno(self::ID_AKTIVITY));
+    }
+
+    public function testPotvrzeniOdemkneJenSvouAktivitu(): void
+    {
+        $potvrzeni = $this->potvrzeni();
+        $potvrzeni->potvrd(self::prihlasenyUzivatel(), self::ID_AKTIVITY);
+
+        self::assertTrue($potvrzeni->jePotvrzeno(self::ID_AKTIVITY));
+        self::assertFalse(
+            $potvrzeni->jePotvrzeno(self::ID_AKTIVITY + 1),
+            'Souhlas u jedné aktivity nesmí odemknout kontakty u jiné',
+        );
+    }
+
+    public function testPotvrzeniSeZaloguje(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        $pocetPred = $this->pocetLogu($uzivatel->id());
+
+        $this->potvrzeni()->potvrd($uzivatel, self::ID_AKTIVITY);
+
+        self::assertSame(
+            $pocetPred + 1,
+            $this->pocetLogu($uzivatel->id()),
+            'Odemčení kontaktů se musí zaznamenat kvůli dohledatelnosti',
+        );
+    }
+
+    public function testOpakovanePotvrzeniNezaloguDvakrat(): void
+    {
+        $uzivatel = self::prihlasenyUzivatel();
+        $potvrzeni = $this->potvrzeni();
+
+        $potvrzeni->potvrd($uzivatel, self::ID_AKTIVITY);
+        $pocetPoPrvnim = $this->pocetLogu($uzivatel->id());
+        $potvrzeni->potvrd($uzivatel, self::ID_AKTIVITY);
+
+        self::assertSame(
+            $pocetPoPrvnim,
+            $this->pocetLogu($uzivatel->id()),
+            'Znovunačtení stránky nesmí log zahltit duplicitami',
+        );
+    }
+
+    private function pocetLogu(int $idUzivatele): int
+    {
+        return (int) dbOneCol(
+            'SELECT COUNT(*) FROM log_udalosti WHERE id_logujiciho = $0 AND zprava = $1',
+            [$idUzivatele, PotvrzeniZobrazeniKontaktu::ZPRAVA_LOGU],
+        );
+    }
+
+    private function potvrzeni(): PotvrzeniZobrazeniKontaktu
+    {
+        return new PotvrzeniZobrazeniKontaktu(new LogUdalosti());
+    }
+}


### PR DESCRIPTION
## Problém

Někdo z larpové komunity použil e-maily účastníků z online prezence k hromadnému rozeslání reklamy na akci, která s GameConem nesouvisí.

Kontakty přitom byly na `admin/moje-aktivity` vidět bez jakékoli bariéry a hlavně **bez jakékoli stopy** — nedalo se zpětně zjistit, kdo je viděl. Navíc pod tabulkou je odkaz „napiš všem", který z `data-email` atributů poskládá `mailto:?bcc=` na všechny přihlášené naráz. To je přesně ta cesta, kterou lze kontakty vytěžit jedním kliknutím.

## Řešení

Kontakty (e-maily i telefony) jsou skryté, dokud vypravěč nepotvrdí podmínky jejich použití — modal s vysvětlením + checkbox + tlačítko. Potvrzuje se **jednou pro celou aktivitu**, ne pro každý kontakt zvlášť.

Potvrzení se zapisuje do `log_udalosti` (zpráva `odemcení kontaktů účastníků`, metadata `{"idAktivity": N}`), takže je zpětně dohledatelné, kdo si kontakty které aktivity zobrazil.

Stav potvrzení drží **session, ne cookie**. Cookie by si nastavil i ten, kdo souhlas odklikat nechce — odemčení by se pak neprojevilo v logu a záznam by zachytil jen ty poctivé. Session drží rozhodnutí na serveru, kde zápis do logu proběhne na stejné cestě, která kontakty odemyká.

Kontakty se do HTML **vůbec nedostanou**, dokud není potvrzeno — gateuje se buňka, `data-email` atribut i AJAX payload `emaily`. Rozmazaná atrapa je jen zástupný text, ne rozmazaná skutečná hodnota; vypnutí CSS tedy nic neodhalí.

### Dva stavy skrytí, schválně odlišené

Telefon má nad rámec tohohle souhlasu ještě vlastní GDPR bránu z `3b65097fb` (organizátor vidí vždy, ostatní jen po dobu běhu GC). Kdyby se u telefonu neorganizátorovi mimo běh GC ukázala rozmazaná atrapa, slibovala by něco, co po odsouhlasení stejně neuvidí — odklikl by souhlas zbytečně.

| stav | zobrazení | význam |
|---|---|---|
| zamčeno, půjde odemknout | rozmazané `••••` | „po potvrzení uvidíš" |
| zamčeno, neodemkne se | ⛔ `fa-ban` + tooltip s důvodem | „tady se nic neukáže, a proto" |
| odemčeno | skutečná hodnota | — |

## Ověření

Nad reálnými daty (aktivita 7178 „Dark Tower 2", 11 přihlášených, všech 11 má vyplněný telefon i e-mail):

| divák | stav | skutečné maily v HTML | skutečné telefony | rozmazaná atrapa | ⛔ nepřístupné |
|---|---|---|---|---|---|
| organizátor | zamčeno | 0 | 0 | 22 | 0 |
| organizátor | odemčeno | 11 | 11 | 0 | 0 |
| neorganizátor mimo GC | zamčeno | 0 | 0 | 11 | 11 |
| neorganizátor mimo GC | odemčeno | 11 | **0** | 0 | 11 |

Poslední řádek je ten podstatný: po potvrzení se odemknou e-maily, ale telefony zůstanou poctivě označené jako nepřístupné (GDPR brána drží dál) — místo aby buňka mlčky zůstala prázdná.

Kontrolní řádky, které se změnit **nesmí**: telefony u organizátora se chovají stejně před i po této změně (GDPR brána z `3b65097fb` je nedotčená), a `smiZobrazitTelefon()` má stále původní logiku.

`tests/Aktivity` — **121 testů prošlo**, 6 přeskočeno (přeskoky existovaly i před touto změnou). ECS proběhl na všech změněných PHP souborech.

## Pozor při review

- **Tohle je odrazení a dohledatelnost, ne technická zábrana.** Kdo souhlas odklikne, může kontakty pořád vytěžit — nově po sobě ale nechá záznam v `log_udalosti`. Pro zneužití zevnitř od důvěryhodných dobrovolníků je tohle ten správný nástroj, ale neplést si to s ochranou proti scrapingu.
- **`admin/scripts/modules/aktivity/prihlaseni.php:92` zůstává úplně nechráněný** — vypisuje `telefon_uzivatele` a `{telefon}`/e-maily bez jakékoli brány, i mimo běh GC. Stejná data, jiný modul, žádný souhlas ani log. Nechal jsem to schválně mimo tenhle PR (jiný modul, jiné publikum práv), ale je to díra, kterou GDPR commit `3b65097fb` taky nepokryl. Chce samostatnou kartu.
- **Nový AJAX endpoint kontroluje oprávnění**: `ajaxOdemknoutKontakty()` ověřuje `maOrganizatora($vypravec) || jeOrganizator()`. Bez toho by stačilo poslat cizí `idAktivity` a odemknout si kontakty k akci, se kterou nemám nic společného.
- **Změna signatury konstruktoru** `OnlinePrezenceUcastnikHtml` (přibyl `PotvrzeniZobrazeniKontaktu`) — upravena i volání ve stávajícím testu.
- **`LogUdalosti` byla dosud mrtvý kód** (nulové call sites). Tímhle se stává prvním konzumentem. `zalogovatUdalost()` sama nededuplikuje, proto `potvrd()` dělá early-return, aby reload stránky log nezahltil.

### Co jsem NEověřil

- **Neproklikal jsem to v reálném prohlížeči end-to-end.** Přihlášení přes `curl` se mi nepodařilo rozchodit, takže ověření výše běželo přímým voláním rendereru nad reálnou DB, ne přes HTTP. Modal, JS a reload po potvrzení tedy nejsou ověřené klikáním — stojí za to je proklikat při review.
- **Automatický test pokrývá jen session/logování** (`PotvrzeniZobrazeniKontaktuTest`: výchozí zamčeno, izolace mezi aktivitami, zalogování, žádné duplicity). Čtyřstavové vykreslování atrap testem pokryté **není**, ověřoval jsem ho skriptem nad reálnými daty.
- Neřešil jsem chování při souběžném otevření více aktivit v různých panelech.

## Kde to naklikat

Lokálně, přihlášený jako vypravěč (např. `jaroslav.tyc.83@gmail.com`):

- <http://localhost/admin/moje-aktivity> — otevři aktivitu → **čekej** rozmazané `••••` ve sloupci E-mail a ⛔ ikonu ve sloupci Telefon (mimo běh GC a bez organizátorské role), plus pruh „Kontakty účastníků jsou skryté" s tlačítkem. Hromadný „napiš všem" odkaz nad tabulkou **nesmí být vidět**.
- Klikni **Zobrazit kontakty** → **čekej** modal; tlačítko je neaktivní, dokud nezaškrtneš checkbox.
- Potvrď → **čekej** reload, e-maily se objeví, telefony zůstanou ⛔ (dokud nemáš organizátorskou roli nebo neběží GC).
- Ověření zápisu do logu:
  ```sql
  SELECT * FROM log_udalosti WHERE zprava = 'odemcení kontaktů účastníků';
  ```
- Chceš-li vidět i telefony, přidej si dočasně organizátorskou roli (`INSERT INTO uzivatele_role (id_uzivatele, id_role) VALUES (<id>, 2)`) a **znovu se přihlas** — práva se načítají do session při loginu.
