### PR TITLE
Revoke Google access only for current user

### DIFF
--- a/admin/scripts/modules/aktivity/_GoogleSheets/GoogleApiClient.php
+++ b/admin/scripts/modules/aktivity/_GoogleSheets/GoogleApiClient.php
@@ -167,7 +167,7 @@ class GoogleApiClient
         return $this->getNativeClient();
     }
 
-    public function odeberPristup() {
+    public function revokeAccess() {
         $this->googleApiTokenStorage->deleteTokensFor($this->userId);
     }
 }

--- a/admin/scripts/modules/aktivity/_GoogleSheets/GoogleApiClient.php
+++ b/admin/scripts/modules/aktivity/_GoogleSheets/GoogleApiClient.php
@@ -167,7 +167,7 @@ class GoogleApiClient
         return $this->getNativeClient();
     }
 
-    public function flushAllAuthorizations() {
-        $this->googleApiTokenStorage->deleteAllTokens();
+    public function odeberPristup() {
+        $this->googleApiTokenStorage->deleteTokensFor($this->userId);
     }
 }

--- a/admin/scripts/modules/aktivity/_GoogleSheets/Models/GoogleApiTokenStorage.php
+++ b/admin/scripts/modules/aktivity/_GoogleSheets/Models/GoogleApiTokenStorage.php
@@ -128,21 +128,4 @@ SQL
         }
     }
 
-    public function deleteAllTokens() {
-        try {
-            dbQuery(<<<SQL
-DELETE FROM google_api_user_tokens
-WHERE google_client_id = $1
-SQL
-                , [$this->googleClientId]
-            );
-        } catch (\DbException $exception) {
-            throw new GoogleSheetsException(
-                "Can not delete Google API tokens: {$exception->getMessage()}",
-                $exception->getCode(),
-                $exception
-            );
-        }
-    }
-
 }

--- a/admin/scripts/modules/aktivity/export-import-aktivit.php
+++ b/admin/scripts/modules/aktivity/export-import-aktivit.php
@@ -45,7 +45,7 @@ $googleApiClient = new GoogleApiClient(
 );
 
 if (!empty($_GET['flush-authorization'])) {
-    $googleApiClient->odeberPristup();
+    $googleApiClient->revokeAccess();
     oznameni('Přístup Gameconu k tvému Google účtu byl odebrán', false);
     // redirect to remove the parameter from URL and avoid repeated revoking on page reload
     back(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));

--- a/admin/scripts/modules/aktivity/export-import-aktivit.php
+++ b/admin/scripts/modules/aktivity/export-import-aktivit.php
@@ -45,7 +45,10 @@ $googleApiClient = new GoogleApiClient(
 );
 
 if (!empty($_GET['flush-authorization'])) {
-    $googleApiClient->flushAllAuthorizations();
+    $googleApiClient->odeberPristup();
+    oznameni('Přístup Gameconu k tvému Google účtu byl odebrán', false);
+    // redirect to remove the parameter from URL and avoid repeated revoking on page reload
+    back(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 }
 
 if (isset($_GET['code'])) {

--- a/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiClientTest.php
+++ b/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiClientTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Admin\Modules\Aktivity\GoogleSheets;
+
+use Gamecon\Admin\Modules\Aktivity\GoogleSheets\GoogleApiClient;
+use Gamecon\Admin\Modules\Aktivity\GoogleSheets\Models\GoogleApiCredentials;
+use Gamecon\Admin\Modules\Aktivity\GoogleSheets\Models\GoogleApiTokenStorage;
+use Gamecon\Tests\Db\AbstractTestDb;
+
+class GoogleApiClientTest extends AbstractTestDb
+{
+    private const GOOGLE_CLIENT_ID = 'test-google-client-id.apps.googleusercontent.com';
+
+    public function testOdebraniPristupuNechaTokenyOstatnichUzivateluNetknute()
+    {
+        $tokenStorage = new GoogleApiTokenStorage(self::GOOGLE_CLIENT_ID);
+
+        $prihlasenyUzivatelId = $this->vytvorUzivatele();
+        $jinyUzivatelId = $this->vytvorUzivatele();
+
+        $tokenStorage->setTokensFor([
+            'access_token' => 'prihlaseny',
+        ], $prihlasenyUzivatelId);
+        $tokenStorage->setTokensFor([
+            'access_token' => 'jiny',
+        ], $jinyUzivatelId);
+
+        $googleApiClient = new GoogleApiClient(
+            new GoogleApiCredentials([
+                'web' => [
+                    'client_id' => self::GOOGLE_CLIENT_ID,
+                ],
+            ]),
+            $tokenStorage,
+            $prihlasenyUzivatelId,
+        );
+
+        $googleApiClient->odeberPristup();
+
+        self::assertFalse(
+            $tokenStorage->hasTokensFor($prihlasenyUzivatelId),
+            'Tokeny odhlašovaného uživatele měly být smazané',
+        );
+        self::assertTrue(
+            $tokenStorage->hasTokensFor($jinyUzivatelId),
+            'Odebrání přístupu jednoho uživatele nesmí odhlásit ostatní uživatele',
+        );
+    }
+
+    private function vytvorUzivatele(): int
+    {
+        $jednoznacnyNazev = uniqid('google-test-', true);
+        dbQuery(
+            'INSERT INTO uzivatele_hodnoty (login_uzivatele, email1_uzivatele) VALUES ($1, $2)',
+            [$jednoznacnyNazev, $jednoznacnyNazev . '@example.com'],
+        );
+
+        return (int) dbInsertId();
+    }
+}

--- a/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiClientTest.php
+++ b/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiClientTest.php
@@ -37,7 +37,7 @@ class GoogleApiClientTest extends AbstractTestDb
             $prihlasenyUzivatelId,
         );
 
-        $googleApiClient->odeberPristup();
+        $googleApiClient->revokeAccess();
 
         self::assertFalse(
             $tokenStorage->hasTokensFor($prihlasenyUzivatelId),

--- a/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiTokenStorageTest.php
+++ b/tests/Admin/Modules/Aktivity/GoogleSheets/GoogleApiTokenStorageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Admin\Modules\Aktivity\GoogleSheets;
+
+use Gamecon\Admin\Modules\Aktivity\GoogleSheets\Models\GoogleApiTokenStorage;
+use Gamecon\Tests\Db\AbstractTestDb;
+
+class GoogleApiTokenStorageTest extends AbstractTestDb
+{
+    private const GOOGLE_CLIENT_ID = 'test-google-client-id.apps.googleusercontent.com';
+
+    public function testOdebraniPristupuSmazeTokenyPouzePrihlasenehoUzivatele()
+    {
+        $tokenStorage = new GoogleApiTokenStorage(self::GOOGLE_CLIENT_ID);
+
+        $prihlasenyUzivatelId = $this->vytvorUzivatele();
+        $jinyUzivatelId = $this->vytvorUzivatele();
+
+        $tokenStorage->setTokensFor([
+            'access_token' => 'prihlaseny',
+        ], $prihlasenyUzivatelId);
+        $tokenStorage->setTokensFor([
+            'access_token' => 'jiny',
+        ], $jinyUzivatelId);
+
+        $tokenStorage->deleteTokensFor($prihlasenyUzivatelId);
+
+        self::assertFalse(
+            $tokenStorage->hasTokensFor($prihlasenyUzivatelId),
+            'Tokeny odhlašovaného uživatele měly být smazané',
+        );
+        self::assertTrue(
+            $tokenStorage->hasTokensFor($jinyUzivatelId),
+            'Tokeny ostatních uživatelů měly zůstat zachované',
+        );
+    }
+
+    public function testTokenyJsouOddeleneProKazdyGoogleClientId()
+    {
+        $uzivatelId = $this->vytvorUzivatele();
+
+        $tokenStorage = new GoogleApiTokenStorage(self::GOOGLE_CLIENT_ID);
+        $jinyClientStorage = new GoogleApiTokenStorage('jiny-client-id.apps.googleusercontent.com');
+
+        $tokenStorage->setTokensFor([
+            'access_token' => 'puvodni',
+        ], $uzivatelId);
+        $jinyClientStorage->setTokensFor([
+            'access_token' => 'novy',
+        ], $uzivatelId);
+
+        $tokenStorage->deleteTokensFor($uzivatelId);
+
+        self::assertFalse($tokenStorage->hasTokensFor($uzivatelId));
+        self::assertTrue(
+            $jinyClientStorage->hasTokensFor($uzivatelId),
+            'Smazání tokenů jednoho Google klienta nesmí zasáhnout tokeny jiného',
+        );
+    }
+
+    private function vytvorUzivatele(): int
+    {
+        $jednoznacnyNazev = uniqid('google-test-', true);
+        dbQuery(
+            'INSERT INTO uzivatele_hodnoty (login_uzivatele, email1_uzivatele) VALUES ($1, $2)',
+            [$jednoznacnyNazev, $jednoznacnyNazev . '@example.com'],
+        );
+
+        return (int) dbInsertId();
+    }
+}


### PR DESCRIPTION
## Problém

Odkaz `?flush-authorization=1` na stránce *Export & Import aktivit* má odebrat Google přístup **přihlášenému uživateli**. Místo toho mazal tokeny **všem** — `GoogleApiClient::flushAllAuthorizations()` volal `deleteAllTokens()`, což smaže všechny řádky `google_api_user_tokens` pro dané `google_client_id`, bez ohledu na uživatele.

Důsledek: kdokoli si chtěl přepárovat svůj Google účet, tím odhlásil od Googlu i všechny ostatní organizátory. Ti pak museli projít autorizací znovu, aniž by tušili proč.

## Řešení

- `flushAllAuthorizations()` → `odeberPristup()`, volá `deleteTokensFor($this->userId)` (metoda už existovala a byla správně omezená na jednoho uživatele, jen ji nic nevolalo)
- `deleteAllTokens()` smazána — po opravě neměla volajícího a je to přesně ta past, kvůli které chyba vznikla
- po odebrání přístupu se nyní zobrazí potvrzení a stránka přesměruje bez parametru v URL, takže refresh přístup neodebere znovu (stejný vzorec, jaký už používá větev `?code=`)

## Testy

Nové `tests/Admin/Modules/Aktivity/GoogleSheets/`:

- `GoogleApiClientTest` — ověřuje, že odebrání přístupu jednoho uživatele nechá tokeny ostatních netknuté. Proti původnímu kódu tento test padá (`Failed asserting that false is true`).
- `GoogleApiTokenStorageTest` — mazání je omezené na jednoho uživatele a zároveň na jedno `google_client_id`.

## Jak ověřit

1. <http://localhost/admin/aktivity/export-import> — spárovat s Googlem (lokálně vyžaduje vyplněné `GOOGLE_API_CREDENTIALS`, jinak se zobrazí hláška o chybějícím nastavení)
2. <http://localhost/admin/aktivity/export-import?flush-authorization=1> — očekávej hlášku „Přístup Gameconu k tvému Google účtu byl odebrán", návrat na URL bez parametru a nabídku k opětovné autorizaci
3. U druhého admina ověř, že jeho spárování zůstalo funkční
