### PR TITLE
Fix bin-docker wrappers in a git worktree

### DIFF
--- a/bin-docker/_tty.sh
+++ b/bin-docker/_tty.sh
@@ -1,3 +1,11 @@
+# Where docker-compose.yml mounts the sources inside the container. The image
+# bakes the same path in (APACHE_DOCUMENT_ROOT and WORKDIR in .docker/Dockerfile,
+# DocumentRoot in the apache config), so it does not depend on the host directory
+# name — and must not. Deriving it from the project basename broke every git
+# worktree whose directory is not named "gamecon": the wrappers then failed with
+# "chdir to cwd ... failed".
+GAMECON_CONTAINER_DIR="/var/www/html/gamecon"
+
 if [ -t 0 ] && [ -t 1 ]; then
 	DC_INTERACTIVITY=""
 else

--- a/bin-docker/composer
+++ b/bin-docker/composer
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$DIR")"
-PROJECT_DIR="$(basename "$PROJECT_ROOT")"
 
 source "${DIR}/_tty.sh"
 
@@ -12,12 +10,12 @@ mkdir -p "$HOME/.composer/cache"
 
 if [ "$(docker compose ps web | grep --count Up)" -gt 0 ]; then
 	docker_compose_exec \
-		--workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web composer "$@"
 else
 	docker_compose_run \
-    --workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web composer "$@"
 fi

--- a/bin-docker/docker-bash
+++ b/bin-docker/docker-bash
@@ -5,19 +5,17 @@
 set -euo pipefail
 IFS=$'\n\t'
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROJECT_ROOT="$(dirname "$DIR")"
-PROJECT_DIR="$(basename "$PROJECT_ROOT")"
 
 source "${DIR}/_tty.sh"
 
 if [ "$(docker compose ps web | grep --count Up)" -gt 0 ]; then
 	docker_compose_exec \
-		--workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web bash "$@"
 else
 	docker_compose_run \
-		--workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web bash "$@"
 fi

--- a/bin-docker/php
+++ b/bin-docker/php
@@ -2,19 +2,17 @@
 set -euo pipefail
 IFS=$'\n\t'
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$DIR")"
-PROJECT_DIR="$(basename "$PROJECT_ROOT")"
 
 source "${DIR}/_tty.sh"
 
 if [ "$(docker compose ps web | grep --count Up)" -gt 0 ]; then
 	docker_compose_exec \
-    --workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web php "$@"
 else
 	docker_compose_run \
-    --workdir="/var/www/html/${PROJECT_DIR}" \
+		--workdir="${GAMECON_CONTAINER_DIR}" \
 		--user=www-data \
 		web php "$@"
 fi

--- a/bin-docker/yarn
+++ b/bin-docker/yarn
@@ -2,19 +2,17 @@
 set -euo pipefail
 IFS=$'\n\t'
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$DIR")"
-PROJECT_DIR="$(basename "$PROJECT_ROOT")"
 
 source "${DIR}/_tty.sh"
 
 if [ "$(docker compose ps web | grep --count Up)" -gt 0 ]; then
 	docker_compose_exec \
-    --workdir="/var/www/html/${PROJECT_DIR}/ui" \
+		--workdir="${GAMECON_CONTAINER_DIR}/ui" \
 		--user=www-data \
 		web yarn "$@"
 else
 	docker_compose_run \
-    --workdir="/var/www/html/${PROJECT_DIR}/ui" \
+		--workdir="${GAMECON_CONTAINER_DIR}/ui" \
 		--user=www-data \
 		web yarn "$@"
 fi


### PR DESCRIPTION
The `bin-docker/` wrappers built the container workdir from the **host
directory basename**:

```bash
PROJECT_DIR="$(basename "$PROJECT_ROOT")"
--workdir="/var/www/html/${PROJECT_DIR}"
```

But the sources are always mounted at `/var/www/html/gamecon`, and the image
bakes that same path in — `APACHE_DOCUMENT_ROOT` and `WORKDIR` in
`.docker/Dockerfile`, `DocumentRoot` in the apache config. As long as the
directory happens to be named `gamecon`, the two agree by coincidence.

In a **git worktree** that stops holding, because the directory is named after
the branch. Every wrapper then fails:

```
OCI runtime exec failed: exec failed: unable to start container process:
chdir to cwd ("/var/www/html/gamecon-nocni-blok-test") set in config.json failed:
no such file or directory
```

This broke `php`, `composer`, `yarn` and `docker-bash` — and with them
`make init`, `make run`, `make tests`, `make cache` and everything else that
goes through them.

## The fix

The path is no longer derived from the directory name; it is a single constant
in `_tty.sh` (a file every wrapper already sources):

```bash
GAMECON_CONTAINER_DIR="/var/www/html/gamecon"
```

That also removes the four-way duplication of the same derivation and the now
unused `PROJECT_ROOT` / `PROJECT_DIR` variables. The reformatted lines are only
an indentation fix (the file mixed spaces and tabs).

## Verification

Tested from the worktree `gamecon-nocni-blok-test` (a directory that is
**not** named `gamecon`), with no workaround in the override file — only the
canonical `/var/www/html/gamecon` exists in the container:

| wrapper | result |
|---|---|
| `./bin-docker/php -r ...` | `ok 8.2.30` |
| `./bin-docker/console dbal:run-sql` | returns rows |
| `./bin-docker/composer --version` | OK |
| `./bin-docker/yarn --version` | `1.22.22` |
| `./bin-docker/yarn build` | `✓ built in 1.34s` |
| `./bin-docker/docker-bash -c 'pwd'` | `/var/www/html/gamecon` |
| `./bin-docker/mysql -e ...` | OK |

The main checkout (directory `gamecon`) is unaffected — behaviour there does
not change, because the derived value happened to be correct already.
