### PR TITLE
1481 Dvojí dobrovolné vstupné shodí výpočet zůstatku

### DIFF
--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -798,22 +798,32 @@ SQL;
     ', [$this->u->id(), $this->systemoveNastaveni->rocnik()]);
 
         $soucty = [];
+        /* Přihláška umí mít jen jedno vstupné (jeden slider s absolutní částkou), takže víc řádků
+           téhož vstupného je anomálie dat — nejspíš souběh dvou odeslání formuláře. Je to jeden a
+           týž příspěvek zapsaný vícekrát, ne víc příspěvků, takže se nesmí sečíst ani dvakrát
+           vypsat; přebytečné řádky zahazujeme rovnou. Po souběhu jsou obě částky stejné, takže je
+           jedno která projde; tady je to ta nejnižší, protože řádky chodí seřazené vzestupně podle
+           ceny (kvůli slevám na trička). */
+        $zpracovaneVstupne = [];
         foreach ($o as $r) {
+            if ($r[PredmetSql::TYP] == TypPredmetu::VSTUPNE) {
+                if (isset($zpracovaneVstupne[$r[PredmetSql::ID_PREDMETU]])) {
+                    continue;
+                }
+                $zpracovaneVstupne[$r[PredmetSql::ID_PREDMETU]] = true;
+            }
             $priceAfterDiscountDto = $this->cenik()->cena($r);
             $cena                  = $priceAfterDiscountDto->finalPrice;
             // započtení ceny
             if ($r[PredmetSql::TYP] == TypPredmetu::UBYTOVANI) {
                 $this->cenaUbytovani += $cena;
             } elseif ($r[PredmetSql::TYP] == TypPredmetu::VSTUPNE) {
-                /* Přihláška umí mít jen jedno vstupné (jeden slider s absolutní částkou), takže
-                   víc řádků je anomálie dat — nejspíš souběh dvou odeslání formuláře. Sčítáme je,
-                   aby výpočet zůstatku nespadl a nezahodil část zaplacené částky. */
                 if (Predmet::jeToVstupnePozde((int)$r[PredmetSql::TYP], $r[PredmetSql::KOD_PREDMETU])) {
-                    $this->cenaVstupnePozde += $cena;
+                    $this->cenaVstupnePozde = $cena;
                 } else {
-                    $this->cenaVstupne += $cena;
+                    $this->cenaVstupne = $cena;
                 }
-                $this->dobrovolneVstupnePrehled[] = $this->formatujProLog(
+                $this->dobrovolneVstupnePrehled = $this->formatujProLog(
                     nazev: "{$r[PredmetSql::NAZEV]} $cena.-",
                     castka: $cena,
                     kategorie: (int)$r[PredmetSql::TYP],

--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -805,7 +805,9 @@ SQL;
             if ($r[PredmetSql::TYP] == TypPredmetu::UBYTOVANI) {
                 $this->cenaUbytovani += $cena;
             } elseif ($r[PredmetSql::TYP] == TypPredmetu::VSTUPNE) {
-                // dobrovolné vstupné může být koupené vícekrát, když účastník přispěl opakovaně
+                /* Přihláška umí mít jen jedno vstupné (jeden slider s absolutní částkou), takže
+                   víc řádků je anomálie dat — nejspíš souběh dvou odeslání formuláře. Sčítáme je,
+                   aby výpočet zůstatku nespadl a nezahodil část zaplacené částky. */
                 if (Predmet::jeToVstupnePozde((int)$r[PredmetSql::TYP], $r[PredmetSql::KOD_PREDMETU])) {
                     $this->cenaVstupnePozde += $cena;
                 } else {

--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -805,14 +805,13 @@ SQL;
             if ($r[PredmetSql::TYP] == TypPredmetu::UBYTOVANI) {
                 $this->cenaUbytovani += $cena;
             } elseif ($r[PredmetSql::TYP] == TypPredmetu::VSTUPNE) {
+                // dobrovolné vstupné může být koupené vícekrát, když účastník přispěl opakovaně
                 if (Predmet::jeToVstupnePozde((int)$r[PredmetSql::TYP], $r[PredmetSql::KOD_PREDMETU])) {
-                    assert($this->cenaVstupnePozde === 0.0);
-                    $this->cenaVstupnePozde = $cena;
+                    $this->cenaVstupnePozde += $cena;
                 } else {
-                    assert($this->cenaVstupne === 0.0);
-                    $this->cenaVstupne = $cena;
+                    $this->cenaVstupne += $cena;
                 }
-                $this->dobrovolneVstupnePrehled = $this->formatujProLog(
+                $this->dobrovolneVstupnePrehled[] = $this->formatujProLog(
                     nazev: "{$r[PredmetSql::NAZEV]} $cena.-",
                     castka: $cena,
                     kategorie: (int)$r[PredmetSql::TYP],

--- a/tests/Model/Uzivatel/FinanceBfgrVsStrukturovanyPrehledTest.php
+++ b/tests/Model/Uzivatel/FinanceBfgrVsStrukturovanyPrehledTest.php
@@ -387,6 +387,44 @@ SQL,
     /**
      * @test
      */
+    public function testDvojiVstupneVcasSeSecte(): void
+    {
+        $this->vlozNakup(44409, 117);
+        $this->vlozNakup(44409, 117);
+        $finance = $this->dejFinanci();
+
+        self::assertSame(234.0, $finance->cenaVstupne());
+        self::assertSame(234.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
+        self::assertSame(234.0, $this->sumaCastekStrukturovany($finance->dejStrukturovanyPrehled(), TypPredmetu::VSTUPNE));
+    }
+
+    /**
+     * @test
+     */
+    public function testDvojiVstupnePozdeSeSecte(): void
+    {
+        $this->vlozNakup(44410, 100);
+        $this->vlozNakup(44410, 100);
+        $finance = $this->dejFinanci();
+
+        self::assertSame(200.0, $finance->cenaVstupnePozde());
+        self::assertSame(200.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
+    }
+
+    /**
+     * @test
+     */
+    public function testDvojiVstupneNeshodiVypocetZustatku(): void
+    {
+        $this->vlozNakup(44409, 117);
+        $this->vlozNakup(44409, 117);
+
+        self::assertSame(-234.0, $this->dejFinanci()->stav());
+    }
+
+    /**
+     * @test
+     */
     public function testProplaceniBonusuJenVBfgr(): void
     {
         $this->vlozNakup(44412, 500);

--- a/tests/Model/Uzivatel/FinanceBfgrVsStrukturovanyPrehledTest.php
+++ b/tests/Model/Uzivatel/FinanceBfgrVsStrukturovanyPrehledTest.php
@@ -385,30 +385,60 @@ SQL,
     }
 
     /**
+     * Dvojí vstupné je anomálie dat (souběh dvou odeslání přihlášky), ne dva příspěvky —
+     * jde o jeden a týž příspěvek zapsaný dvakrát, takže se počítá jen jednou.
+     *
      * @test
      */
-    public function testDvojiVstupneVcasSeSecte(): void
+    public function testDvojiVstupneVcasSePocitaJenJednou(): void
     {
         $this->vlozNakup(44409, 117);
         $this->vlozNakup(44409, 117);
         $finance = $this->dejFinanci();
 
-        self::assertSame(234.0, $finance->cenaVstupne());
-        self::assertSame(234.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
-        self::assertSame(234.0, $this->sumaCastekStrukturovany($finance->dejStrukturovanyPrehled(), TypPredmetu::VSTUPNE));
+        self::assertSame(117.0, $finance->cenaVstupne());
+        self::assertSame(117.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
+        self::assertSame(117.0, $this->sumaCastekStrukturovany($finance->dejStrukturovanyPrehled(), TypPredmetu::VSTUPNE));
     }
 
     /**
      * @test
      */
-    public function testDvojiVstupnePozdeSeSecte(): void
+    public function testDvojiVstupnePozdeSePocitaJenJednou(): void
     {
         $this->vlozNakup(44410, 100);
         $this->vlozNakup(44410, 100);
         $finance = $this->dejFinanci();
 
-        self::assertSame(200.0, $finance->cenaVstupnePozde());
-        self::assertSame(200.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
+        self::assertSame(100.0, $finance->cenaVstupnePozde());
+        self::assertSame(100.0, $this->sumaCastekBfgr($finance->dejPolozkyProBfgr(), TypPredmetu::VSTUPNE));
+    }
+
+    /**
+     * Po souběhu dvou odeslání jsou obě částky stejné, takže je jedno která projde. Kdyby se přesto
+     * lišily (ruční zásah do DB), počítá se jedna z nich — nikdy ne součet.
+     *
+     * @test
+     */
+    public function testRuznaDvojiVstupneSeNesecte(): void
+    {
+        $this->vlozNakup(44409, 117);
+        $this->vlozNakup(44409, 300);
+
+        self::assertContains($this->dejFinanci()->cenaVstupne(), [117.0, 300.0]);
+    }
+
+    /**
+     * @test
+     */
+    public function testDvojiVstupneJeVeVypisuJenJednou(): void
+    {
+        $this->vlozNakup(44409, 117);
+        $this->vlozNakup(44409, 117);
+        $finance = $this->dejFinanci();
+
+        self::assertCount(1, $finance->dejPolozkyProBfgr());
+        self::assertCount(1, $finance->dejStrukturovanyPrehled());
     }
 
     /**
@@ -419,7 +449,7 @@ SQL,
         $this->vlozNakup(44409, 117);
         $this->vlozNakup(44409, 117);
 
-        self::assertSame(-234.0, $this->dejFinanci()->stav());
+        self::assertSame(-117.0, $this->dejFinanci()->stav());
     }
 
     /**


### PR DESCRIPTION
[Trello 1481 — Dvojí dobrovolné vstupné shodí výpočet zůstatku](https://trello.com/c/0mtyelwS/1481-dvoj%C3%AD-dobrovoln%C3%A9-vstupn%C3%A9-shod%C3%AD-v%C3%BDpo%C4%8Det-z%C5%AFstatku)

## Problém

Uživatel, který má v jednom ročníku dvakrát koupené dobrovolné vstupné, shodí výpočet svého zůstatku. Na lokálu a betě (`zend.assertions=1`) rovnou spadne:

```
AssertionError: assert($this->cenaVstupne === 0)
model/Uzivatel/Finance.php:812
```

Dopad není jen na jednoho uživatele: `UpominaniDluzniku::najdiDluzniky()` prochází **všechny** uživatele a každému volá `finance()->stav()`, takže jediný takový uživatel shodí celý job upomínek dlužníkům, ne jen svůj řádek.

## Příčina

`Finance::zapoctiShop()` počítá s tím, že vstupné je v ročníku nejvýš jedno, a hlídá to assertionem. Druhý řádek předpoklad poruší a assertion padne.

## Řešení: duplicitu započítat jednou, ne sečíst

**Klíčové zjištění — dvojí vstupné není opakovaný příspěvek, ale jeden příspěvek zapsaný dvakrát.** Ověřoval jsem, jestli přihláška umí přispět vícekrát; **neumí**:

- `shop-vstupne.xtpl` má **jediný input** (slider) s absolutní částkou, žádné „přidat další příspěvek".
- `Shop::vstupneHtml()` (`Shop.php:951`) ho předvyplní **současným součtem**, takže uživatel tu částku *edituje*, ne přidává.
- `Shop::zpracujVstupne()` porovná odeslanou částku s uloženým součtem a existující řádek přepíše přes `dbUpdate`. Odeslání 117 podruhé nechá 117, ne 234.

Větev s `INSERT` se trefí jen když uživatel žádné vstupné nemá. Duplicita tedy vzniká souběhem dvou odeslání formuláře nebo ručním zásahem do DB — u uživatele 7237 dva identické řádky po 117 Kč sedí na dvojklik.

**Proto se nesmí sčítat.** Uživatel zaplatil 117, ne 234; sečtení by mu do zůstatku přidalo peníze, které nikdy neposlal, a chtělo by je po něm. To je horší než původní tichá chyba. Navíc by to eskalovalo: `Shop.php:951` předvyplní formulář součtem, takže by příspěvek s každým dalším uložením rostl (117 → 234 → 468).

Přebytečné řádky se proto zahazují hned na začátku smyčky:

```php
if ($r[PredmetSql::TYP] == TypPredmetu::VSTUPNE) {
    if (isset($zpracovaneVstupne[$r[PredmetSql::ID_PREDMETU]])) {
        continue;
    }
    $zpracovaneVstupne[$r[PredmetSql::ID_PREDMETU]] = true;
}
```

Jedno místo řeší všechno — cenu, BFGR i strukturovaný výpis vidí jen jeden řádek, takže původní přiřazení (`=`) i `dobrovolneVstupnePrehled` zůstávají beze změny. Assertiony padají, protože duplicita je teď ošetřená dřív, než se k nim dojde.

Po souběhu jsou obě částky stejné, takže je jedno která projde. Projde ta nejnižší — řádky chodí seřazené vzestupně podle ceny (`ORDER BY nakupy.cena_nakupni`, kvůli slevám na trička) a bereme první.

## Ověření

Pět nových testů v `FinanceBfgrVsStrukturovanyPrehledTest` (soubor už fixtury na vstupné měl):

| Scénář | Před | Po |
|---|---|---|
| 2× vstupné včas po 117 → `cenaVstupne()` | `AssertionError` | `117.0` |
| 2× vstupné pozdě po 100 → `cenaVstupnePozde()` | `AssertionError` | `100.0` |
| 2× vstupné po 117 → `stav()` | `AssertionError` | `-117.0` |
| 2× vstupné po 117 → počet položek ve výpisu | `AssertionError` | `1` (ne 2) |
| 2× vstupné 117 a 300 (různé částky) | `AssertionError` | jedna z nich, nikdy součet |
| 1× vstupné včas 300 (kontrola beze změny) | `300.0` | `300.0` |
| 1× vstupné pozdě 100 (kontrola beze změny) | `100.0` | `100.0` |

Celá sada: **864 testů, 3211 asercí, OK** (6 přeskočených, stejně jako na `main`).

## Pozor při review

- **Neřeší se datová část karty.** Karta chce i smazat duplicitní nákup u uživatele 7237 a projít, jestli takových případů není víc. To jsem nedělal — je to zásah do produkční DB a chci na něj napřed potvrzení. Po téhle opravě už ale duplicita nic neshazuje a počítá se správně, takže to není blokující.
- **Příčinu vzniku duplicity to neřeší**, jen její důsledek. Pokud jde o souběh, dá se zamknout unikátním indexem nad `shop_nakupy(id_uzivatele, id_predmetu, rok)` pro vstupné — samostatná karta, a chce to napřed vědět, kolik takových případů v datech je.
- **S duplicitou v datech zůstává formulář nekonzistentní.** Předvyplní se součtem (2× 117 → ukáže 234), protože `Shop.php:951` čte `sum_cena_nakupni`. Tenhle PR mění jen `Finance`, do shopu nesahá — po vyčištění dat problém zmizí. Kdybychom chtěli, aby formulář seděl i s duplicitou, je to změna v `Shop`, ne tady.
- **ECS na `Finance.php` neběžel.** Soubor má 1 předexistující ECS chybu už na `main` a `--fix` přeformátoval 510 řádků nesouvisejícího kódu. Hlavně by `StrictComparisonFixer` změnil `==` na `===` u `$r[PredmetSql::TYP] == TypPredmetu::VSTUPNE` — a protože z DB chodí typ jako **string** a konstanta je **int**, tohle by tiše rozbilo veškerý výpočet cen v shopu. Reformát jsem zahodil. Nový testovací soubor ECS-clean je.

## Kde to naklikat

Lokální appka běží na `http://localhost`.

- `http://localhost/admin/finance` — otevři a najdi uživatele s dvojím dobrovolným vstupným → zůstatek nespadne a vstupné je v něm započtené **jednou**.
- `http://localhost/prihlaska` (přihlášený jako takový uživatel) → v přehledu financí je vstupné **jednou**, ne dvakrát.

Pozn.: lokální DB je po recreatu kontejnerů prázdná, takže jsem to naklikané neověřoval — pokrytí je testy (viz výše). Případ z karty (uživatel 7237) je produkční data, tam jsem nesahal.
