### PR TITLE
Formát data platby a odsazení položek v přehledu objednávek

### DIFF
--- a/admin/files/design/styl.css
+++ b/admin/files/design/styl.css
@@ -1591,6 +1591,10 @@ Radio musí být ve tvaru:
   color: inherit;
 }
 
+.objednavky .objednavky--polozka td:first-child {
+  padding-left: 1em;
+}
+
 @media (min-width: 1100px) {
   .vyber-casu {
     position: absolute;

--- a/model/Accounting/PersonalAccount.php
+++ b/model/Accounting/PersonalAccount.php
@@ -87,7 +87,7 @@ readonly class PersonalAccount
             if ($groupedSplit['count'] > 1) {
                 $description .= ' ' . $groupedSplit['count'] . '×';
             }
-            $result = $result . '<tr><td>' . $description . '</td><td>'
+            $result = $result . '<tr class="objednavky--polozka"><td>' . $description . '</td><td>'
                 . ($negatePrice ? -1 : 1) * $groupedSplit['amount']
                 . '</td></tr>';
         }

--- a/model/Cas/DateTimeCzTrait.php
+++ b/model/Cas/DateTimeCzTrait.php
@@ -238,6 +238,12 @@ trait DateTimeCzTrait
         return parent::format(self::FORMAT_DATUM_DB);
     }
 
+    /** Vrací datum bez roku - tvar d. m. */
+    public function formatDatumLetos(): string
+    {
+        return parent::format(self::FORMAT_DATUM_LETOS);
+    }
+
     /**
      * Vrací běžně používaný formát data - tvar d. m. yyyy
      *

--- a/model/Uzivatel/Finance.php
+++ b/model/Uzivatel/Finance.php
@@ -721,10 +721,11 @@ SQL;
             $uzivatelSystemId = \Uzivatel::SYSTEM;
             $result           = dbQuery(<<<SQL
                 SELECT
+                    NULLIF(COALESCE(pripsano_na_ucet_banky, provedeno), '0000-00-00 00:00:00') as datum,
                     IF(provedl=$uzivatelSystemId,
-                      CONCAT(DATE_FORMAT(COALESCE(pripsano_na_ucet_banky, provedeno),'%e.%c.'),' Platba na účet'),
-                      CONCAT(DATE_FORMAT(COALESCE(pripsano_na_ucet_banky, provedeno),'%e.%c.'),' ',IFNULL(poznamka,'(bez poznámky)'))
-                      ) as nazev,
+                      'Platba na účet',
+                      IFNULL(poznamka,'(bez poznámky)')
+                      ) as popis,
                     castka as cena
                 FROM platby
                 WHERE id_uzivatele = {$this->u->id()} AND rok = $rocnik
@@ -733,14 +734,20 @@ SQL;
             $sumaPlateb       = 0.0;
             while ($row = mysqli_fetch_assoc($result)) {
                 $sumaPlateb += (float)$row['cena'];
+                // Nulové datum ('0000-00-00') je v DB možné (sql_mode nemá NO_ZERO_DATE) a PHP
+                // by ho přeložilo na uvěřitelné „30. 11.“ místo aby bylo vidět, že datum chybí.
+                $datum = $row['datum'] !== null
+                    ? DateTimeCz::createFromMysql($row['datum'])->formatDatumLetos() . ' '
+                    : '';
+                $nazev = $datum . $row['popis'];
                 $this->log(
-                    nazev: $row['nazev'],
+                    nazev: $nazev,
                     castka: $row['cena'],
                     kategorie: self::PLATBA,
                     idPolozky: null,
                 );
                 $this->logPolozkaProBfgr(
-                    nazev: $row['nazev'],
+                    nazev: $nazev,
                     pocet: 1,
                     priceAfterDiscountDto: new PriceAfterDiscountDto(
                         finalPrice: -(float)$row['cena'],

--- a/tests/Model/AccountingTest.php
+++ b/tests/Model/AccountingTest.php
@@ -585,8 +585,8 @@ SQL,
         $html = $account->formatForHtml(positivePrices: true);
 
         self::assertStringContainsString('<tr><td><b>Aktivity</b></td><td><b>250</b></td></tr>', $html);
-        self::assertStringContainsString('<tr><td>Vodní bitva</td><td>100</td></tr>', $html);
-        self::assertStringContainsString('<tr><td>Kubb</td><td>150</td></tr>', $html);
+        self::assertStringContainsString('<tr class="objednavky--polozka"><td>Vodní bitva</td><td>100</td></tr>', $html);
+        self::assertStringContainsString('<tr class="objednavky--polozka"><td>Kubb</td><td>150</td></tr>', $html);
     }
 
     /**
@@ -891,4 +891,24 @@ SQL,
         );
     }
 
+    /**
+     * @test
+     */
+    public function testPolozkyPrehleduMajiVlastniTriduKvuliOdsazeni(): void
+    {
+        $this->vlozAktivitu(idAktivity: 55613, nazev: 'Krycí jména', cena: 220);
+
+        $html = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false)->formatForHtml();
+
+        self::assertStringContainsString(
+            '<tr class="objednavky--polozka"><td>Krycí jména</td>',
+            $html,
+            'Řádky jednotlivých položek musí mít třídu, podle které se odsadí od souhrnných řádků kategorií',
+        );
+        self::assertStringNotContainsString(
+            '<tr class="objednavky--polozka"><td><b>',
+            $html,
+            'Souhrnné řádky kategorií se odsazovat nemají',
+        );
+    }
 }

--- a/tests/Model/AccountingTest.php
+++ b/tests/Model/AccountingTest.php
@@ -95,16 +95,21 @@ SQL,
         ],
     ];
 
-    private function vlozPlatbu(float $castka, string $poznamka = 'Test platba'): void
-    {
+    private function vlozPlatbu(
+        float $castka,
+        string $poznamka = 'Test platba',
+        ?string $provedeno = null,
+        ?int $provedl = null,
+    ): void {
         dbQuery(
-            'INSERT INTO platby(id_uzivatele, castka, rok, provedeno, poznamka, provedl) VALUES($0, $1, $2, NOW(), $3, $4)',
+            'INSERT INTO platby(id_uzivatele, castka, rok, provedeno, poznamka, provedl) VALUES($0, $1, $2, COALESCE($3, NOW()), $4, $5)',
             [
                 0 => 555,
                 1 => $castka,
                 2 => ROCNIK,
-                3 => $poznamka,
-                4 => 555,
+                3 => $provedeno,
+                4 => $poznamka,
+                5 => $provedl ?? 555,
             ],
         );
     }
@@ -825,4 +830,65 @@ SQL,
             'FK ON DELETE CASCADE musí smazat generované slevy zaniklého uživatele',
         );
     }
+
+    /**
+     * @test
+     */
+    public function testDatumPlatbyMaMeziDnemAMesicemMezeru(): void
+    {
+        $this->vlozPlatbu(
+            castka: 337,
+            provedeno: ROCNIK . '-07-19 10:00:00',
+            provedl: \Uzivatel::SYSTEM,
+        );
+
+        $html = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false)->formatForHtml();
+
+        self::assertStringContainsString('19. 7. Platba na účet', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function testDatumPlatbySPoznamkouMaMeziDnemAMesicemMezeru(): void
+    {
+        $this->vlozPlatbu(
+            castka: 215,
+            poznamka: 'srovnání nějakého loňského bordelu',
+            provedeno: ROCNIK . '-07-19 10:00:00',
+        );
+
+        $html = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false)->formatForHtml();
+
+        self::assertStringContainsString('19. 7. srovnání nějakého loňského bordelu', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function testNuloveDatumPlatbySeNezobraziJakoSmyslneDatum(): void
+    {
+        // sql_mode nemá NO_ZERO_DATE, takže '0000-00-00' v DB být může.
+        dbQuery(
+            "INSERT INTO platby(id_uzivatele, castka, rok, provedeno, pripsano_na_ucet_banky, poznamka, provedl)
+             VALUES($0, $1, $2, NOW(), '0000-00-00 00:00:00', $3, $4)",
+            [
+                0 => 555,
+                1 => 100,
+                2 => ROCNIK,
+                3 => 'platba bez data',
+                4 => 555,
+            ],
+        );
+
+        $html = Accounting::getPersonalFinance($this->dejUzivatele(), showDiscounts: false)->formatForHtml();
+
+        self::assertStringContainsString('platba bez data', $html);
+        self::assertStringNotContainsString(
+            '30. 11. platba bez data',
+            $html,
+            'Chybějící datum se nesmí zobrazit jako uvěřitelné datum (PHP překládá nulové datum na 30. 11. roku -0001)',
+        );
+    }
+
 }

--- a/web/moduly/finance.php
+++ b/web/moduly/finance.php
@@ -86,6 +86,10 @@ if (!$zaplaceno) {
             width: 20px;
         }
 
+        .tabVeci table .objednavky--polozka td:first-child {
+            padding-left: 1em;
+        }
+
         .payment-methods {
             display: grid;
             gap: 24px;


### PR DESCRIPTION
Dvě drobné úpravy tabulky *Objednávky a platby* v adminu a na webu. Bez Trello karty — zadáno přímo.

## Problém

**1. Datum platby bez mezery.** Řádek platby se vypisoval jako `19.7. Platba na účet`, správně má být `19. 7. Platba na účet`.

Datum se neformátovalo přes žádný formátovač — bylo natvrdo v SQL, dvakrát:

```sql
CONCAT(DATE_FORMAT(COALESCE(pripsano_na_ucet_banky, provedeno),'%e.%c.'),' Platba na účet')
```

Přitom konstanta už v projektu existovala (`DateTimeCzTrait::FORMAT_DATUM_LETOS = 'j. n.'`), jen k ní — na rozdíl od svých sourozenců `formatDatumStandard()`, `formatDatumDb()` a dalších — chyběl přístupový formátovač.

**2. Položky nebyly odsazené.** Jednotlivé položky (konkrétní aktivity, předměty, platby) se vizuálně nelišily od tučných souhrnných řádků kategorií, takže nebylo poznat, co ke které kategorii patří.

## Řešení

**Datum:** doplněn chybějící `formatDatumLetos()` k existující konstantě a použit v `Finance::sumaPlateb()`. SQL nyní vrací datum a popis zvlášť, popisek se skládá v PHP. Obě varianty popisku (systémové „Platba na účet" i vlastní poznámka) jdou přes jeden formátovač.

**Odsazení:** vědomě **ne** plošným selektorem na `.objednavky`. Ta tabulka je sdílená — infopult si do `<table class="objednavky">` skládá vlastní řádky bez tučného textu, takže plošné pravidlo by odsadilo i je. Místo toho položkové řádky dostaly vlastní třídu `objednavky--polozka`, kterou emituje jen `PersonalAccount::formatForHtml()` (má právě dva konzumenty — admin a web), a CSS cílí na ni.

**Nulové datum.** Při review vyšlo najevo, že `sql_mode` nemá `NO_ZERO_DATE`, takže `'0000-00-00'` v `platby` uložit lze — a oba formátovače se na něm rozcházejí:

| | výstup |
|---|---|
| původní `DATE_FORMAT` | `0.0.` — zjevně rozbité, čte se jako chybějící údaj |
| nový PHP formátovač | **`30. 11.`** — PHP překlopí nulové datum na 30. 11. roku −0001 |

Na finančním přehledu je „špatně, ale uvěřitelně" horší než „viditelně prázdné" — proto `NULLIF(...)` v SQL a null guard v PHP: řádek bez data se vypíše jen popiskem. V datech takový řádek dnes není (`SELECT COUNT(*) … = 0`), jde o pojistku.

## Testy

Čtyři nové testy v `tests/Model/AccountingTest.php`, každý ověřen tak, že proti původnímu kódu **padá**:

- `testDatumPlatbyMaMeziDnemAMesicemMezeru` — padá s `19.7. Platba na účet`
- `testDatumPlatbySPoznamkouMaMeziDnemAMesicemMezeru` — totéž pro platbu s poznámkou
- `testNuloveDatumPlatbySeNezobraziJakoSmyslneDatum` — padá s `30. 11. platba bez data`
- `testPolozkyPrehleduMajiVlastniTriduKvuliOdsazeni` — třídu mají jen položky, souhrnné řádky ne

Celá sada: **871 testů, 3218 asercí, OK** (8 přeskočených, dtto na `main`).

PHPStan hlásí na dotčených souborech 33 chyb před i po — diffnuto, liší se jen čísla řádků, žádná nová. ECS je čistý na `PersonalAccount.php` i `AccountingTest.php`; `Finance.php` a `DateTimeCzTrait.php` mají předchozí porušení už na `main` (chybějící `declare(strict_types=1)`, zarovnané konstanty), jejich přeformátování by k 88 řádkům přidalo ~700 řádků nesouvisejícího šumu, tak jsem to nechal být.

Rozděleno na dva commity, každý si nese vlastní testy a je zeleně samostatně.

## Jak ověřit

1. <http://localhost/admin/uzivatel> — vyber uživatele s platbami (např. `?pracovni_uzivatel=2069`). V boxu *Objednávky a platby* očekávej datum ve tvaru `20. 7. Platba na účet` a odsazené položky pod tučnými kategoriemi.
2. <http://localhost/web/finance> — jako přihlášený účastník; stejné odsazení i formát data na veřejné stránce.
3. <http://localhost/admin/infopult> — kontrola, že se **nic nezměnilo**. Infopult sdílí `table.objednavky`, ale své řádky si staví sám, takže odsazení tam dosáhnout nemá.

Ověřeno v prohlížeči: položkové řádky `padding-left: 12px` (= 1em), tučné souhrnné řádky zůstávají na `5px`, infopult beze změny na `5px`.
