### PR TITLE
Oprava neviditelné ikony sledujícího ve Firefoxu

### DIFF
--- a/admin/files/design/online-prezence.css
+++ b/admin/files/design/online-prezence.css
@@ -30,15 +30,6 @@ input:not([disabled])[type=checkbox] {
   -moz-transition: background 0.1s linear;
 }
 
-/*
- * Marker sledujícího sedí na .bg-dark, takže musí mít explicitně světlou
- * barvu – zděděná výchozí by na tmavém podkladu splynula. (Dřív tu bylo
- * barevné emoji, které barvu textu ignoruje, takže to nikdo neřešil.)
- */
-.sledujici .fa-eye {
-  color: #fff;
-}
-
 .tlacitko-testu {
   width: 100%;
   z-index: 1;

--- a/admin/files/design/online-prezence.css
+++ b/admin/files/design/online-prezence.css
@@ -30,6 +30,15 @@ input:not([disabled])[type=checkbox] {
   -moz-transition: background 0.1s linear;
 }
 
+/*
+ * Marker sledujícího sedí na .bg-dark, takže musí mít explicitně světlou
+ * barvu – zděděná výchozí by na tmavém podkladu splynula. (Dřív tu bylo
+ * barevné emoji, které barvu textu ignoruje, takže to nikdo neřešil.)
+ */
+.sledujici .fa-eye {
+  color: #fff;
+}
+
 .tlacitko-testu {
   width: 100%;
   z-index: 1;

--- a/admin/files/design/online-prezence.css
+++ b/admin/files/design/online-prezence.css
@@ -30,11 +30,6 @@ input:not([disabled])[type=checkbox] {
   -moz-transition: background 0.1s linear;
 }
 
-.flipped-icon {
-  transform: scale(-1, 1);
-  display: inline-block;
-}
-
 .tlacitko-testu {
   width: 100%;
   z-index: 1;

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
@@ -41,7 +41,7 @@
               data-bs-toggle="tooltip"
               title="Je to sledující. Pokud sháníš náhradníka, tenhle bude mít zájem."
         >
-      <span class="flipped-icon">👀</span>
+      👀
     </span>
         <span class="spici display-none"
               id="ucastnik-{u.id}-je-spici-na-aktivite-{a.id}"

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
@@ -41,7 +41,7 @@
               data-bs-toggle="tooltip"
               title="Je to sledující. Pokud sháníš náhradníka, tenhle bude mít zájem."
         >
-      👀
+      <i class="fa-solid fa-eye"></i>
     </span>
         <span class="spici display-none"
               id="ucastnik-{u.id}-je-spici-na-aktivite-{a.id}"

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence-ucastnik.xtpl
@@ -41,7 +41,7 @@
               data-bs-toggle="tooltip"
               title="Je to sledující. Pokud sháníš náhradníka, tenhle bude mít zájem."
         >
-      <i class="fa-solid fa-eye"></i>
+      👀
     </span>
         <span class="spici display-none"
               id="ucastnik-{u.id}-je-spici-na-aktivite-{a.id}"

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -122,7 +122,7 @@
                                 </li>
                                 <li>
                                     Volná místa nabídni náhradníkům {FILE "./_nahradnik.xtpl"}.
-                                    Sledující <i class="fa-solid fa-eye"></i> můžeš
+                                    Sledující <span class="bg-dark">👀</span> můžeš
                                     oslovit první.
                                 </li>
                                 <li>Náhradníky přidej na prezenčku.</li>
@@ -274,7 +274,7 @@
                             💤 Zrušený náhradník
                           </div>
                           <hr>
-                          <div><i class='fa-solid fa-eye'></i> Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
+                          <div>Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem. 👀</div>
                           <hr>
                           <div>
                             <i class='mladsi-osmnacti-let fa-solid fa-baby'></i>

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -122,7 +122,7 @@
                                 </li>
                                 <li>
                                     Volná místa nabídni náhradníkům {FILE "./_nahradnik.xtpl"}.
-                                    Sledující <span class="bg-dark">👀</span> můžeš
+                                    Sledující <i class="fa-solid fa-eye"></i> můžeš
                                     oslovit první.
                                 </li>
                                 <li>Náhradníky přidej na prezenčku.</li>
@@ -274,7 +274,7 @@
                             💤 Zrušený náhradník
                           </div>
                           <hr>
-                          <div>👀 Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
+                          <div><i class='fa-solid fa-eye'></i> Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
                           <hr>
                           <div>
                             <i class='mladsi-osmnacti-let fa-solid fa-baby'></i>

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -274,7 +274,7 @@
                             💤 Zrušený náhradník
                           </div>
                           <hr>
-                          <div>Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem. 👀</div>
+                          <div>👀 Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
                           <hr>
                           <div>
                             <i class='mladsi-osmnacti-let fa-solid fa-baby'></i>

--- a/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
+++ b/model/Aktivita/OnlinePrezence/templates/online-prezence.xtpl
@@ -122,7 +122,7 @@
                                 </li>
                                 <li>
                                     Volná místa nabídni náhradníkům {FILE "./_nahradnik.xtpl"}.
-                                    Sledující <span class="flipped-icon"><span class="bg-dark">👀</span></span> můžeš
+                                    Sledující <span class="bg-dark">👀</span> můžeš
                                     oslovit první.
                                 </li>
                                 <li>Náhradníky přidej na prezenčku.</li>
@@ -224,7 +224,7 @@
                     id="skoncila-{idAktivity}"
                     class="alert-info text-skoncila display-none skryt-pokud-aktivitu-nelze-editovat"
             >
-              ✋ <em>Aktivita už skončila, pozor na úpravy</em> <span class="flipped-icon">✋</span>
+              ✋ <em>Aktivita už skončila, pozor na úpravy</em> 🤚
             </span>
             <span class="alert-info text-skoncila display-none zobrazit-pokud-aktivitu-nelze-editovat">
               <em>🧊 Už ji nelze editovat ani zpětně 🧊</em>
@@ -274,7 +274,7 @@
                             💤 Zrušený náhradník
                           </div>
                           <hr>
-                          <div><span class='flipped-icon'>👀</span> Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
+                          <div>👀 Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem.</div>
                           <hr>
                           <div>
                             <i class='mladsi-osmnacti-let fa-solid fa-baby'></i>


### PR DESCRIPTION
## Problém

V legendě online prezence (tooltip nad hlavičkou sloupce) chybí u položky „Sledující" ikona — řádek začíná rovnou textem. Sousední položky (💤 Zrušený náhradník, 👶 Mladší 18ti let) se přitom vykreslí správně.

**Projevuje se jen ve Firefoxu, v Chrome je ikona vidět.**

## Příčina

Emoji bylo zabalené v `<span class="flipped-icon">`:

```css
.flipped-icon {
  transform: scale(-1, 1);
  display: inline-block;
}
```

**Firefox nevykreslí barevný emoji glyf uvnitř transformovaného elementu.** Chrome ano — proto ten rozdíl mezi prohlížeči.

### Ověřeno izolovaným testem

Stejné emoji, stejná stránka, mění se jen obalová struktura a CSS. Ve Firefoxu:

| | co se testovalo | vykreslí se? |
|---|---|---|
| A | holé `👀` bez CSS | ✅ |
| C | `span` s `scale(-1,1)` přímo kolem emoji (původní stav) | ❌ |
| G | `div` s transformem, emoji přímo v něm (bez span) | ❌ |
| H | `div` s transformem → `span` → emoji | ❌ |
| I | `div` s transformem → `div` → emoji | ❌ |
| J | `div` s transformem → `div` → `div` → `span` → emoji | ❌ |
| K, L | totéž s `p` místo `div` | ❌ |
| M–P | `display: block` / `inline-flex` / `will-change` / vlastní vrstva | ❌ |
| Q | `rotate(180deg)` | ❌ |
| R | `matrix(-1,0,0,1,0,0)` | ❌ |
| S | holé `👀` na konci stránky (kontrola) | ✅ |

Vykreslí se **jen** varianty bez transformu. Nezáleží na tom, který element transform nese, jak daleko je od textového uzlu, jaký má `display`, ani jakým zápisem se zrcadlí.

**Rozhodující detail:** varianta P měla na transformovaném spanu `background`. Ve Firefoxu je vidět **šedý obdélník správné velikosti, ale bez emoji uvnitř**. Box tedy existuje, má rozměry, transform se aplikoval a pozadí se vykreslilo — selhává výhradně rasterizace emoji glyfu.

Tím padají i ostatní hypotézy: není to nulová šířka boxu (box je vidět), není to Bootstrap sanitizer (testovací stránka žádný Bootstrap nemá), není to umístění v DOM (G–L) ani způsob kompozice (M–P).

## Řešení

Zrušení `flipped-icon` wrapperu. Emoji `👀` zůstává všude, jen se nezrcadlí:

- `online-prezence-ucastnik.xtpl:44` — marker sledujícího v řádku účastníka
- `online-prezence.xtpl:125` — nápověda „Sledující 👀 můžeš oslovit první" (chip `bg-dark` zachovaný)
- `online-prezence.xtpl:277` — legenda (nahlášený případ)

Nepoužívané pravidlo `.flipped-icon` je z `admin/files/design/online-prezence.css` odstraněné.

### Proč zůstat u emoji a nepoužít ikonu z Font Awesome

Zvažoval jsem `fa-eye`, ale zamítnuto ze dvou důvodů:

1. **`👀` je zavedený symbol pro „sledujícího" i mimo tuhle šablonu** — je ve třech místech uživatelské dokumentace: `docs/napoveda/moje-aktivity.md:28` (tabulka legendy `👀` → Sledující), `:63` (stejná věta jako nápověda v appce) a `docs/napoveda/prezence.md:46`. Změna ikony v appce by je rozešla s realitou a vyžádala si úpravu dokumentace navíc.
2. **Jedno oko čte jinak než dvě.** `fa-eye` působí spíš jako „zobrazit/zkontrolovat" než „někdo tohle sleduje". Dvouoká ikona ve Font Awesome 6.1.1 Free není — `fa-eyes` je placená (Pro).

### Proč nejde zrcadlení zachovat

Zrcadlení glyfu vede vždy přes `transform` a ten je ve Firefoxu u barevných emoji rozbitý (viz tabulka, C–R). Netransformační alternativa `unicode-bidi: bidi-override; direction: rtl` se sice vykreslí, ale obrací **pořadí znaků**, nezrcadlí jednotlivý glyf — u jednoho emoji tedy nedělá vůbec nic.

Zrcadlené `👀`, které se ve Firefoxu vykreslí, proto neexistuje. Ztráta je ale malá: nezrcadlené oči se dívají mírně doleva, což je detail, kterého si při čtení legendy nikdo nevšimne — a pořadí „ikona, pak popis" zůstává stejné jako u ostatních položek.

### Vedlejší oprava

`online-prezence.xtpl:227` používal `flipped-icon` na `✋` — dvě dlaně rámující text z obou stran. Tam mělo zrcadlení smysl, takže je místo transformu použité `🤚` (hřbet ruky), přirozený protějšek `✋` bez potřeby CSS:

```
✋ Aktivita už skončila, pozor na úpravy 🤚
```

## Pozor při review

- **Dokumentace se nemění** a zůstává v souladu s appkou, protože symbol je pořád `👀`.
- Změna je čistě vizuální, žádná logika ani chování. Automatický test proto nepřidávám.
- `web/soubory/blackarrow/program/program.less:319` má stejné nepoužívané pravidlo `.flipped-icon`. Nechal jsem ho být — veřejný web s vlastním LESS buildem, samostatná věc.

## Kde to naklikat

**Ve Firefoxu** (v Chrome to bylo v pořádku i před opravou):

- <http://localhost/admin/moje-aktivity> → najeď na ikonu osoby v hlavičce sloupce → **čekej** v legendě řádek `Sledující. Pokud sháníš náhradníka, tenhle bude mít zájem. 👀` s viditelným emoji na konci.
- Tamtéž, u aktivity se sledujícím účastníkem → **čekej** `👀` v jeho řádku.
- Rozbal návod (📖 nahoře) → **čekej** „Sledující 👀 můžeš oslovit první."
- U už skončené aktivity → **čekej** `✋ Aktivita už skončila, pozor na úpravy 🤚` s oběma dlaněmi.

