### PR TITLE
1274 Slevy jako data — model, pravidla a výpočet (zatím bez volajícího)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,20 @@ class ProductService
 }
 ```
 
+## Migrace obsahují jen holé hodnoty
+
+**Migrace nesmí volat aplikační kód.** Žádné `Pravo::KOSTKA_ZDARMA`, žádné enumy, žádné `use App\...`, žádná validace přes servisní třídu — jen literály a SQL. Co migrace potřebuje vědět, musí mít napsané v sobě.
+
+**Proč:** migrace je *historický zápis* — „v tomhle okamžiku dej do DB tyhle řádky". Jenže se přehrává na každé čerstvé databázi, tedy při každém běhu testů, a to i za rok. Když se odkazuje na živý kód, není fixní: přejmenuje se konstanta nebo se zpřísní validátor a **historická migrace začne padat**, přestože data, která chtěla vložit, jsou v pořádku. Selže něco, co se dávno stalo, kvůli změně někde jinde.
+
+Konkrétně (stalo se v `2026-09-04-100013_seed-discount-rules.php`, obojí opraveno): `Pravo::KOSTKA_ZDARMA` místo `1003` znamená, že po případné změně hodnoty konstanty se stará migrace přehraje s *novým* číslem — tiše přepíše historii. A `DiscountParameters::fromArray()` uvnitř migrace znamenalo, že překlep v nesouvisejícím enumu shodil build celé testovací databáze.
+
+**Pozor na svůdný argument:** „ale díky té validaci se chyba pozná hned" je právě ten příznak, ne přínos — migrace, kterou rozbije editace jiného enumu, je na ten enum navázaná a neměla by být.
+
+**Jak to dělat:** vlož číslo/string přímo a do komentáře napiš, co znamená (`1003 = Pravo::KOSTKA_ZDARMA`). Když se hodnota časem rozejde s konstantou, je to správně — historický řádek si drží, co platilo tehdy. Validace patří tam, kde data píše člověk (admin formulář), ne tam, kde se přehrává historie.
+
+**Výjimka:** pomocné funkce definované přímo v souboru migrace (`$columnExists = fn (...) => ...`) jsou v pořádku — nejsou to závislosti na kódu venku.
+
 ## SQL Coding Style
 
 ### Table Naming Convention

--- a/model/Shop/SqlStruktura/NakupySqlStruktura.php
+++ b/model/Shop/SqlStruktura/NakupySqlStruktura.php
@@ -8,24 +8,24 @@ class NakupySqlStruktura
 {
     public const SHOP_NAKUPY_TABULKA = 'shop_nakupy';
 
-    public const ID_NAKUPU           = 'id_nakupu';
-    public const ID_UZIVATELE       = 'id_uzivatele';
-    public const ID_OBJEDNATELE     = 'id_objednatele';
-    public const ID_PREDMETU        = 'id_predmetu';
-    public const ROK                = 'rok';
-    public const CENA_NAKUPNI       = 'cena_nakupni';
-    public const DATUM              = 'datum';
-    public const ORDER_ID           = 'order_id';
-    public const PRODUCT_NAME       = 'product_name';
-    public const PRODUCT_CODE       = 'product_code';
-    public const PRODUCT_TAGS       = 'product_tags';
+    public const ID_NAKUPU = 'id_nakupu';
+    public const ID_UZIVATELE = 'id_uzivatele';
+    public const ID_OBJEDNATELE = 'id_objednatele';
+    public const ID_PREDMETU = 'id_predmetu';
+    public const ROK = 'rok';
+    public const CENA_NAKUPNI = 'cena_nakupni';
+    public const DATUM = 'datum';
+    public const ORDER_ID = 'order_id';
+    public const PRODUCT_NAME = 'product_name';
+    public const PRODUCT_CODE = 'product_code';
+    public const PRODUCT_TAGS = 'product_tags';
     public const PRODUCT_DESCRIPTION = 'product_description';
-    public const ORIGINAL_PRICE     = 'original_price';
-    public const DISCOUNT_AMOUNT    = 'discount_amount';
-    public const DISCOUNT_REASON    = 'discount_reason';
-    public const VARIANT_ID         = 'variant_id';
-    public const VARIANT_NAME       = 'variant_name';
-    public const VARIANT_CODE       = 'variant_code';
-    public const BUNDLE_ID          = 'bundle_id';
-
+    public const ORIGINAL_PRICE = 'original_price';
+    public const DISCOUNT_AMOUNT = 'discount_amount';
+    public const DISCOUNT_REASON = 'discount_reason';
+    public const DISCOUNT_SNAPSHOT = 'discount_snapshot';
+    public const VARIANT_ID = 'variant_id';
+    public const VARIANT_NAME = 'variant_name';
+    public const VARIANT_CODE = 'variant_code';
+    public const BUNDLE_ID = 'bundle_id';
 }

--- a/symfony/migrations/structures/2026-09-04-100012_discount-rules.php
+++ b/symfony/migrations/structures/2026-09-04-100012_discount-rules.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var Godric\DbMigrations\Migration $this */
+
+// Discount rules become data an admin can read and edit.
+//
+// Today they are branches in Cenik keyed on a Pravo, with the numbers hardcoded in
+// three places: quantities in Cenik and Finance, the meal amount and the bonus base in
+// systemove_nastaveni, and the bonus threshold derived as 3 × the base. Nothing can
+// answer "what discounts are in force" without reading PHP.
+//
+// The columns here are the ones an admin filters by and an audit queries. The varying
+// part of each rule — scope, effect, quantity, threshold — lives in `parameters` as
+// JSON, because the six rules genuinely have different shapes and as columns most
+// would be NULL most of the time. App\Discount\DiscountParameters is the only way in,
+// and rejects anything the scope and effect do not describe, including unknown keys.
+//
+// Rules key on a right (Pravo), not a role, because that is what Cenik checks — so a
+// role gaining or losing a right keeps flowing through unchanged.
+
+$this->q(<<<SQL
+CREATE TABLE IF NOT EXISTS discount_rule (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    code VARCHAR(64) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT NULL,
+    required_right INT NOT NULL,
+    parameters LONGTEXT NOT NULL CHECK (JSON_VALID(parameters)),
+    year SMALLINT NOT NULL,
+    active TINYINT(1) NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY UNIQ_discount_rule_code_year (code, year),
+    KEY IDX_discount_rule_right (required_right),
+    KEY IDX_discount_rule_year_active (year, active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci
+SQL);
+
+// The rule as it was applied, recorded on the purchase. discount_amount and
+// discount_reason stay as the queryable summary; this is the full parameters plus the
+// threshold as resolved at the time, so a later change to a rule cannot rewrite what
+// somebody was charged. Legacy records nothing at all — all 71 709 rows have
+// cena_nakupni equal to the catalogue price and no discount, because Cenik recomputes
+// it on every read.
+$columnExists = fn (string $table, string $column): bool => (bool) $this->q(
+    "SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = DATABASE() AND table_name = '{$table}' AND column_name = '{$column}'",
+)->fetchColumn();
+
+if (! $columnExists('shop_nakupy', 'discount_snapshot')) {
+    $this->q(<<<SQL
+ALTER TABLE shop_nakupy
+    ADD COLUMN discount_snapshot LONGTEXT NULL DEFAULT NULL CHECK (discount_snapshot IS NULL OR JSON_VALID(discount_snapshot))
+SQL);
+}

--- a/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
+++ b/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
@@ -4,152 +4,121 @@ declare(strict_types=1);
 
 /** @var Godric\DbMigrations\Migration $this */
 
-// The six discount rules Cenik implements, expressed as data.
+// The thirteen discount rules Cenik implements, expressed as data.
 //
-// Two things are deliberately NOT copied into the rules:
+// Everything here is a literal on purpose — no constants, no enums, no validation
+// through application code. A migration is a historical statement, but it replays on
+// every fresh database including every test run, so a reference to live code makes it
+// keep changing: rename a constant or tighten a validator and this migration starts
+// failing years later, over rows that were always fine. The numbers below therefore
+// record what the values were when the rules were introduced, and are allowed to drift
+// from the constants if those ever change.
 //
-// The meal discount amount and the bonus threshold stay in systemove_nastaveni rather
-// than being duplicated here. Copying today's numbers would silently freeze them: an
-// admin changing the setting would change the legacy price and not the rule. The rule
-// refers to the setting through DiscountSetting, so the settings key lives in exactly
-// one place the compiler can see, and the value is resolved when the discount is
-// calculated — the resolved number then goes into the snapshot on the purchase, so
-// history stays truthful even when the setting later changes.
+// Rights (id_prava), not roles: Cenik checks Pravo throughout, so a role gaining or
+// losing a right keeps working with no change here.
 //
-// Rights, not roles: Cenik checks Pravo throughout, so a role gaining or losing a
-// right keeps working with no change here.
+// The meal amount and the bonus threshold stay in systemove_nastaveni and are named
+// through DiscountSetting case names rather than copied, so an admin changing a setting
+// changes the rule instead of moving legacy and data apart.
 //
-// Seeded per year, for the current ROCNIK. Rules are copied forward when a new year
-// starts; that is a separate concern and deliberately not automated here.
+// Seeded for the current ROCNIK. Copying rules into a new year is a separate concern.
 
 $rules = [
     [
         'code'           => 'kostka_zdarma',
         'name'           => 'Kostka zdarma',
         'description'    => 'Jedna kostka zdarma pro toho, kdo má právo na kostku zdarma. Druhá a další už za plnou cenu.',
-        'required_right' => Gamecon\Pravo::KOSTKA_ZDARMA,
-        'parameters'     => [
-            'scope'        => 'code_contains',
-            'effect'       => 'free',
-            'codeFragment' => 'kostka',
-            'maxQuantity'  => 1,
-        ],
+        'required_right' => 1003, // Pravo::KOSTKA_ZDARMA
+        'parameters'     => '{"scope":"code_contains","effect":"free","codeFragment":"kostka","maxQuantity":1}',
     ],
     [
         'code'           => 'placka_zdarma',
         'name'           => 'Placka zdarma',
         'description'    => 'Jedna placka zdarma. Nárok na kostku se tím nevyčerpá, jsou to dvě samostatná práva.',
-        'required_right' => Gamecon\Pravo::PLACKA_ZDARMA,
-        'parameters'     => [
-            'scope'        => 'code_contains',
-            'effect'       => 'free',
-            'codeFragment' => 'placka',
-            'maxQuantity'  => 1,
-        ],
+        'required_right' => 1002, // Pravo::PLACKA_ZDARMA
+        'parameters'     => '{"scope":"code_contains","effect":"free","codeFragment":"placka","maxQuantity":1}',
     ],
     [
         'code'           => 'tricko_za_bonus',
         'name'           => 'Tričko zdarma za bonus',
-        'description'    => 'Kdo dosáhne bonusu za vedení aktivit, má zdarma libovolné tričko — vždy to nejlevnější v košíku, bez ohledu na barvu a typ. Práh je hodnota nastavení MODRE_TRICKO_ZDARMA_OD.',
-        'required_right' => Gamecon\Pravo::MODRE_TRICKO_ZDARMA,
-        'parameters'     => [
-            'scope'            => 'tag_cheapest',
-            'effect'           => 'free',
-            'tag'              => 'tricko',
-            'maxQuantity'      => 1,
-            'thresholdSetting' => App\Discount\DiscountSetting::FreeShirtBonusThreshold->value,
-        ],
+        'description'    => 'Kdo dosáhne bonusu za vedení aktivit, má zdarma libovolné tričko — vždy to nejlevnější v košíku, bez ohledu na barvu a typ.',
+        'required_right' => 1012, // Pravo::MODRE_TRICKO_ZDARMA
+        'parameters'     => '{"scope":"tag_cheapest","effect":"free","tag":"tricko","maxQuantity":1,"thresholdSetting":"freeShirtBonusThreshold"}',
     ],
     [
         'code'           => 'jedno_tricko_zdarma',
         'name'           => 'Jedno tričko zdarma',
         'description'    => 'Jedno libovolné tričko zdarma, nezávisle na bonusu.',
-        'required_right' => Gamecon\Pravo::JAKEKOLIV_TRICKO_ZDARMA,
-        'parameters'     => [
-            'scope'       => 'tag',
-            'effect'      => 'free',
-            'tag'         => 'tricko',
-            'maxQuantity' => 1,
-        ],
+        'required_right' => 1035, // Pravo::JAKEKOLIV_TRICKO_ZDARMA
+        'parameters'     => '{"scope":"tag","effect":"free","tag":"tricko","maxQuantity":1}',
     ],
     [
         'code'           => 'dve_tricka_zdarma',
         'name'           => 'Dvě trička zdarma',
-        'description'    => 'Dvě libovolná trička zdarma. Nekumuluje se s jedním tričkem zdarma — kdo má obě práva, dostane dvě.',
-        'required_right' => Gamecon\Pravo::DVE_JAKAKOLI_TRICKA_ZDARMA,
-        'parameters'     => [
-            'scope'       => 'tag',
-            'effect'      => 'free',
-            'tag'         => 'tricko',
-            'maxQuantity' => 2,
-        ],
+        'description'    => 'Dvě libovolná trička zdarma. Kdo má obě práva, dostane dvě.',
+        'required_right' => 1020, // Pravo::DVE_JAKAKOLI_TRICKA_ZDARMA
+        'parameters'     => '{"scope":"tag","effect":"free","tag":"tricko","maxQuantity":2}',
     ],
     [
         'code'           => 'ubytovani_zdarma',
         'name'           => 'Ubytování zdarma',
         'description'    => 'Ubytování zdarma po celou dobu festivalu, všechny noci.',
-        'required_right' => Gamecon\Pravo::UBYTOVANI_ZDARMA,
-        'parameters'     => [
-            'scope'  => 'tag',
-            'effect' => 'free',
-            'tag'    => 'ubytovani',
-        ],
+        'required_right' => 1008, // Pravo::UBYTOVANI_ZDARMA
+        'parameters'     => '{"scope":"tag","effect":"free","tag":"ubytovani"}',
     ],
     [
         'code'           => 'jidlo_zdarma',
         'name'           => 'Jídlo zdarma',
         'description'    => 'Všechna jídla zdarma.',
-        'required_right' => Gamecon\Pravo::JIDLO_ZDARMA,
-        'parameters'     => [
-            'scope'  => 'tag',
-            'effect' => 'free',
-            'tag'    => 'jidlo',
-        ],
+        'required_right' => 1005, // Pravo::JIDLO_ZDARMA
+        'parameters'     => '{"scope":"tag","effect":"free","tag":"jidlo"}',
     ],
     [
         'code'           => 'jidlo_se_slevou',
         'name'           => 'Jídlo se slevou',
-        'description'    => 'Sleva pevnou částkou na každé jídlo. Částka je hodnota nastavení SLEVA_ORGU_NA_JIDLO_CASTKA — jediná sleva, která není 100 %.',
-        'required_right' => Gamecon\Pravo::JIDLO_SE_SLEVOU,
-        'parameters'     => [
-            'scope'         => 'tag',
-            'effect'        => 'fixed_amount',
-            'tag'           => 'jidlo',
-            'amountSetting' => App\Discount\DiscountSetting::OrganizerMealDiscount->value,
-        ],
+        'description'    => 'Sleva pevnou částkou na každé jídlo — jediná sleva, která není 100 %.',
+        'required_right' => 1004, // Pravo::JIDLO_SE_SLEVOU
+        'parameters'     => '{"scope":"tag","effect":"fixed_amount","tag":"jidlo","amountSetting":"organizerMealDiscount"}',
+    ],
+    [
+        'code'           => 'ubytovani_stredecni_noc_zdarma',
+        'name'           => 'Ubytování středeční noc zdarma',
+        'description'    => 'Zdarma středeční noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => 1015, // Pravo::UBYTOVANI_STREDECNI_NOC_ZDARMA
+        'parameters'     => '{"scope":"tag_and_day","effect":"free","tag":"ubytovani","day":0}',
+    ],
+    [
+        'code'           => 'ubytovani_ctvrtecni_noc_zdarma',
+        'name'           => 'Ubytování čtvrteční noc zdarma',
+        'description'    => 'Zdarma čtvrteční noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => 1029, // Pravo::UBYTOVANI_CTVRTECNI_NOC_ZDARMA
+        'parameters'     => '{"scope":"tag_and_day","effect":"free","tag":"ubytovani","day":1}',
+    ],
+    [
+        'code'           => 'ubytovani_patecni_noc_zdarma',
+        'name'           => 'Ubytování páteční noc zdarma',
+        'description'    => 'Zdarma páteční noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => 1030, // Pravo::UBYTOVANI_PATECNI_NOC_ZDARMA
+        'parameters'     => '{"scope":"tag_and_day","effect":"free","tag":"ubytovani","day":2}',
+    ],
+    [
+        'code'           => 'ubytovani_sobotni_noc_zdarma',
+        'name'           => 'Ubytování sobotní noc zdarma',
+        'description'    => 'Zdarma sobotní noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => 1031, // Pravo::UBYTOVANI_SOBOTNI_NOC_ZDARMA
+        'parameters'     => '{"scope":"tag_and_day","effect":"free","tag":"ubytovani","day":3}',
+    ],
+    [
+        'code'           => 'ubytovani_nedelni_noc_zdarma',
+        'name'           => 'Ubytování nedělní noc zdarma',
+        'description'    => 'Zdarma nedělní noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => 1018, // Pravo::UBYTOVANI_NEDELNI_NOC_ZDARMA
+        'parameters'     => '{"scope":"tag_and_day","effect":"free","tag":"ubytovani","day":4}',
     ],
 ];
 
-// Free-night rights, one rule per night. The entitlement is not consumed — it applies
-// to every night bought for that day, unlike the dice.
-$nightRights = [
-    0 => [Gamecon\Pravo::UBYTOVANI_STREDECNI_NOC_ZDARMA, 'stredecni', 'středeční'],
-    1 => [Gamecon\Pravo::UBYTOVANI_CTVRTECNI_NOC_ZDARMA, 'ctvrtecni', 'čtvrteční'],
-    2 => [Gamecon\Pravo::UBYTOVANI_PATECNI_NOC_ZDARMA, 'patecni', 'páteční'],
-    3 => [Gamecon\Pravo::UBYTOVANI_SOBOTNI_NOC_ZDARMA, 'sobotni', 'sobotní'],
-    4 => [Gamecon\Pravo::UBYTOVANI_NEDELNI_NOC_ZDARMA, 'nedelni', 'nedělní'],
-];
-foreach ($nightRights as $day => [$right, $codeSuffix, $label]) {
-    $rules[] = [
-        'code'           => 'ubytovani_' . $codeSuffix . '_noc_zdarma',
-        'name'           => 'Ubytování ' . $label . ' noc zdarma',
-        'description'    => 'Zdarma ' . $label . ' noc. Nárok se nevyčerpá, platí na každou takovou noc.',
-        'required_right' => $right,
-        'parameters'     => [
-            'scope'  => 'tag_and_day',
-            'effect' => 'free',
-            'tag'    => 'ubytovani',
-            'day'    => $day,
-        ],
-    ];
-}
-
 foreach ($rules as $rule) {
-    // Validated on the way in, so a malformed rule fails the migration rather than
-    // sitting in the table until someone buys something.
-    App\Discount\DiscountParameters::fromArray($rule['parameters']);
-
-    \dbQuery(
+    dbQuery(
         'INSERT INTO discount_rule (code, name, description, required_right, parameters, year, active)
          VALUES ($0, $1, $2, $3, $4, $5, 1)
          ON DUPLICATE KEY UPDATE
@@ -162,7 +131,7 @@ foreach ($rules as $rule) {
             1 => $rule['name'],
             2 => $rule['description'],
             3 => $rule['required_right'],
-            4 => json_encode($rule['parameters'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+            4 => $rule['parameters'],
             5 => ROCNIK,
         ],
     );

--- a/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
+++ b/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
@@ -8,14 +8,13 @@ declare(strict_types=1);
 //
 // Two things are deliberately NOT copied into the rules:
 //
-// The meal discount amount stays in systemove_nastaveni (SLEVA_ORGU_NA_JIDLO_CASTKA)
-// rather than being duplicated here, and so does the bonus threshold
-// (MODRE_TRICKO_ZDARMA_OD, itself derived as 3 × BONUS_ZA_STANDARDNI_3H_AZ_5H_AKTIVITU).
-// Copying today's numbers would silently freeze them: an admin changing the setting
-// would change the legacy price and not the rule. The rule names the setting, and the
-// value is resolved when the discount is calculated — the resolved number then goes
-// into the snapshot on the purchase, so history stays truthful even when the setting
-// later changes.
+// The meal discount amount and the bonus threshold stay in systemove_nastaveni rather
+// than being duplicated here. Copying today's numbers would silently freeze them: an
+// admin changing the setting would change the legacy price and not the rule. The rule
+// refers to the setting through DiscountSetting, so the settings key lives in exactly
+// one place the compiler can see, and the value is resolved when the discount is
+// calculated — the resolved number then goes into the snapshot on the purchase, so
+// history stays truthful even when the setting later changes.
 //
 // Rights, not roles: Cenik checks Pravo throughout, so a role gaining or losing a
 // right keeps working with no change here.
@@ -58,7 +57,7 @@ $rules = [
             'effect'           => 'free',
             'tag'              => 'tricko',
             'maxQuantity'      => 1,
-            'thresholdSetting' => 'MODRE_TRICKO_ZDARMA_OD',
+            'thresholdSetting' => App\Discount\DiscountSetting::FreeShirtBonusThreshold->value,
         ],
     ],
     [
@@ -116,7 +115,7 @@ $rules = [
             'scope'         => 'tag',
             'effect'        => 'fixed_amount',
             'tag'           => 'jidlo',
-            'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
+            'amountSetting' => App\Discount\DiscountSetting::OrganizerMealDiscount->value,
         ],
     ],
 ];

--- a/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
+++ b/symfony/migrations/structures/2026-09-04-100013_seed-discount-rules.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var Godric\DbMigrations\Migration $this */
+
+// The six discount rules Cenik implements, expressed as data.
+//
+// Two things are deliberately NOT copied into the rules:
+//
+// The meal discount amount stays in systemove_nastaveni (SLEVA_ORGU_NA_JIDLO_CASTKA)
+// rather than being duplicated here, and so does the bonus threshold
+// (MODRE_TRICKO_ZDARMA_OD, itself derived as 3 × BONUS_ZA_STANDARDNI_3H_AZ_5H_AKTIVITU).
+// Copying today's numbers would silently freeze them: an admin changing the setting
+// would change the legacy price and not the rule. The rule names the setting, and the
+// value is resolved when the discount is calculated — the resolved number then goes
+// into the snapshot on the purchase, so history stays truthful even when the setting
+// later changes.
+//
+// Rights, not roles: Cenik checks Pravo throughout, so a role gaining or losing a
+// right keeps working with no change here.
+//
+// Seeded per year, for the current ROCNIK. Rules are copied forward when a new year
+// starts; that is a separate concern and deliberately not automated here.
+
+$rules = [
+    [
+        'code'           => 'kostka_zdarma',
+        'name'           => 'Kostka zdarma',
+        'description'    => 'Jedna kostka zdarma pro toho, kdo má právo na kostku zdarma. Druhá a další už za plnou cenu.',
+        'required_right' => Gamecon\Pravo::KOSTKA_ZDARMA,
+        'parameters'     => [
+            'scope'        => 'code_contains',
+            'effect'       => 'free',
+            'codeFragment' => 'kostka',
+            'maxQuantity'  => 1,
+        ],
+    ],
+    [
+        'code'           => 'placka_zdarma',
+        'name'           => 'Placka zdarma',
+        'description'    => 'Jedna placka zdarma. Nárok na kostku se tím nevyčerpá, jsou to dvě samostatná práva.',
+        'required_right' => Gamecon\Pravo::PLACKA_ZDARMA,
+        'parameters'     => [
+            'scope'        => 'code_contains',
+            'effect'       => 'free',
+            'codeFragment' => 'placka',
+            'maxQuantity'  => 1,
+        ],
+    ],
+    [
+        'code'           => 'tricko_za_bonus',
+        'name'           => 'Tričko zdarma za bonus',
+        'description'    => 'Kdo dosáhne bonusu za vedení aktivit, má zdarma libovolné tričko — vždy to nejlevnější v košíku, bez ohledu na barvu a typ. Práh je hodnota nastavení MODRE_TRICKO_ZDARMA_OD.',
+        'required_right' => Gamecon\Pravo::MODRE_TRICKO_ZDARMA,
+        'parameters'     => [
+            'scope'            => 'tag_cheapest',
+            'effect'           => 'free',
+            'tag'              => 'tricko',
+            'maxQuantity'      => 1,
+            'thresholdSetting' => 'MODRE_TRICKO_ZDARMA_OD',
+        ],
+    ],
+    [
+        'code'           => 'jedno_tricko_zdarma',
+        'name'           => 'Jedno tričko zdarma',
+        'description'    => 'Jedno libovolné tričko zdarma, nezávisle na bonusu.',
+        'required_right' => Gamecon\Pravo::JAKEKOLIV_TRICKO_ZDARMA,
+        'parameters'     => [
+            'scope'       => 'tag',
+            'effect'      => 'free',
+            'tag'         => 'tricko',
+            'maxQuantity' => 1,
+        ],
+    ],
+    [
+        'code'           => 'dve_tricka_zdarma',
+        'name'           => 'Dvě trička zdarma',
+        'description'    => 'Dvě libovolná trička zdarma. Nekumuluje se s jedním tričkem zdarma — kdo má obě práva, dostane dvě.',
+        'required_right' => Gamecon\Pravo::DVE_JAKAKOLI_TRICKA_ZDARMA,
+        'parameters'     => [
+            'scope'       => 'tag',
+            'effect'      => 'free',
+            'tag'         => 'tricko',
+            'maxQuantity' => 2,
+        ],
+    ],
+    [
+        'code'           => 'ubytovani_zdarma',
+        'name'           => 'Ubytování zdarma',
+        'description'    => 'Ubytování zdarma po celou dobu festivalu, všechny noci.',
+        'required_right' => Gamecon\Pravo::UBYTOVANI_ZDARMA,
+        'parameters'     => [
+            'scope'  => 'tag',
+            'effect' => 'free',
+            'tag'    => 'ubytovani',
+        ],
+    ],
+    [
+        'code'           => 'jidlo_zdarma',
+        'name'           => 'Jídlo zdarma',
+        'description'    => 'Všechna jídla zdarma.',
+        'required_right' => Gamecon\Pravo::JIDLO_ZDARMA,
+        'parameters'     => [
+            'scope'  => 'tag',
+            'effect' => 'free',
+            'tag'    => 'jidlo',
+        ],
+    ],
+    [
+        'code'           => 'jidlo_se_slevou',
+        'name'           => 'Jídlo se slevou',
+        'description'    => 'Sleva pevnou částkou na každé jídlo. Částka je hodnota nastavení SLEVA_ORGU_NA_JIDLO_CASTKA — jediná sleva, která není 100 %.',
+        'required_right' => Gamecon\Pravo::JIDLO_SE_SLEVOU,
+        'parameters'     => [
+            'scope'         => 'tag',
+            'effect'        => 'fixed_amount',
+            'tag'           => 'jidlo',
+            'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
+        ],
+    ],
+];
+
+// Free-night rights, one rule per night. The entitlement is not consumed — it applies
+// to every night bought for that day, unlike the dice.
+$nightRights = [
+    0 => [Gamecon\Pravo::UBYTOVANI_STREDECNI_NOC_ZDARMA, 'stredecni', 'středeční'],
+    1 => [Gamecon\Pravo::UBYTOVANI_CTVRTECNI_NOC_ZDARMA, 'ctvrtecni', 'čtvrteční'],
+    2 => [Gamecon\Pravo::UBYTOVANI_PATECNI_NOC_ZDARMA, 'patecni', 'páteční'],
+    3 => [Gamecon\Pravo::UBYTOVANI_SOBOTNI_NOC_ZDARMA, 'sobotni', 'sobotní'],
+    4 => [Gamecon\Pravo::UBYTOVANI_NEDELNI_NOC_ZDARMA, 'nedelni', 'nedělní'],
+];
+foreach ($nightRights as $day => [$right, $codeSuffix, $label]) {
+    $rules[] = [
+        'code'           => 'ubytovani_' . $codeSuffix . '_noc_zdarma',
+        'name'           => 'Ubytování ' . $label . ' noc zdarma',
+        'description'    => 'Zdarma ' . $label . ' noc. Nárok se nevyčerpá, platí na každou takovou noc.',
+        'required_right' => $right,
+        'parameters'     => [
+            'scope'  => 'tag_and_day',
+            'effect' => 'free',
+            'tag'    => 'ubytovani',
+            'day'    => $day,
+        ],
+    ];
+}
+
+foreach ($rules as $rule) {
+    // Validated on the way in, so a malformed rule fails the migration rather than
+    // sitting in the table until someone buys something.
+    App\Discount\DiscountParameters::fromArray($rule['parameters']);
+
+    \dbQuery(
+        'INSERT INTO discount_rule (code, name, description, required_right, parameters, year, active)
+         VALUES ($0, $1, $2, $3, $4, $5, 1)
+         ON DUPLICATE KEY UPDATE
+            name = VALUES(name),
+            description = VALUES(description),
+            required_right = VALUES(required_right),
+            parameters = VALUES(parameters)',
+        [
+            0 => $rule['code'],
+            1 => $rule['name'],
+            2 => $rule['description'],
+            3 => $rule['required_right'],
+            4 => json_encode($rule['parameters'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+            5 => ROCNIK,
+        ],
+    );
+}

--- a/symfony/src/Discount/AppliedDiscount.php
+++ b/symfony/src/Discount/AppliedDiscount.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * What a rule did to one item, and enough of the rule to explain it later.
+ *
+ * The snapshot is the point: legacy records nothing at all — every shop_nakupy row
+ * holds the catalogue price and no discount, because Cenik recomputes it on each read.
+ * Change a rule or a role and history silently rewrites itself. Here the rule as
+ * applied, including any threshold as it resolved at that moment, is stored with the
+ * purchase, so an audit years later reads what actually happened.
+ */
+final readonly class AppliedDiscount
+{
+    public function __construct(
+        public int|string $itemKey,
+        public string $ruleCode,
+        public string $ruleName,
+        public float $originalPrice,
+        public float $discountAmount,
+        public float $finalPrice,
+        /**
+         * @var array<string, mixed> the rule as applied, for shop_nakupy.discount_snapshot
+         */
+        public array $snapshot,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $resolved values resolved at calculation time, e.g. the threshold
+     */
+    public static function create(
+        DiscountableItem $item,
+        DiscountRule $rule,
+        float $discountAmount,
+        array $resolved = [],
+    ): self {
+        return new self(
+            itemKey: $item->key,
+            ruleCode: $rule->code,
+            ruleName: $rule->name,
+            originalPrice: $item->price,
+            discountAmount: $discountAmount,
+            finalPrice: round($item->price - $discountAmount, 2),
+            snapshot: [
+                'ruleCode'       => $rule->code,
+                'ruleName'       => $rule->name,
+                'requiredRight'  => $rule->requiredRight,
+                'parameters'     => $rule->parameters->toArray(),
+                'resolved'       => $resolved,
+                'originalPrice'  => $item->price,
+                'discountAmount' => $discountAmount,
+            ],
+        );
+    }
+}

--- a/symfony/src/Discount/DiscountCalculation.php
+++ b/symfony/src/Discount/DiscountCalculation.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * Applies discount rules to a whole cart.
+ *
+ * Cart-level rather than per-item, because three of the rule kinds cannot be decided
+ * one item at a time: TAG_CHEAPEST needs to know which matching item is cheapest,
+ * maxQuantity counters run across items, and legacy prices from the cheapest up so the
+ * free-shirt entitlement lands on the cheapest shirt.
+ *
+ * Pure: no database, no entity manager, no Uzivatel. The caller supplies the rules, the
+ * rights, and the earned bonus, so the same code serves the new cart and legacy Cenik.
+ */
+final readonly class DiscountCalculation
+{
+    /**
+     * @param DiscountRule[]       $rules
+     * @param int[]                $rights      id_prava the buyer holds
+     * @param array<string, float> $settings    resolved DiscountSetting values, keyed by case value
+     * @param float                $earnedBonus bonus for running activities, for threshold rules
+     */
+    public function __construct(
+        private array $rules,
+        private array $rights,
+        private array $settings,
+        private float $earnedBonus = 0.0,
+    ) {
+    }
+
+    /**
+     * @param DiscountableItem[] $items
+     *
+     * @return AppliedDiscount[] keyed by item key; items with no discount are absent
+     */
+    public function apply(array $items): array
+    {
+        // Cheapest first, matching Finance::zapoctiShop's ORDER BY: a single free-shirt
+        // entitlement must land on the cheapest shirt, not on whichever came first.
+        usort($items, static fn (DiscountableItem $a, DiscountableItem $b): int => $a->price <=> $b->price);
+
+        $applied = [];
+        $remaining = $this->initialQuantities();
+
+        foreach ($items as $item) {
+            foreach ($this->rules as $rule) {
+                if (! $this->isEligible($rule)) {
+                    continue;
+                }
+                if (! $item->matches($rule->parameters)) {
+                    continue;
+                }
+                if (isset($remaining[$rule->code]) && $remaining[$rule->code] <= 0) {
+                    continue;
+                }
+
+                $amount = $this->amountFor($rule);
+                if ($amount === null) {
+                    continue;
+                }
+
+                $discount = $rule->parameters->effect->discountFrom($item->price, $amount);
+                if ($discount <= 0.0) {
+                    continue;
+                }
+
+                $applied[$item->key] = AppliedDiscount::create($item, $rule, $discount, $this->resolvedFor($rule));
+
+                if (isset($remaining[$rule->code])) {
+                    --$remaining[$rule->code];
+                }
+
+                // One discount per item: the rules are entitlements, not stacking offers.
+                break;
+            }
+        }
+
+        return $applied;
+    }
+
+    /**
+     * @return array<string, int> remaining uses per rule code; rules without a limit are absent
+     */
+    private function initialQuantities(): array
+    {
+        $quantities = [];
+        foreach ($this->rules as $rule) {
+            // An entitlement tied to a specific night is not consumed — it applies to
+            // every night bought for that day, unlike a free dice.
+            if ($rule->parameters->maxQuantity !== null && $rule->parameters->scope->isConsumable()) {
+                $quantities[$rule->code] = $rule->parameters->maxQuantity;
+            }
+        }
+
+        return $quantities;
+    }
+
+    private function isEligible(DiscountRule $rule): bool
+    {
+        if (! in_array($rule->requiredRight, $this->rights, true)) {
+            return false;
+        }
+
+        $threshold = $rule->parameters->thresholdSetting;
+
+        return $threshold === null || $this->earnedBonus >= $this->settingValue($threshold);
+    }
+
+    /**
+     * @return float|null the effect's parameter, or null when the rule cannot be priced
+     */
+    private function amountFor(DiscountRule $rule): ?float
+    {
+        if ($rule->parameters->effect === DiscountEffect::FREE) {
+            return 0.0;
+        }
+        if ($rule->parameters->amountSetting !== null) {
+            return $this->settingValue($rule->parameters->amountSetting);
+        }
+
+        return $rule->parameters->amount;
+    }
+
+    /**
+     * @return array<string, mixed> the values a rule resolved to, recorded in the snapshot
+     */
+    private function resolvedFor(DiscountRule $rule): array
+    {
+        $resolved = [];
+        if ($rule->parameters->thresholdSetting !== null) {
+            $resolved['threshold'] = $this->settingValue($rule->parameters->thresholdSetting);
+            $resolved['earnedBonus'] = $this->earnedBonus;
+        }
+        if ($rule->parameters->amountSetting !== null) {
+            $resolved['amount'] = $this->settingValue($rule->parameters->amountSetting);
+        }
+
+        return $resolved;
+    }
+
+    private function settingValue(DiscountSetting $setting): float
+    {
+        // A rule naming a setting the caller did not supply would otherwise be treated
+        // as a zero threshold or a zero discount — silently wrong in both directions.
+        return $this->settings[$setting->value]
+            ?? throw new \InvalidArgumentException(sprintf('Chybí hodnota nastavení "%s" (%s)', $setting->value, $setting->settingKey()));
+    }
+}

--- a/symfony/src/Discount/DiscountEffect.php
+++ b/symfony/src/Discount/DiscountEffect.php
@@ -26,14 +26,18 @@ enum DiscountEffect: string
     }
 
     /**
-     * @return string[]
+     * One of these must be present. FIXED_AMOUNT accepts either a literal amount or
+     * the name of a system setting to read it from, so the organizer meal discount can
+     * follow SLEVA_ORGU_NA_JIDLO_CASTKA instead of freezing today's value.
+     *
+     * @return string[][]
      */
     public function requiredParameters(): array
     {
         return match ($this) {
             self::FREE         => [],
-            self::FIXED_AMOUNT => ['amount'],
-            self::PERCENT      => ['percent'],
+            self::FIXED_AMOUNT => [['amount', 'amountSetting']],
+            self::PERCENT      => [['percent']],
         };
     }
 

--- a/symfony/src/Discount/DiscountEffect.php
+++ b/symfony/src/Discount/DiscountEffect.php
@@ -42,6 +42,23 @@ enum DiscountEffect: string
     }
 
     /**
+     * Of those, the ones an admin may change — the numbers, not the shape.
+     *
+     * amountSetting is not among them: which setting a rule follows is a wiring
+     * decision, and the number itself is already editable on the settings page.
+     *
+     * @return string[]
+     */
+    public function editableParameters(): array
+    {
+        return match ($this) {
+            self::FREE         => [],
+            self::FIXED_AMOUNT => ['amount'],
+            self::PERCENT      => ['percent'],
+        };
+    }
+
+    /**
      * @param float $price     the price before this rule
      * @param float $parameter amount in Kč, or percent, depending on the effect
      *

--- a/symfony/src/Discount/DiscountEffect.php
+++ b/symfony/src/Discount/DiscountEffect.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * What the rule does to the price.
+ *
+ * FIXED_AMOUNT exists because the organizer meal discount is a flat 30 Kč rather than
+ * a percentage — the reason a percent-only column could not express these rules.
+ */
+enum DiscountEffect: string
+{
+    case FREE = 'free';
+    case FIXED_AMOUNT = 'fixed_amount';
+    case PERCENT = 'percent';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::FREE         => 'Zdarma',
+            self::FIXED_AMOUNT => 'Sleva pevnou částkou',
+            self::PERCENT      => 'Sleva procentem',
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    public function requiredParameters(): array
+    {
+        return match ($this) {
+            self::FREE         => [],
+            self::FIXED_AMOUNT => ['amount'],
+            self::PERCENT      => ['percent'],
+        };
+    }
+
+    /**
+     * @param float $price     the price before this rule
+     * @param float $parameter amount in Kč, or percent, depending on the effect
+     *
+     * @return float the discount to subtract, never more than the price itself
+     */
+    public function discountFrom(float $price, float $parameter): float
+    {
+        $discount = match ($this) {
+            self::FREE         => $price,
+            self::FIXED_AMOUNT => $parameter,
+            self::PERCENT      => $price * $parameter / 100,
+        };
+
+        return min($discount, $price);
+    }
+}

--- a/symfony/src/Discount/DiscountParameters.php
+++ b/symfony/src/Discount/DiscountParameters.php
@@ -120,6 +120,22 @@ final readonly class DiscountParameters
     }
 
     /**
+     * Parameter names the admin form may offer as inputs, everything else being shown
+     * read-only. maxQuantity is here regardless of scope and effect — how many items a
+     * rule covers is policy, not shape.
+     *
+     * @return string[]
+     */
+    public function editableParameters(): array
+    {
+        return [
+            ...$this->scope->editableParameters(),
+            ...$this->effect->editableParameters(),
+            'maxQuantity',
+        ];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array

--- a/symfony/src/Discount/DiscountParameters.php
+++ b/symfony/src/Discount/DiscountParameters.php
@@ -42,6 +42,11 @@ final readonly class DiscountParameters
          */
         public ?int $maxQuantity,
         /**
+         * System setting to read the discount amount from, instead of freezing today's
+         * number into the rule.
+         */
+        public ?string $amountSetting,
+        /**
          * System setting whose value the user's bonus must reach, e.g.
          * MODRE_TRICKO_ZDARMA_OD. Resolved at calculation time so an admin changing
          * the setting changes the rule, and the resolved number is recorded in the
@@ -64,13 +69,14 @@ final readonly class DiscountParameters
             ?? throw new \InvalidArgumentException(sprintf('Neznámý efekt slevy "%s"', (string) ($parameters['effect'] ?? '')));
 
         $required = [...$scope->requiredParameters(), ...$effect->requiredParameters()];
-        foreach ($required as $name) {
-            if (! isset($parameters[$name])) {
-                throw new \InvalidArgumentException(sprintf('Sleva typu %s/%s vyžaduje parametr "%s"', $scope->value, $effect->value, $name));
+        foreach ($required as $alternatives) {
+            $present = array_filter($alternatives, static fn (string $name): bool => isset($parameters[$name]));
+            if ($present === []) {
+                throw new \InvalidArgumentException(sprintf('Sleva typu %s/%s vyžaduje parametr "%s"', $scope->value, $effect->value, implode('" nebo "', $alternatives)));
             }
         }
 
-        $known = [...$required, 'scope', 'effect', 'maxQuantity', 'thresholdSetting'];
+        $known = [...array_merge(...$required), 'scope', 'effect', 'maxQuantity', 'thresholdSetting'];
         $unknown = array_diff(array_keys($parameters), $known);
         if ($unknown !== []) {
             // A typo in a parameter name would otherwise be silently ignored and the
@@ -92,6 +98,7 @@ final readonly class DiscountParameters
             amount: isset($parameters['amount'])
                 ? (float) $parameters['amount']
                 : (isset($parameters['percent']) ? (float) $parameters['percent'] : null),
+            amountSetting: isset($parameters['amountSetting']) ? (string) $parameters['amountSetting'] : null,
             maxQuantity: isset($parameters['maxQuantity']) ? (int) $parameters['maxQuantity'] : null,
             thresholdSetting: isset($parameters['thresholdSetting']) ? (string) $parameters['thresholdSetting'] : null,
         );
@@ -109,6 +116,7 @@ final readonly class DiscountParameters
             'tag'                                                            => $this->tag,
             'day'                                                            => $this->day,
             $this->effect === DiscountEffect::PERCENT ? 'percent' : 'amount' => $this->amount,
+            'amountSetting'                                                  => $this->amountSetting,
             'maxQuantity'                                                    => $this->maxQuantity,
             'thresholdSetting'                                               => $this->thresholdSetting,
         ], static fn ($value): bool => $value !== null);

--- a/symfony/src/Discount/DiscountParameters.php
+++ b/symfony/src/Discount/DiscountParameters.php
@@ -42,17 +42,17 @@ final readonly class DiscountParameters
          */
         public ?int $maxQuantity,
         /**
-         * System setting to read the discount amount from, instead of freezing today's
-         * number into the rule.
+         * Setting to read the discount amount from, instead of freezing today's number
+         * into the rule.
          */
-        public ?string $amountSetting,
+        public ?DiscountSetting $amountSetting,
         /**
-         * System setting whose value the user's bonus must reach, e.g.
-         * MODRE_TRICKO_ZDARMA_OD. Resolved at calculation time so an admin changing
-         * the setting changes the rule, and the resolved number is recorded in the
-         * snapshot on the purchase.
+         * Setting whose value the user's bonus must reach. Resolved at calculation
+         * time, so an admin changing the setting changes the rule; the resolved number
+         * goes into the snapshot on the purchase, so history stays truthful when the
+         * setting later changes.
          */
-        public ?string $thresholdSetting,
+        public ?DiscountSetting $thresholdSetting,
     ) {
     }
 
@@ -98,10 +98,20 @@ final readonly class DiscountParameters
             amount: isset($parameters['amount'])
                 ? (float) $parameters['amount']
                 : (isset($parameters['percent']) ? (float) $parameters['percent'] : null),
-            amountSetting: isset($parameters['amountSetting']) ? (string) $parameters['amountSetting'] : null,
+            amountSetting: isset($parameters['amountSetting'])
+                ? self::setting((string) $parameters['amountSetting'], 'amountSetting')
+                : null,
             maxQuantity: isset($parameters['maxQuantity']) ? (int) $parameters['maxQuantity'] : null,
-            thresholdSetting: isset($parameters['thresholdSetting']) ? (string) $parameters['thresholdSetting'] : null,
+            thresholdSetting: isset($parameters['thresholdSetting'])
+                ? self::setting((string) $parameters['thresholdSetting'], 'thresholdSetting')
+                : null,
         );
+    }
+
+    private static function setting(string $value, string $parameterName): DiscountSetting
+    {
+        return DiscountSetting::tryFrom($value)
+            ?? throw new \InvalidArgumentException(sprintf('Neznámé nastavení "%s" v parametru %s. Povolené: %s', $value, $parameterName, implode(', ', array_column(DiscountSetting::cases(), 'value'))));
     }
 
     /**
@@ -116,9 +126,9 @@ final readonly class DiscountParameters
             'tag'                                                            => $this->tag,
             'day'                                                            => $this->day,
             $this->effect === DiscountEffect::PERCENT ? 'percent' : 'amount' => $this->amount,
-            'amountSetting'                                                  => $this->amountSetting,
+            'amountSetting'                                                  => $this->amountSetting?->value,
             'maxQuantity'                                                    => $this->maxQuantity,
-            'thresholdSetting'                                               => $this->thresholdSetting,
+            'thresholdSetting'                                               => $this->thresholdSetting?->value,
         ], static fn ($value): bool => $value !== null);
     }
 }

--- a/symfony/src/Discount/DiscountParameters.php
+++ b/symfony/src/Discount/DiscountParameters.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * The varying part of a discount rule, stored as JSON on discount_rule.parameters.
+ *
+ * The rules have genuinely different shapes — a cart-wide "cheapest t-shirt" has no
+ * product, a free night needs a day, a meal discount needs an amount in Kč — so as
+ * columns most would be NULL most of the time and every new shape would be a
+ * migration. Keeping them as JSON puts the shape where it can be validated properly,
+ * here in PHP, while the columns an admin filters by stay real columns.
+ *
+ * Nothing outside this class should read the raw array: fromArray() is the only way
+ * in, and it refuses anything the scope or effect does not describe.
+ */
+final readonly class DiscountParameters
+{
+    private function __construct(
+        public DiscountScope $scope,
+        public DiscountEffect $effect,
+        /**
+         * Fragment of kod_predmetu, for CODE_CONTAINS.
+         */
+        public ?string $codeFragment,
+        /**
+         * Product tag code, for the TAG scopes.
+         */
+        public ?string $tag,
+        /**
+         * Accommodation day 0–4 (Wed–Sun), for TAG_AND_DAY.
+         */
+        public ?int $day,
+        /**
+         * Kč for FIXED_AMOUNT, percent for PERCENT.
+         */
+        public ?float $amount,
+        /**
+         * How many purchases the rule covers; null means every match.
+         */
+        public ?int $maxQuantity,
+        /**
+         * System setting whose value the user's bonus must reach, e.g.
+         * MODRE_TRICKO_ZDARMA_OD. Resolved at calculation time so an admin changing
+         * the setting changes the rule, and the resolved number is recorded in the
+         * snapshot on the purchase.
+         */
+        public ?string $thresholdSetting,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @throws \InvalidArgumentException when the shape does not match the scope and effect
+     */
+    public static function fromArray(array $parameters): self
+    {
+        $scope = DiscountScope::tryFrom((string) ($parameters['scope'] ?? ''))
+            ?? throw new \InvalidArgumentException(sprintf('Neznámý rozsah slevy "%s"', (string) ($parameters['scope'] ?? '')));
+        $effect = DiscountEffect::tryFrom((string) ($parameters['effect'] ?? ''))
+            ?? throw new \InvalidArgumentException(sprintf('Neznámý efekt slevy "%s"', (string) ($parameters['effect'] ?? '')));
+
+        $required = [...$scope->requiredParameters(), ...$effect->requiredParameters()];
+        foreach ($required as $name) {
+            if (! isset($parameters[$name])) {
+                throw new \InvalidArgumentException(sprintf('Sleva typu %s/%s vyžaduje parametr "%s"', $scope->value, $effect->value, $name));
+            }
+        }
+
+        $known = [...$required, 'scope', 'effect', 'maxQuantity', 'thresholdSetting'];
+        $unknown = array_diff(array_keys($parameters), $known);
+        if ($unknown !== []) {
+            // A typo in a parameter name would otherwise be silently ignored and the
+            // rule would quietly behave as if the value had never been set.
+            throw new \InvalidArgumentException(sprintf('Neznámé parametry slevy: %s', implode(', ', $unknown)));
+        }
+
+        $day = isset($parameters['day']) ? (int) $parameters['day'] : null;
+        if ($day !== null && ($day < 0 || $day > 4)) {
+            throw new \InvalidArgumentException(sprintf('Den ubytování musí být 0–4, dostal %d', $day));
+        }
+
+        return new self(
+            scope: $scope,
+            effect: $effect,
+            codeFragment: isset($parameters['codeFragment']) ? (string) $parameters['codeFragment'] : null,
+            tag: isset($parameters['tag']) ? (string) $parameters['tag'] : null,
+            day: $day,
+            amount: isset($parameters['amount'])
+                ? (float) $parameters['amount']
+                : (isset($parameters['percent']) ? (float) $parameters['percent'] : null),
+            maxQuantity: isset($parameters['maxQuantity']) ? (int) $parameters['maxQuantity'] : null,
+            thresholdSetting: isset($parameters['thresholdSetting']) ? (string) $parameters['thresholdSetting'] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'scope'                                                          => $this->scope->value,
+            'effect'                                                         => $this->effect->value,
+            'codeFragment'                                                   => $this->codeFragment,
+            'tag'                                                            => $this->tag,
+            'day'                                                            => $this->day,
+            $this->effect === DiscountEffect::PERCENT ? 'percent' : 'amount' => $this->amount,
+            'maxQuantity'                                                    => $this->maxQuantity,
+            'thresholdSetting'                                               => $this->thresholdSetting,
+        ], static fn ($value): bool => $value !== null);
+    }
+}

--- a/symfony/src/Discount/DiscountParameters.php
+++ b/symfony/src/Discount/DiscountParameters.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Discount;
 
+use App\Enum\ProductTagCode;
+
 /**
  * The varying part of a discount rule, stored as JSON on discount_rule.parameters.
  *
@@ -26,9 +28,9 @@ final readonly class DiscountParameters
          */
         public ?string $codeFragment,
         /**
-         * Product tag code, for the TAG scopes.
+         * Product tag, for the TAG scopes.
          */
-        public ?string $tag,
+        public ?ProductTagCode $tag,
         /**
          * Accommodation day 0–4 (Wed–Sun), for TAG_AND_DAY.
          */
@@ -93,7 +95,10 @@ final readonly class DiscountParameters
             scope: $scope,
             effect: $effect,
             codeFragment: isset($parameters['codeFragment']) ? (string) $parameters['codeFragment'] : null,
-            tag: isset($parameters['tag']) ? (string) $parameters['tag'] : null,
+            tag: isset($parameters['tag'])
+                ? (ProductTagCode::tryFrom((string) $parameters['tag'])
+                    ?? throw new \InvalidArgumentException(sprintf('Neznámý tag "%s". Povolené: %s', (string) $parameters['tag'], implode(', ', array_column(ProductTagCode::cases(), 'value')))))
+                : null,
             day: $day,
             amount: isset($parameters['amount'])
                 ? (float) $parameters['amount']
@@ -123,7 +128,7 @@ final readonly class DiscountParameters
             'scope'                                                          => $this->scope->value,
             'effect'                                                         => $this->effect->value,
             'codeFragment'                                                   => $this->codeFragment,
-            'tag'                                                            => $this->tag,
+            'tag'                                                            => $this->tag?->value,
             'day'                                                            => $this->day,
             $this->effect === DiscountEffect::PERCENT ? 'percent' : 'amount' => $this->amount,
             'amountSetting'                                                  => $this->amountSetting?->value,

--- a/symfony/src/Discount/DiscountRule.php
+++ b/symfony/src/Discount/DiscountRule.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * One row of discount_rule, with its JSON already parsed.
+ *
+ * Deliberately not a Doctrine entity: the calculator is pure, so it can be tested
+ * without a database and called from legacy Cenik, which has no entity manager.
+ */
+final readonly class DiscountRule
+{
+    public function __construct(
+        public string $code,
+        public string $name,
+        /**
+         * id_prava the buyer must hold — see Pravo.
+         */
+        public int $requiredRight,
+        public DiscountParameters $parameters,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $row as stored in discount_rule
+     */
+    public static function fromRow(array $row): self
+    {
+        $parameters = json_decode((string) $row['parameters'], true, 512, JSON_THROW_ON_ERROR);
+        if (! is_array($parameters)) {
+            throw new \InvalidArgumentException(sprintf('Pravidlo "%s" nemá parametry jako objekt', (string) $row['code']));
+        }
+
+        return new self(
+            code: (string) $row['code'],
+            name: (string) $row['name'],
+            requiredRight: (int) $row['required_right'],
+            parameters: DiscountParameters::fromArray($parameters),
+        );
+    }
+}

--- a/symfony/src/Discount/DiscountRuleLoader.php
+++ b/symfony/src/Discount/DiscountRuleLoader.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * Reads the rules, the buyer's rights and the settings a rule refers to.
+ *
+ * Plain SQL rather than Doctrine, because legacy Cenik has no entity manager and this
+ * has to serve both sides. Once the storefront no longer goes through Cenik this can
+ * become a repository like everything else.
+ */
+final class DiscountRuleLoader
+{
+    /**
+     * @var \Closure(string, array<int, mixed>): array<int, array<string, mixed>>
+     */
+    private readonly \Closure $fetchAll;
+
+    /**
+     * @param callable(string, array<int, mixed>): array<int, array<string, mixed>> $fetchAll
+     *                                                                                        usually dbFetchAll; injected so the loader can be tested without a database
+     */
+    public function __construct(callable $fetchAll)
+    {
+        $this->fetchAll = $fetchAll(...);
+    }
+
+    /**
+     * @return DiscountRule[]
+     */
+    public function rulesForYear(int $year): array
+    {
+        $rows = ($this->fetchAll)(
+            'SELECT code, name, required_right, parameters
+             FROM discount_rule
+             WHERE year = $0 AND active = 1
+             ORDER BY code',
+            [
+                0 => $year,
+            ],
+        );
+
+        return array_map(
+            static fn (array $row): DiscountRule => DiscountRule::fromRow($row),
+            $rows,
+        );
+    }
+
+    /**
+     * @return int[] id_prava the user holds
+     */
+    public function rightsOfUser(int $userId): array
+    {
+        // uzivatele_role, not the platne_role_uzivatelu view: that view is defined
+        // against the `gamecon` database by name, so under the test database it would
+        // report the developer's roles instead of the fixtures'.
+        $rows = ($this->fetchAll)(
+            'SELECT DISTINCT prava_role.id_prava
+             FROM uzivatele_role
+             JOIN prava_role ON prava_role.id_role = uzivatele_role.id_role
+             WHERE uzivatele_role.id_uzivatele = $0',
+            [
+                0 => $userId,
+            ],
+        );
+
+        return array_map(static fn (array $row): int => (int) $row['id_prava'], $rows);
+    }
+}

--- a/symfony/src/Discount/DiscountScope.php
+++ b/symfony/src/Discount/DiscountScope.php
@@ -30,8 +30,7 @@ enum DiscountScope: string
     }
 
     /**
-     * Names of the parameters this scope requires, so validation and the admin form
-     * can both be driven from one place.
+     * Parameters this scope cannot do without, for validation.
      *
      * Each entry is a set of alternatives, of which at least one must be present.
      *
@@ -43,6 +42,27 @@ enum DiscountScope: string
             self::CODE_CONTAINS => [['codeFragment']],
             self::TAG, self::TAG_CHEAPEST => [['tag']],
             self::TAG_AND_DAY => [['tag'], ['day']],
+        };
+    }
+
+    /**
+     * Of those, the ones an admin may change.
+     *
+     * Deliberately narrower than requiredParameters(): the numbers are policy an admin
+     * tunes, the rest is what the rule *is*. Switching a rule's tag from jidlo to
+     * tricko does not adjust "free meals", it turns it into free shirts while the name
+     * and description still say meals — a different rule wearing the old one's label.
+     * Same for the scope and effect themselves.
+     *
+     * The admin form shows everything, but only these as inputs.
+     *
+     * @return string[]
+     */
+    public function editableParameters(): array
+    {
+        return match ($this) {
+            self::CODE_CONTAINS, self::TAG, self::TAG_CHEAPEST => [],
+            self::TAG_AND_DAY => ['day'],
         };
     }
 

--- a/symfony/src/Discount/DiscountScope.php
+++ b/symfony/src/Discount/DiscountScope.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+/**
+ * Which purchases a rule can apply to.
+ *
+ * The four shapes come from the rules that exist, not from a guess at what might be
+ * useful: dice and badges are matched by a fragment of their code, t-shirts by their
+ * tag, a free night by tag plus the day, and TAG_CHEAPEST covers the bonus t-shirt,
+ * which applies once to whichever matching item is cheapest rather than to each.
+ */
+enum DiscountScope: string
+{
+    case CODE_CONTAINS = 'code_contains';
+    case TAG = 'tag';
+    case TAG_AND_DAY = 'tag_and_day';
+    case TAG_CHEAPEST = 'tag_cheapest';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CODE_CONTAINS => 'Předměty, jejichž kód obsahuje',
+            self::TAG           => 'Předměty s tagem',
+            self::TAG_AND_DAY   => 'Předměty s tagem, jen pro daný den',
+            self::TAG_CHEAPEST  => 'Nejlevnější předmět s tagem v košíku',
+        };
+    }
+
+    /**
+     * Names of the parameters this scope requires, so validation and the admin form
+     * can both be driven from one place.
+     *
+     * @return string[]
+     */
+    public function requiredParameters(): array
+    {
+        return match ($this) {
+            self::CODE_CONTAINS => ['codeFragment'],
+            self::TAG, self::TAG_CHEAPEST => ['tag'],
+            self::TAG_AND_DAY => ['tag', 'day'],
+        };
+    }
+
+    /**
+     * Does the entitlement get used up, or does it apply to every matching purchase?
+     *
+     * A free night applies to every Wednesday night bought; a free dice applies once.
+     * Getting this backwards is the difference between one free bed and five.
+     */
+    public function isConsumable(): bool
+    {
+        return $this !== self::TAG_AND_DAY;
+    }
+}

--- a/symfony/src/Discount/DiscountScope.php
+++ b/symfony/src/Discount/DiscountScope.php
@@ -33,14 +33,16 @@ enum DiscountScope: string
      * Names of the parameters this scope requires, so validation and the admin form
      * can both be driven from one place.
      *
-     * @return string[]
+     * Each entry is a set of alternatives, of which at least one must be present.
+     *
+     * @return string[][]
      */
     public function requiredParameters(): array
     {
         return match ($this) {
-            self::CODE_CONTAINS => ['codeFragment'],
-            self::TAG, self::TAG_CHEAPEST => ['tag'],
-            self::TAG_AND_DAY => ['tag', 'day'],
+            self::CODE_CONTAINS => [['codeFragment']],
+            self::TAG, self::TAG_CHEAPEST => [['tag']],
+            self::TAG_AND_DAY => [['tag'], ['day']],
         };
     }
 

--- a/symfony/src/Discount/DiscountSetting.php
+++ b/symfony/src/Discount/DiscountSetting.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+use Gamecon\SystemoveNastaveni\SystemoveNastaveniKlice;
+
+/**
+ * The system settings a discount rule may read a number from.
+ *
+ * Rules keep their numbers in systemove_nastaveni rather than copying them, so that
+ * changing a setting changes the rule instead of moving the two apart. That means the
+ * stored JSON has to name the setting somehow, and a bare setting key would be a
+ * string nothing checks: rename the constant and the rule silently stops resolving.
+ *
+ * So the JSON holds one of these case names instead, and this enum is the only place
+ * that knows which setting each one means. A rename of a settings key is then a change
+ * here, where the compiler can see it, and the stored data does not move at all.
+ *
+ * The case names are camelCase on purpose — deliberately unlike the SCREAMING_CASE
+ * setting keys, so nobody reads them as needing to match.
+ */
+enum DiscountSetting: string
+{
+    case FreeShirtBonusThreshold = 'freeShirtBonusThreshold';
+    case OrganizerMealDiscount = 'organizerMealDiscount';
+
+    /**
+     * @return SystemoveNastaveniKlice::* the settings key this stands for
+     */
+    public function settingKey(): string
+    {
+        return match ($this) {
+            self::FreeShirtBonusThreshold => SystemoveNastaveniKlice::MODRE_TRICKO_ZDARMA_OD,
+            self::OrganizerMealDiscount   => SystemoveNastaveniKlice::SLEVA_ORGU_NA_JIDLO_CASTKA,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::FreeShirtBonusThreshold => 'Bonus, od kterého je tričko zdarma',
+            self::OrganizerMealDiscount   => 'Sleva orga na jídlo',
+        };
+    }
+}

--- a/symfony/src/Discount/DiscountableItem.php
+++ b/symfony/src/Discount/DiscountableItem.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Discount;
+
+use App\Enum\ProductTagCode;
+
+/**
+ * One thing in the cart, in the only terms the discount rules care about.
+ *
+ * Not a Product or an OrderItem, so the calculator works the same whether it is called
+ * from the new cart or from legacy Cenik, which has an array row and no entities.
+ */
+final readonly class DiscountableItem
+{
+    public function __construct(
+        /** Whatever the caller uses to recognise this item again in the results. */
+        public int|string $key,
+        public string $productCode,
+        public float $price,
+        /**
+         * @var ProductTagCode[]
+         */
+        public array $tags,
+        /**
+         * Accommodation day 0–4, null for everything else.
+         */
+        public ?int $accommodationDay = null,
+    ) {
+    }
+
+    public function hasTag(ProductTagCode $tag): bool
+    {
+        return in_array($tag, $this->tags, true);
+    }
+
+    public function matches(DiscountParameters $parameters): bool
+    {
+        return match ($parameters->scope) {
+            DiscountScope::CODE_CONTAINS => $parameters->codeFragment !== null
+                && str_contains(mb_strtolower($this->productCode), mb_strtolower($parameters->codeFragment)),
+            DiscountScope::TAG, DiscountScope::TAG_CHEAPEST => $parameters->tag !== null
+                && $this->hasTag($parameters->tag),
+            DiscountScope::TAG_AND_DAY => $parameters->tag !== null
+                && $this->hasTag($parameters->tag)
+                && $this->accommodationDay === $parameters->day,
+        };
+    }
+}

--- a/symfony/src/Enum/ProductTagCode.php
+++ b/symfony/src/Enum/ProductTagCode.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Codes in product_tag.code.
+ *
+ * These replaced the old shop_predmety.typ column, and until now lived as string
+ * literals spread across repositories, services and validators. A typo in one of those
+ * — 'tricka' for 'tricko', or a Czech diacritic — matches nothing and fails silently:
+ * no error, no failing test, the feature simply never applies.
+ *
+ * Seven of them are categories, one per product, mirroring the old typ 1–7. MIKINA is
+ * different: it is a sub-tag carried in addition to PREDMET, replacing the old
+ * podtyp='mikina'.
+ */
+enum ProductTagCode: string
+{
+    case PREDMET = 'predmet';
+    case UBYTOVANI = 'ubytovani';
+    case TRICKO = 'tricko';
+    case JIDLO = 'jidlo';
+    case VSTUPNE = 'vstupne';
+    case PARCON = 'parcon';
+    case PROPLACENI_BONUSU = 'proplaceni-bonusu';
+
+    case MIKINA = 'mikina';
+
+    /**
+     * The category tags — exactly one of these per product, the successor of typ 1–7.
+     *
+     * @return self[]
+     */
+    public static function categories(): array
+    {
+        return [
+            self::PREDMET,
+            self::UBYTOVANI,
+            self::TRICKO,
+            self::JIDLO,
+            self::VSTUPNE,
+            self::PARCON,
+            self::PROPLACENI_BONUSU,
+        ];
+    }
+
+    public function isCategory(): bool
+    {
+        return in_array($this, self::categories(), true);
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PREDMET           => 'Předmět',
+            self::UBYTOVANI         => 'Ubytování',
+            self::TRICKO            => 'Tričko',
+            self::JIDLO             => 'Jídlo',
+            self::VSTUPNE           => 'Vstupné',
+            self::PARCON            => 'ParCon mini-akce',
+            self::PROPLACENI_BONUSU => 'Výplata bonusu (interní)',
+            self::MIKINA            => 'Mikina',
+        };
+    }
+}

--- a/symfony/src/Enum/ProductTagCode.php
+++ b/symfony/src/Enum/ProductTagCode.php
@@ -51,6 +51,25 @@ enum ProductTagCode: string
         return in_array($this, self::categories(), true);
     }
 
+    /**
+     * The legacy shop_predmety.typ this category replaced, as the compatibility view
+     * still reports it. Legacy rows carry the number, not the tag, so anything reading
+     * them has to translate — see TypPredmetu.
+     */
+    public static function fromLegacyTyp(int $typ): ?self
+    {
+        return match ($typ) {
+            1       => self::PREDMET,
+            2       => self::UBYTOVANI,
+            3       => self::TRICKO,
+            4       => self::JIDLO,
+            5       => self::VSTUPNE,
+            6       => self::PARCON,
+            7       => self::PROPLACENI_BONUSU,
+            default => null,
+        };
+    }
+
     public function label(): string
     {
         return match ($this) {

--- a/symfony/tests/Discount/DiscountCalculationTest.php
+++ b/symfony/tests/Discount/DiscountCalculationTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Discount;
+
+use App\Discount\DiscountableItem;
+use App\Discount\DiscountCalculation;
+use App\Discount\DiscountParameters;
+use App\Discount\DiscountRule;
+use App\Enum\ProductTagCode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mirrors CenikCharakterizacniTest case for case, with the same prices and the same
+ * expected outcomes. The point is not that this class works — it is that it produces
+ * the numbers Cenik produces, since it is going to replace it.
+ */
+class DiscountCalculationTest extends TestCase
+{
+    private const RIGHT_PLACKA = 1002;
+    private const RIGHT_KOSTKA = 1003;
+    private const RIGHT_JIDLO_SLEVA = 1004;
+    private const RIGHT_JIDLO_ZDARMA = 1005;
+    private const RIGHT_UBYTOVANI = 1008;
+    private const RIGHT_TRICKO_BONUS = 1012;
+    private const RIGHT_NOC_STREDA = 1015;
+    private const RIGHT_DVE_TRICKA = 1020;
+    private const RIGHT_JEDNO_TRICKO = 1035;
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function rule(string $code, int $right, array $parameters): DiscountRule
+    {
+        return new DiscountRule($code, $code, $right, DiscountParameters::fromArray($parameters));
+    }
+
+    /**
+     * The rules as seeded, so the tests exercise what production will run.
+     *
+     * @return DiscountRule[]
+     */
+    private function seededRules(): array
+    {
+        return [
+            $this->rule('kostka_zdarma', self::RIGHT_KOSTKA, [
+                'scope'        => 'code_contains',
+                'effect'       => 'free',
+                'codeFragment' => 'kostka',
+                'maxQuantity'  => 1,
+            ]),
+            $this->rule('placka_zdarma', self::RIGHT_PLACKA, [
+                'scope'        => 'code_contains',
+                'effect'       => 'free',
+                'codeFragment' => 'placka',
+                'maxQuantity'  => 1,
+            ]),
+            $this->rule('tricko_za_bonus', self::RIGHT_TRICKO_BONUS, [
+                'scope'            => 'tag_cheapest',
+                'effect'           => 'free',
+                'tag'              => 'tricko',
+                'maxQuantity'      => 1,
+                'thresholdSetting' => 'freeShirtBonusThreshold',
+            ]),
+            $this->rule('jedno_tricko_zdarma', self::RIGHT_JEDNO_TRICKO, [
+                'scope'       => 'tag',
+                'effect'      => 'free',
+                'tag'         => 'tricko',
+                'maxQuantity' => 1,
+            ]),
+            $this->rule('dve_tricka_zdarma', self::RIGHT_DVE_TRICKA, [
+                'scope'       => 'tag',
+                'effect'      => 'free',
+                'tag'         => 'tricko',
+                'maxQuantity' => 2,
+            ]),
+            $this->rule('ubytovani_zdarma', self::RIGHT_UBYTOVANI, [
+                'scope'  => 'tag',
+                'effect' => 'free',
+                'tag'    => 'ubytovani',
+            ]),
+            $this->rule('jidlo_zdarma', self::RIGHT_JIDLO_ZDARMA, [
+                'scope'  => 'tag',
+                'effect' => 'free',
+                'tag'    => 'jidlo',
+            ]),
+            $this->rule('jidlo_se_slevou', self::RIGHT_JIDLO_SLEVA, [
+                'scope'         => 'tag',
+                'effect'        => 'fixed_amount',
+                'tag'           => 'jidlo',
+                'amountSetting' => 'organizerMealDiscount',
+            ]),
+            $this->rule('ubytovani_stredecni_noc_zdarma', self::RIGHT_NOC_STREDA, [
+                'scope'  => 'tag_and_day',
+                'effect' => 'free',
+                'tag'    => 'ubytovani',
+                'day'    => 0,
+            ]),
+        ];
+    }
+
+    /**
+     * @param int[] $rights
+     */
+    private function calculation(array $rights, float $earnedBonus = 0.0): DiscountCalculation
+    {
+        return new DiscountCalculation(
+            $this->seededRules(),
+            $rights,
+            [
+                'organizerMealDiscount'   => 25.0,
+                'freeShirtBonusThreshold' => 1320.0,
+            ],
+            $earnedBonus,
+        );
+    }
+
+    private function kostka(int|string $key = 'kostka'): DiscountableItem
+    {
+        return new DiscountableItem($key, 'kostka_test_2026', 100.0, [ProductTagCode::PREDMET]);
+    }
+
+    private function placka(): DiscountableItem
+    {
+        return new DiscountableItem('placka', 'placka_test_2026', 50.0, [ProductTagCode::PREDMET]);
+    }
+
+    private function tricko(int|string $key, float $price): DiscountableItem
+    {
+        return new DiscountableItem($key, 'tricko_test_2026', $price, [ProductTagCode::TRICKO]);
+    }
+
+    private function ubytovani(int|string $key, int $day): DiscountableItem
+    {
+        return new DiscountableItem($key, 'ubytovani_test_2026', 400.0, [ProductTagCode::UBYTOVANI], $day);
+    }
+
+    private function jidlo(): DiscountableItem
+    {
+        return new DiscountableItem('jidlo', 'obed_test_2026', 150.0, [ProductTagCode::JIDLO], 1);
+    }
+
+    public function testWithoutRightsNothingIsDiscounted(): void
+    {
+        $applied = $this->calculation([])->apply([
+            $this->kostka(), $this->placka(), $this->tricko('t', 300.0), $this->jidlo(),
+        ]);
+
+        $this->assertSame([], $applied);
+    }
+
+    public function testFreeDiceAppliesOnlyToTheFirstDice(): void
+    {
+        $applied = $this->calculation([self::RIGHT_KOSTKA])->apply([
+            $this->kostka('first'), $this->kostka('second'), $this->placka(),
+        ]);
+
+        $this->assertSame(0.0, $applied['first']->finalPrice);
+        $this->assertArrayNotHasKey('second', $applied, 'Druhá kostka už za plnou cenu');
+        $this->assertArrayNotHasKey('placka', $applied, 'Placka má vlastní právo');
+    }
+
+    public function testFreeBadgeDoesNotConsumeTheDiceEntitlement(): void
+    {
+        $applied = $this->calculation([self::RIGHT_PLACKA])->apply([
+            $this->kostka(), $this->placka(),
+        ]);
+
+        $this->assertSame(0.0, $applied['placka']->finalPrice);
+        $this->assertArrayNotHasKey('kostka', $applied);
+    }
+
+    public function testOneFreeShirtTakesTheCheapest(): void
+    {
+        // Cenik prices from the cheapest up, so a single entitlement lands on the
+        // cheapest shirt regardless of the order they were added.
+        $applied = $this->calculation([self::RIGHT_JEDNO_TRICKO])->apply([
+            $this->tricko('drahe', 500.0), $this->tricko('levne', 300.0),
+        ]);
+
+        $this->assertSame(0.0, $applied['levne']->finalPrice);
+        $this->assertArrayNotHasKey('drahe', $applied);
+    }
+
+    public function testTwoFreeShirtsCoverTwoOfThree(): void
+    {
+        $applied = $this->calculation([self::RIGHT_DVE_TRICKA])->apply([
+            $this->tricko('a', 300.0), $this->tricko('b', 400.0), $this->tricko('c', 500.0),
+        ]);
+
+        $this->assertSame(0.0, $applied['a']->finalPrice);
+        $this->assertSame(0.0, $applied['b']->finalPrice);
+        $this->assertArrayNotHasKey('c', $applied);
+    }
+
+    public function testBonusShirtNeedsTheThreshold(): void
+    {
+        $belowThreshold = $this->calculation([self::RIGHT_TRICKO_BONUS], 1000.0)->apply([
+            $this->tricko('t', 300.0),
+        ]);
+        $this->assertSame([], $belowThreshold, 'Pod prahem bonusu se sleva neuplatní');
+
+        $atThreshold = $this->calculation([self::RIGHT_TRICKO_BONUS], 1320.0)->apply([
+            $this->tricko('t', 300.0),
+        ]);
+        $this->assertSame(0.0, $atThreshold['t']->finalPrice);
+    }
+
+    public function testFreeAccommodationCoversEveryNight(): void
+    {
+        $applied = $this->calculation([self::RIGHT_UBYTOVANI])->apply([
+            $this->ubytovani('st', 0), $this->ubytovani('ct', 1),
+        ]);
+
+        $this->assertSame(0.0, $applied['st']->finalPrice);
+        $this->assertSame(0.0, $applied['ct']->finalPrice);
+    }
+
+    public function testFreeNightAppliesToThatNightOnlyAndIsNotConsumed(): void
+    {
+        $applied = $this->calculation([self::RIGHT_NOC_STREDA])->apply([
+            $this->ubytovani('st1', 0), $this->ubytovani('st2', 0), $this->ubytovani('ct', 1),
+        ]);
+
+        // Not consumed: unlike a dice, the entitlement covers every Wednesday night.
+        $this->assertSame(0.0, $applied['st1']->finalPrice);
+        $this->assertSame(0.0, $applied['st2']->finalPrice);
+        $this->assertArrayNotHasKey('ct', $applied, 'Čtvrteční noc se platí');
+    }
+
+    public function testMealDiscountSubtractsAFixedAmount(): void
+    {
+        $applied = $this->calculation([self::RIGHT_JIDLO_SLEVA])->apply([$this->jidlo()]);
+
+        // The only rule that is not 100 % off.
+        $this->assertSame(125.0, $applied['jidlo']->finalPrice);
+        $this->assertSame(25.0, $applied['jidlo']->discountAmount);
+    }
+
+    public function testMealDiscountNeverGoesBelowZero(): void
+    {
+        $cheapMeal = new DiscountableItem('m', 'obed_test_2026', 20.0, [ProductTagCode::JIDLO], 1);
+        $applied = $this->calculation([self::RIGHT_JIDLO_SLEVA])->apply([$cheapMeal]);
+
+        $this->assertSame(0.0, $applied['m']->finalPrice);
+        $this->assertSame(20.0, $applied['m']->discountAmount, 'Sleva se ořízne na cenu položky');
+    }
+
+    public function testRightsForOneKindDoNotDiscountAnother(): void
+    {
+        $applied = $this->calculation([self::RIGHT_JIDLO_ZDARMA, self::RIGHT_UBYTOVANI])->apply([
+            $this->kostka(), $this->tricko('t', 300.0),
+        ]);
+
+        $this->assertSame([], $applied);
+    }
+
+    public function testSnapshotRecordsTheRuleAsApplied(): void
+    {
+        $applied = $this->calculation([self::RIGHT_TRICKO_BONUS], 1500.0)->apply([
+            $this->tricko('t', 300.0),
+        ]);
+
+        $snapshot = $applied['t']->snapshot;
+        $this->assertSame('tricko_za_bonus', $snapshot['ruleCode']);
+        $this->assertSame(self::RIGHT_TRICKO_BONUS, $snapshot['requiredRight']);
+        $this->assertSame(300.0, $snapshot['originalPrice']);
+        $this->assertSame(300.0, $snapshot['discountAmount']);
+
+        // The threshold as it resolved at that moment, so changing the setting later
+        // cannot rewrite what this purchase was entitled to.
+        $this->assertSame(1320.0, $snapshot['resolved']['threshold']);
+        $this->assertSame(1500.0, $snapshot['resolved']['earnedBonus']);
+    }
+
+    public function testMissingSettingIsRefusedRatherThanTreatedAsZero(): void
+    {
+        $calculation = new DiscountCalculation(
+            $this->seededRules(),
+            [self::RIGHT_JIDLO_SLEVA],
+            [], // caller forgot to resolve the settings
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Chybí hodnota nastavení "organizerMealDiscount"');
+
+        $calculation->apply([$this->jidlo()]);
+    }
+
+    public function testOnlyOneRuleAppliesPerItem(): void
+    {
+        // Holding both shirt rights must not stack into a double discount on one shirt.
+        $applied = $this->calculation([self::RIGHT_JEDNO_TRICKO, self::RIGHT_DVE_TRICKA])->apply([
+            $this->tricko('t', 300.0),
+        ]);
+
+        $this->assertCount(1, $applied);
+        $this->assertSame(300.0, $applied['t']->discountAmount);
+    }
+}

--- a/symfony/tests/Discount/DiscountParametersTest.php
+++ b/symfony/tests/Discount/DiscountParametersTest.php
@@ -8,6 +8,7 @@ use App\Discount\DiscountEffect;
 use App\Discount\DiscountParameters;
 use App\Discount\DiscountScope;
 use App\Discount\DiscountSetting;
+use App\Enum\ProductTagCode;
 use PHPUnit\Framework\TestCase;
 
 class DiscountParametersTest extends TestCase
@@ -36,6 +37,7 @@ class DiscountParametersTest extends TestCase
             'amount' => 30,
         ]);
 
+        $this->assertSame(ProductTagCode::JIDLO, $parameters->tag);
         $this->assertSame(30.0, $parameters->amount);
         $this->assertNull($parameters->maxQuantity, 'Sleva na jídlo platí na každé jídlo');
     }
@@ -150,6 +152,34 @@ class DiscountParametersTest extends TestCase
             'tag'           => 'jidlo',
             'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
         ]);
+    }
+
+    public function testUnknownTagIsRejected(): void
+    {
+        // A typo matches no product, so the rule would validate, store, and then
+        // silently never apply — free meals that quietly stop being free.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Neznámý tag "jidla"');
+
+        DiscountParameters::fromArray([
+            'scope'  => 'tag',
+            'effect' => 'free',
+            'tag'    => 'jidla',
+        ]);
+    }
+
+    public function testTagSurvivesTheRoundTripAsItsCode(): void
+    {
+        // The JSON stores the tag code, not the case name, because that is what
+        // product_tag.code holds and what any SQL against it has to match.
+        $parameters = DiscountParameters::fromArray([
+            'scope'  => 'tag',
+            'effect' => 'free',
+            'tag'    => 'ubytovani',
+        ]);
+
+        $this->assertSame(ProductTagCode::UBYTOVANI, $parameters->tag);
+        $this->assertSame('ubytovani', $parameters->toArray()['tag']);
     }
 
     public function testEffectNeverDiscountsMoreThanThePrice(): void

--- a/symfony/tests/Discount/DiscountParametersTest.php
+++ b/symfony/tests/Discount/DiscountParametersTest.php
@@ -108,6 +108,33 @@ class DiscountParametersTest extends TestCase
         $this->assertSame($original, DiscountParameters::fromArray($original)->toArray());
     }
 
+    public function testFixedAmountAcceptsASettingInsteadOfANumber(): void
+    {
+        // The meal discount follows SLEVA_ORGU_NA_JIDLO_CASTKA rather than freezing
+        // today's value, so an admin changing the setting changes the rule.
+        $parameters = DiscountParameters::fromArray([
+            'scope'         => 'tag',
+            'effect'        => 'fixed_amount',
+            'tag'           => 'jidlo',
+            'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
+        ]);
+
+        $this->assertSame('SLEVA_ORGU_NA_JIDLO_CASTKA', $parameters->amountSetting);
+        $this->assertNull($parameters->amount);
+    }
+
+    public function testFixedAmountNeedsEitherAnAmountOrASetting(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('vyžaduje parametr "amount" nebo "amountSetting"');
+
+        DiscountParameters::fromArray([
+            'scope'  => 'tag',
+            'effect' => 'fixed_amount',
+            'tag'    => 'jidlo',
+        ]);
+    }
+
     public function testEffectNeverDiscountsMoreThanThePrice(): void
     {
         // A 30 Kč discount on a 20 Kč item must not produce a negative price.

--- a/symfony/tests/Discount/DiscountParametersTest.php
+++ b/symfony/tests/Discount/DiscountParametersTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Discount;
+
+use App\Discount\DiscountEffect;
+use App\Discount\DiscountParameters;
+use App\Discount\DiscountScope;
+use PHPUnit\Framework\TestCase;
+
+class DiscountParametersTest extends TestCase
+{
+    public function testFreeDiceRule(): void
+    {
+        $parameters = DiscountParameters::fromArray([
+            'scope'        => 'code_contains',
+            'effect'       => 'free',
+            'codeFragment' => 'kostka',
+            'maxQuantity'  => 1,
+        ]);
+
+        $this->assertSame(DiscountScope::CODE_CONTAINS, $parameters->scope);
+        $this->assertSame(DiscountEffect::FREE, $parameters->effect);
+        $this->assertSame('kostka', $parameters->codeFragment);
+        $this->assertSame(1, $parameters->maxQuantity);
+    }
+
+    public function testMealDiscountKeepsItsAmount(): void
+    {
+        $parameters = DiscountParameters::fromArray([
+            'scope'  => 'tag',
+            'effect' => 'fixed_amount',
+            'tag'    => 'jidlo',
+            'amount' => 30,
+        ]);
+
+        $this->assertSame(30.0, $parameters->amount);
+        $this->assertNull($parameters->maxQuantity, 'Sleva na jídlo platí na každé jídlo');
+    }
+
+    public function testAccommodationNightCarriesTheDay(): void
+    {
+        $parameters = DiscountParameters::fromArray([
+            'scope'  => 'tag_and_day',
+            'effect' => 'free',
+            'tag'    => 'ubytovani',
+            'day'    => 0,
+        ]);
+
+        $this->assertSame(0, $parameters->day);
+        $this->assertFalse(
+            $parameters->scope->isConsumable(),
+            'Nárok na noc se nevyčerpá — platí na každou takovou noc',
+        );
+    }
+
+    public function testMissingRequiredParameterIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('vyžaduje parametr "amount"');
+
+        DiscountParameters::fromArray([
+            'scope'  => 'tag',
+            'effect' => 'fixed_amount',
+            'tag'    => 'jidlo',
+        ]);
+    }
+
+    public function testUnknownParameterIsRejected(): void
+    {
+        // A typo would otherwise be ignored and the rule would behave as if the
+        // value had never been set — the failure mode JSON storage invites.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Neznámé parametry slevy: maxQantity');
+
+        DiscountParameters::fromArray([
+            'scope'      => 'tag',
+            'effect'     => 'free',
+            'tag'        => 'tricko',
+            'maxQantity' => 1,
+        ]);
+    }
+
+    public function testDayOutsideTheFestivalIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Den ubytování musí být 0–4');
+
+        DiscountParameters::fromArray([
+            'scope'  => 'tag_and_day',
+            'effect' => 'free',
+            'tag'    => 'ubytovani',
+            'day'    => 7,
+        ]);
+    }
+
+    public function testRoundTripThroughArray(): void
+    {
+        $original = [
+            'scope'            => 'tag_cheapest',
+            'effect'           => 'free',
+            'tag'              => 'tricko',
+            'maxQuantity'      => 1,
+            'thresholdSetting' => 'MODRE_TRICKO_ZDARMA_OD',
+        ];
+
+        $this->assertSame($original, DiscountParameters::fromArray($original)->toArray());
+    }
+
+    public function testEffectNeverDiscountsMoreThanThePrice(): void
+    {
+        // A 30 Kč discount on a 20 Kč item must not produce a negative price.
+        $this->assertSame(20.0, DiscountEffect::FIXED_AMOUNT->discountFrom(20.0, 30.0));
+        $this->assertSame(100.0, DiscountEffect::FREE->discountFrom(100.0, 0.0));
+        $this->assertSame(25.0, DiscountEffect::PERCENT->discountFrom(100.0, 25.0));
+    }
+}

--- a/symfony/tests/Discount/DiscountParametersTest.php
+++ b/symfony/tests/Discount/DiscountParametersTest.php
@@ -182,6 +182,45 @@ class DiscountParametersTest extends TestCase
         $this->assertSame('ubytovani', $parameters->toArray()['tag']);
     }
 
+    public function testStructuralParametersAreNeverEditable(): void
+    {
+        // Changing a rule's tag, scope or effect does not tune it — it turns "free
+        // meals" into free shirts while the name and description still say meals.
+        // Those are what the rule is, not knobs on it.
+        $structural = ['scope', 'effect', 'tag', 'codeFragment', 'amountSetting', 'thresholdSetting'];
+
+        foreach (DiscountScope::cases() as $scope) {
+            foreach (DiscountEffect::cases() as $effect) {
+                $editable = [...$scope->editableParameters(), ...$effect->editableParameters()];
+
+                $this->assertSame(
+                    [],
+                    array_values(array_intersect($editable, $structural)),
+                    sprintf('%s/%s nabízí k editaci strukturální parametr', $scope->value, $effect->value),
+                );
+            }
+        }
+    }
+
+    public function testEditableParametersAreASubsetOfWhatTheRuleHas(): void
+    {
+        // The form must not offer a field the rule does not carry.
+        $parameters = DiscountParameters::fromArray([
+            'scope'       => 'tag_and_day',
+            'effect'      => 'free',
+            'tag'         => 'ubytovani',
+            'day'         => 0,
+            'maxQuantity' => 1,
+        ]);
+
+        $this->assertSame(['day', 'maxQuantity'], $parameters->editableParameters());
+
+        $stored = array_keys($parameters->toArray());
+        foreach ($parameters->editableParameters() as $name) {
+            $this->assertContains($name, $stored, sprintf('Editovatelný parametr %s v pravidle není', $name));
+        }
+    }
+
     public function testEffectNeverDiscountsMoreThanThePrice(): void
     {
         // A 30 Kč discount on a 20 Kč item must not produce a negative price.

--- a/symfony/tests/Discount/DiscountParametersTest.php
+++ b/symfony/tests/Discount/DiscountParametersTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Discount;
 use App\Discount\DiscountEffect;
 use App\Discount\DiscountParameters;
 use App\Discount\DiscountScope;
+use App\Discount\DiscountSetting;
 use PHPUnit\Framework\TestCase;
 
 class DiscountParametersTest extends TestCase
@@ -102,7 +103,7 @@ class DiscountParametersTest extends TestCase
             'effect'           => 'free',
             'tag'              => 'tricko',
             'maxQuantity'      => 1,
-            'thresholdSetting' => 'MODRE_TRICKO_ZDARMA_OD',
+            'thresholdSetting' => 'freeShirtBonusThreshold',
         ];
 
         $this->assertSame($original, DiscountParameters::fromArray($original)->toArray());
@@ -116,10 +117,10 @@ class DiscountParametersTest extends TestCase
             'scope'         => 'tag',
             'effect'        => 'fixed_amount',
             'tag'           => 'jidlo',
-            'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
+            'amountSetting' => 'organizerMealDiscount',
         ]);
 
-        $this->assertSame('SLEVA_ORGU_NA_JIDLO_CASTKA', $parameters->amountSetting);
+        $this->assertSame(DiscountSetting::OrganizerMealDiscount, $parameters->amountSetting);
         $this->assertNull($parameters->amount);
     }
 
@@ -132,6 +133,22 @@ class DiscountParametersTest extends TestCase
             'scope'  => 'tag',
             'effect' => 'fixed_amount',
             'tag'    => 'jidlo',
+        ]);
+    }
+
+    public function testUnknownSettingNameIsRejected(): void
+    {
+        // A settings key written straight into the JSON is exactly what the enum
+        // exists to prevent — it would resolve to nothing and the rule would quietly
+        // stop discounting.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Neznámé nastavení "SLEVA_ORGU_NA_JIDLO_CASTKA"');
+
+        DiscountParameters::fromArray([
+            'scope'         => 'tag',
+            'effect'        => 'fixed_amount',
+            'tag'           => 'jidlo',
+            'amountSetting' => 'SLEVA_ORGU_NA_JIDLO_CASTKA',
         ]);
     }
 

--- a/symfony/tests/Discount/DiscountRuleLoaderTest.php
+++ b/symfony/tests/Discount/DiscountRuleLoaderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Discount;
+
+use App\Discount\DiscountRuleLoader;
+use App\Discount\DiscountScope;
+use App\Enum\ProductTagCode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The loader takes its fetcher as a callable, so these run without a database and
+ * assert on the SQL as much as on the result — the queries are the part that can go
+ * quietly wrong.
+ */
+class DiscountRuleLoaderTest extends TestCase
+{
+    public function testRulesAreParsedFromTheStoredJson(): void
+    {
+        $loader = new DiscountRuleLoader(static fn (): array => [
+            [
+                'code'           => 'kostka_zdarma',
+                'name'           => 'Kostka zdarma',
+                'required_right' => '1003',
+                'parameters'     => '{"scope":"code_contains","effect":"free","codeFragment":"kostka","maxQuantity":1}',
+            ],
+        ]);
+
+        $rules = $loader->rulesForYear(2026);
+
+        $this->assertCount(1, $rules);
+        $this->assertSame('kostka_zdarma', $rules[0]->code);
+        $this->assertSame(1003, $rules[0]->requiredRight, 'Právo se přetypuje na int');
+        $this->assertSame(DiscountScope::CODE_CONTAINS, $rules[0]->parameters->scope);
+        $this->assertSame(1, $rules[0]->parameters->maxQuantity);
+    }
+
+    public function testOnlyActiveRulesOfThatYearAreAsked(): void
+    {
+        $captured = null;
+        $loader = new DiscountRuleLoader(static function (string $sql, array $params) use (&$captured): array {
+            $captured = [$sql, $params];
+
+            return [];
+        });
+
+        $loader->rulesForYear(2025);
+
+        [$sql, $params] = $captured;
+        $this->assertStringContainsString('active = 1', $sql);
+        $this->assertStringContainsString('year = $0', $sql);
+        $this->assertSame([
+            0 => 2025,
+        ], $params);
+    }
+
+    public function testRightsComeFromTheBaseTableNotTheView(): void
+    {
+        $captured = null;
+        $loader = new DiscountRuleLoader(static function (string $sql, array $params) use (&$captured): array {
+            $captured = [$sql, $params];
+
+            return [
+                [
+                    'id_prava' => '1003',
+                ],
+                [
+                    'id_prava' => '1012',
+                ],
+            ];
+        });
+
+        $rights = $loader->rightsOfUser(335);
+
+        [$sql, $params] = $captured;
+        // platne_role_uzivatelu is a view defined against the `gamecon` database by
+        // name, so under the test database it reports the developer's roles. Reading
+        // uzivatele_role directly is what makes this correct under test.
+        $this->assertStringContainsString('uzivatele_role', $sql);
+        $this->assertStringNotContainsString('platne_role_uzivatelu', $sql);
+        $this->assertSame([
+            0 => 335,
+        ], $params);
+        $this->assertSame([1003, 1012], $rights);
+    }
+
+    public function testMalformedParametersAreRefused(): void
+    {
+        $loader = new DiscountRuleLoader(static fn (): array => [
+            [
+                'code'           => 'rozbite',
+                'name'           => 'Rozbité',
+                'required_right' => '1003',
+                'parameters'     => '{"scope":"tag","effect":"free","tag":"jidla"}',
+            ],
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Neznámý tag "jidla"');
+
+        $loader->rulesForYear(2026);
+    }
+
+    public function testTagSurvivesLoadingAsTheEnum(): void
+    {
+        $loader = new DiscountRuleLoader(static fn (): array => [
+            [
+                'code'           => 'jidlo_zdarma',
+                'name'           => 'Jídlo zdarma',
+                'required_right' => '1005',
+                'parameters'     => '{"scope":"tag","effect":"free","tag":"jidlo"}',
+            ],
+        ]);
+
+        $this->assertSame(ProductTagCode::JIDLO, $loader->rulesForYear(2026)[0]->parameters->tag);
+    }
+}

--- a/symfony/tests/Discount/DiscountSettingTest.php
+++ b/symfony/tests/Discount/DiscountSettingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Discount;
+
+use App\Discount\DiscountSetting;
+use App\Tests\AbstractDatabaseKernelTestCase;
+
+/**
+ * The stored JSON refers to a setting by DiscountSetting case name, so a rename of a
+ * settings key is a change in one typed place rather than a string nobody checks.
+ *
+ * That only holds while every case still points at a setting that exists — otherwise
+ * the rule resolves to nothing and the discount quietly stops applying, which is the
+ * failure the enum was introduced to prevent.
+ */
+class DiscountSettingTest extends AbstractDatabaseKernelTestCase
+{
+    public function testEverySettingReferencedByARuleResolves(): void
+    {
+        // Not "has a row in systemove_nastaveni": MODRE_TRICKO_ZDARMA_OD is derived
+        // (3 × the activity bonus) and has no row of its own. What matters is that
+        // dejHodnotu() returns a value, which is how a rule will read it.
+        $systemoveNastaveni = \Gamecon\SystemoveNastaveni\SystemoveNastaveni::zGlobals(
+            ROCNIK,
+            new \Gamecon\Cas\DateTimeImmutableStrict(),
+        );
+
+        foreach (DiscountSetting::cases() as $setting) {
+            $value = $systemoveNastaveni->dejHodnotu($setting->settingKey());
+
+            $this->assertNotNull(
+                $value,
+                sprintf(
+                    'DiscountSetting::%s ukazuje na nastavení "%s", které se nedá načíst. '
+                    . 'Sleva by tiše přestala platit.',
+                    $setting->name,
+                    $setting->settingKey(),
+                ),
+            );
+        }
+    }
+
+    public function testCaseNamesDoNotLookLikeSettingKeys(): void
+    {
+        // camelCase on purpose: a reader must not assume the JSON value has to match a
+        // SCREAMING_CASE settings key, because it deliberately does not.
+        foreach (DiscountSetting::cases() as $setting) {
+            $this->assertNotSame(
+                $setting->settingKey(),
+                $setting->value,
+                sprintf('Hodnota %s se shoduje s klíčem nastavení, to je matoucí', $setting->name),
+            );
+        }
+    }
+}

--- a/symfony/tests/Entity/ProductListSerializationTest.php
+++ b/symfony/tests/Entity/ProductListSerializationTest.php
@@ -36,11 +36,11 @@ class ProductListSerializationTest extends TestCase
     public static function productFieldsRequiredInList(): array
     {
         return [
-            'id' => ['id'],
-            'name' => ['name'],
-            'code' => ['code'],
+            'id'           => ['id'],
+            'name'         => ['name'],
+            'code'         => ['code'],
             'currentPrice' => ['currentPrice'],
-            'state' => ['state'],
+            'state'        => ['state'],
         ];
     }
 
@@ -58,6 +58,7 @@ class ProductListSerializationTest extends TestCase
 
         if (empty($attributes)) {
             $this->assertTrue(true); // no groups at all = not in list
+
             return;
         }
 
@@ -69,8 +70,8 @@ class ProductListSerializationTest extends TestCase
     {
         return [
             'accommodationDay' => ['accommodationDay'],
-            'tags' => ['tags'],
-            'variants' => ['variants'],
+            'tags'             => ['tags'],
+            'variants'         => ['variants'],
         ];
     }
 

--- a/symfony/tests/Entity/UserTest.php
+++ b/symfony/tests/Entity/UserTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\Entity;
 use App\Entity\Role;
 use App\Entity\User;
 use App\Entity\UserRole;
-use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase

--- a/symfony/tests/Enum/ProductTagCodeTest.php
+++ b/symfony/tests/Enum/ProductTagCodeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Enum;
+
+use App\Enum\ProductTagCode;
+use App\Tests\AbstractDatabaseKernelTestCase;
+
+/**
+ * The enum is only worth anything while it matches product_tag. A case whose code is
+ * not in the table matches no product, so any rule or query using it silently returns
+ * nothing — the failure the enum exists to prevent, just moved one level up.
+ *
+ * Checked in both directions: a case with no row is a typo, and a row with no case is
+ * a tag somebody added that the code cannot address.
+ */
+class ProductTagCodeTest extends AbstractDatabaseKernelTestCase
+{
+    /**
+     * @return string[]
+     */
+    private function storedTagCodes(): array
+    {
+        $codes = $this->connection()->fetchFirstColumn('SELECT code FROM product_tag');
+        $this->assertNotEmpty($codes, 'Žádné tagy v databázi — test by prošel naprázdno');
+
+        return $codes;
+    }
+
+    public function testEveryCaseExistsInTheDatabase(): void
+    {
+        $stored = $this->storedTagCodes();
+
+        foreach (ProductTagCode::cases() as $tag) {
+            $this->assertContains(
+                $tag->value,
+                $stored,
+                sprintf(
+                    'ProductTagCode::%s má kód "%s", který v product_tag není. '
+                    . 'Cokoli podle něj filtruje tiše nevrátí nic.',
+                    $tag->name,
+                    $tag->value,
+                ),
+            );
+        }
+    }
+
+    public function testEveryStoredTagHasACase(): void
+    {
+        $missing = array_diff(
+            $this->storedTagCodes(),
+            array_column(ProductTagCode::cases(), 'value'),
+        );
+
+        $this->assertSame(
+            [],
+            array_values($missing),
+            'Tagy v product_tag bez odpovídajícího ProductTagCode — kód je nedokáže adresovat.',
+        );
+    }
+
+    public function testCategoriesAreTheSuccessorOfTheOldTypColumn(): void
+    {
+        // Seven categories, one per product, mirroring typ 1–7. MIKINA is deliberately
+        // not among them: it is carried in addition to PREDMET, not instead of it.
+        $this->assertCount(7, ProductTagCode::categories());
+        $this->assertFalse(ProductTagCode::MIKINA->isCategory());
+        $this->assertTrue(ProductTagCode::PREDMET->isCategory());
+    }
+}

--- a/symfony/tests/Enum/ProductTagCodeTest.php
+++ b/symfony/tests/Enum/ProductTagCodeTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Enum;
 
 use App\Enum\ProductTagCode;
 use App\Tests\AbstractDatabaseKernelTestCase;
+use Gamecon\Shop\TypPredmetu;
 
 /**
  * The enum is only worth anything while it matches product_tag. A case whose code is
@@ -58,6 +59,39 @@ class ProductTagCodeTest extends AbstractDatabaseKernelTestCase
             array_values($missing),
             'Tagy v product_tag bez odpovídajícího ProductTagCode — kód je nedokáže adresovat.',
         );
+    }
+
+    public function testLegacyTypMapsToTheCategoryThatReplacedIt(): void
+    {
+        // The compatibility view still reports typ, so anything reading a legacy row
+        // has to translate. A wrong number here silently discounts the wrong kind of
+        // thing — meals priced as shirts.
+        $this->assertSame(ProductTagCode::PREDMET, ProductTagCode::fromLegacyTyp(TypPredmetu::PREDMET));
+        $this->assertSame(ProductTagCode::UBYTOVANI, ProductTagCode::fromLegacyTyp(TypPredmetu::UBYTOVANI));
+        $this->assertSame(ProductTagCode::TRICKO, ProductTagCode::fromLegacyTyp(TypPredmetu::TRICKO));
+        $this->assertSame(ProductTagCode::JIDLO, ProductTagCode::fromLegacyTyp(TypPredmetu::JIDLO));
+        $this->assertSame(ProductTagCode::VSTUPNE, ProductTagCode::fromLegacyTyp(TypPredmetu::VSTUPNE));
+        $this->assertSame(ProductTagCode::PARCON, ProductTagCode::fromLegacyTyp(TypPredmetu::PARCON));
+        $this->assertSame(
+            ProductTagCode::PROPLACENI_BONUSU,
+            ProductTagCode::fromLegacyTyp(TypPredmetu::PROPLACENI_BONUSU),
+        );
+    }
+
+    public function testEveryCategoryHasALegacyTyp(): void
+    {
+        // Both directions, so a category added without a typ cannot go unnoticed.
+        $mapped = array_filter(
+            array_map(static fn (int $typ): ?ProductTagCode => ProductTagCode::fromLegacyTyp($typ), range(1, 7)),
+        );
+
+        $this->assertEqualsCanonicalizing(ProductTagCode::categories(), array_values($mapped));
+    }
+
+    public function testUnknownLegacyTypIsNull(): void
+    {
+        $this->assertNull(ProductTagCode::fromLegacyTyp(0));
+        $this->assertNull(ProductTagCode::fromLegacyTyp(99));
     }
 
     public function testCategoriesAreTheSuccessorOfTheOldTypColumn(): void

--- a/symfony/tests/Log/TestLogger.php
+++ b/symfony/tests/Log/TestLogger.php
@@ -12,7 +12,9 @@ use Psr\Log\AbstractLogger;
  */
 class TestLogger extends AbstractLogger
 {
-    /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+    /**
+     * @var list<array{level: string, message: string, context: array<string, mixed>}>
+     */
     public array $records = [];
 
     public function log($level, string|\Stringable $message, array $context = []): void

--- a/symfony/tests/Service/CartServiceTest.php
+++ b/symfony/tests/Service/CartServiceTest.php
@@ -121,10 +121,10 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => null,
+                'discount'       => null,
                 'discountAmount' => '0.00',
-                'finalPrice' => '250.00',
-                'reason' => null,
+                'finalPrice'     => '250.00',
+                'reason'         => null,
             ]);
 
         $this->capacityManager->expects($this->once())
@@ -158,10 +158,10 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => $this->createMock(\App\Entity\ProductDiscount::class),
+                'discount'       => $this->createMock(\App\Entity\ProductDiscount::class),
                 'discountAmount' => '250.00',
-                'finalPrice' => '0.00',
-                'reason' => 'Organizátor (zdarma): 100% sleva',
+                'finalPrice'     => '0.00',
+                'reason'         => 'Organizátor (zdarma): 100% sleva',
             ]);
 
         $roleMeanings = [RoleMeaning::ORGANIZATOR_ZDARMA];
@@ -272,10 +272,10 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => null,
+                'discount'       => null,
                 'discountAmount' => '0.00',
-                'finalPrice' => '250.00',
-                'reason' => null,
+                'finalPrice'     => '250.00',
+                'reason'         => null,
             ]);
 
         $this->cartService->addItem($order, $variant);
@@ -319,10 +319,10 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => null,
+                'discount'       => null,
                 'discountAmount' => '0.00',
-                'finalPrice' => '250.00',
-                'reason' => null,
+                'finalPrice'     => '250.00',
+                'reason'         => null,
             ]);
 
         $item = $this->cartService->addItem($order, $variant, [RoleMeaning::ORGANIZATOR_ZDARMA]);
@@ -351,10 +351,10 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => null,
+                'discount'       => null,
                 'discountAmount' => '0.00',
-                'finalPrice' => '250.00',
-                'reason' => null,
+                'finalPrice'     => '250.00',
+                'reason'         => null,
             ]);
 
         $items = $this->cartService->addBundle($order, $bundle, [RoleMeaning::PRIHLASEN]);
@@ -382,16 +382,16 @@ class CartServiceTest extends TestCase
 
         $this->discountCalculator->method('calculateDiscount')
             ->willReturn([
-                'discount' => null,
+                'discount'       => null,
                 'discountAmount' => '0.00',
-                'finalPrice' => '250.00',
-                'reason' => null,
+                'finalPrice'     => '250.00',
+                'reason'         => null,
             ]);
 
         $callCount = 0;
         $this->capacityManager->method('purchase')
             ->willReturnCallback(function () use (&$callCount): void {
-                $callCount++;
+                ++$callCount;
                 if ($callCount === 2) {
                     throw new \RuntimeException('Nedostatečná kapacita');
                 }

--- a/symfony/tests/State/Admin/BulkCancelProcessorTest.php
+++ b/symfony/tests/State/Admin/BulkCancelProcessorTest.php
@@ -45,8 +45,8 @@ class BulkCancelProcessorTest extends TestCase
 
         $this->entityManager->method('find')
             ->willReturnCallback(fn (string $class, int $id) => match ($id) {
-                1 => $user1,
-                2 => $user2,
+                1       => $user1,
+                2       => $user2,
                 default => null,
             });
 

--- a/symfony/tests/State/Cart/RemoveFromCartProcessorTest.php
+++ b/symfony/tests/State/Cart/RemoveFromCartProcessorTest.php
@@ -8,9 +8,7 @@ use ApiPlatform\Metadata\Delete;
 use App\Dto\Cart\CartOutputDto;
 use App\Entity\Order;
 use App\Entity\OrderItem;
-use App\Entity\Product;
 use App\Entity\ProductBundle;
-use App\Entity\ProductVariant;
 use App\Entity\User;
 use App\Enum\RoleMeaning;
 use App\Service\CartService;
@@ -46,7 +44,7 @@ class RemoveFromCartProcessorTest extends TestCase
     public function testRemoveItemFromCart(): void
     {
         $user = $this->createConfiguredMock(User::class, [
-            'getId' => 1,
+            'getId'           => 1,
             'getRoleMeanings' => [],
         ]);
         $this->security->method('getUser')->willReturn($user);
@@ -73,7 +71,9 @@ class RemoveFromCartProcessorTest extends TestCase
             ->method('removeItem')
             ->with($order, $item, []);
 
-        $result = $this->processor->process(null, new Delete(), ['itemId' => 77]);
+        $result = $this->processor->process(null, new Delete(), [
+            'itemId' => 77,
+        ]);
 
         $this->assertInstanceOf(CartOutputDto::class, $result);
     }
@@ -81,7 +81,7 @@ class RemoveFromCartProcessorTest extends TestCase
     public function testRemoveBundleItemRemovesWholeBundleForParticipant(): void
     {
         $user = $this->createConfiguredMock(User::class, [
-            'getId' => 1,
+            'getId'           => 1,
             'getRoleMeanings' => [RoleMeaning::PRIHLASEN],
         ]);
         $this->security->method('getUser')->willReturn($user);
@@ -117,7 +117,9 @@ class RemoveFromCartProcessorTest extends TestCase
         $this->cartService->expects($this->never())
             ->method('removeItem');
 
-        $result = $this->processor->process(null, new Delete(), ['itemId' => 88]);
+        $result = $this->processor->process(null, new Delete(), [
+            'itemId' => 88,
+        ]);
 
         $this->assertInstanceOf(CartOutputDto::class, $result);
     }
@@ -125,7 +127,7 @@ class RemoveFromCartProcessorTest extends TestCase
     public function testThrowsWhenItemNotFound(): void
     {
         $user = $this->createConfiguredMock(User::class, [
-            'getId' => 1,
+            'getId'           => 1,
             'getRoleMeanings' => [],
         ]);
         $this->security->method('getUser')->willReturn($user);
@@ -134,13 +136,19 @@ class RemoveFromCartProcessorTest extends TestCase
 
         $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
 
-        $this->processor->process(null, new Delete(), ['itemId' => 999]);
+        $this->processor->process(null, new Delete(), [
+            'itemId' => 999,
+        ]);
     }
 
     public function testThrowsWhenItemBelongsToOtherUser(): void
     {
-        $currentUser = $this->createConfiguredMock(User::class, ['getId' => 1]);
-        $otherUser = $this->createConfiguredMock(User::class, ['getId' => 2]);
+        $currentUser = $this->createConfiguredMock(User::class, [
+            'getId' => 1,
+        ]);
+        $otherUser = $this->createConfiguredMock(User::class, [
+            'getId' => 2,
+        ]);
         $this->security->method('getUser')->willReturn($currentUser);
 
         $item = new OrderItem();
@@ -157,6 +165,8 @@ class RemoveFromCartProcessorTest extends TestCase
 
         $this->expectException(\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException::class);
 
-        $this->processor->process(null, new Delete(), ['itemId' => 55]);
+        $this->processor->process(null, new Delete(), [
+            'itemId' => 55,
+        ]);
     }
 }

--- a/symfony/tests/State/Kfc/KfcGridProcessorTest.php
+++ b/symfony/tests/State/Kfc/KfcGridProcessorTest.php
@@ -43,7 +43,11 @@ class KfcGridProcessorTest extends TestCase
         $executedStatements = [];
         $this->connection->method('executeStatement')
             ->willReturnCallback(function (string $sql, array $params) use (&$executedStatements) {
-                $executedStatements[] = ['sql' => $sql, 'params' => $params];
+                $executedStatements[] = [
+                    'sql'    => $sql,
+                    'params' => $params,
+                ];
+
                 return 1;
             });
 
@@ -68,7 +72,11 @@ class KfcGridProcessorTest extends TestCase
         $executedStatements = [];
         $this->connection->method('executeStatement')
             ->willReturnCallback(function (string $sql, array $params) use (&$executedStatements) {
-                $executedStatements[] = ['sql' => $sql, 'params' => $params];
+                $executedStatements[] = [
+                    'sql'    => $sql,
+                    'params' => $params,
+                ];
+
                 return 1;
             });
         $this->connection->method('lastInsertId')->willReturn('99');
@@ -92,7 +100,11 @@ class KfcGridProcessorTest extends TestCase
         $executedStatements = [];
         $this->connection->method('executeStatement')
             ->willReturnCallback(function (string $sql, array $params) use (&$executedStatements) {
-                $executedStatements[] = ['sql' => $sql, 'params' => $params];
+                $executedStatements[] = [
+                    'sql'    => $sql,
+                    'params' => $params,
+                ];
+
                 return 1;
             });
 
@@ -126,7 +138,8 @@ class KfcGridProcessorTest extends TestCase
         $callCount = 0;
         $this->connection->method('executeStatement')
             ->willReturnCallback(function () use (&$callCount) {
-                $callCount++;
+                ++$callCount;
+
                 return 1;
             });
         $this->connection->method('lastInsertId')->willReturn('77');
@@ -157,6 +170,7 @@ class KfcGridProcessorTest extends TestCase
                 if (str_contains($sql, 'INSERT INTO obchod_bunky')) {
                     $insertedCellParams = $params;
                 }
+
                 return 1;
             });
 

--- a/symfony/tests/State/Kfc/KfcGridProviderTest.php
+++ b/symfony/tests/State/Kfc/KfcGridProviderTest.php
@@ -29,14 +29,44 @@ class KfcGridProviderTest extends TestCase
             ->willReturnOnConsecutiveCalls(
                 // grids
                 [
-                    ['id' => '1', 'text' => 'Úvod'],
-                    ['id' => '2', 'text' => 'Trička'],
+                    [
+                        'id'   => '1',
+                        'text' => 'Úvod',
+                    ],
+                    [
+                        'id'   => '2',
+                        'text' => 'Trička',
+                    ],
                 ],
                 // cells
                 [
-                    ['id' => '10', 'typ' => '0', 'text' => null, 'barva' => '#f4bb57', 'barva_text' => '#000', 'cil_id' => '42', 'mrizka_id' => '1'],
-                    ['id' => '11', 'typ' => '1', 'text' => 'Trička', 'barva' => '#ff0000', 'barva_text' => null, 'cil_id' => '2', 'mrizka_id' => '1'],
-                    ['id' => '12', 'typ' => '2', 'text' => 'Zpět', 'barva' => null, 'barva_text' => null, 'cil_id' => null, 'mrizka_id' => '2'],
+                    [
+                        'id'         => '10',
+                        'typ'        => '0',
+                        'text'       => null,
+                        'barva'      => '#f4bb57',
+                        'barva_text' => '#000',
+                        'cil_id'     => '42',
+                        'mrizka_id'  => '1',
+                    ],
+                    [
+                        'id'         => '11',
+                        'typ'        => '1',
+                        'text'       => 'Trička',
+                        'barva'      => '#ff0000',
+                        'barva_text' => null,
+                        'cil_id'     => '2',
+                        'mrizka_id'  => '1',
+                    ],
+                    [
+                        'id'         => '12',
+                        'typ'        => '2',
+                        'text'       => 'Zpět',
+                        'barva'      => null,
+                        'barva_text' => null,
+                        'cil_id'     => null,
+                        'mrizka_id'  => '2',
+                    ],
                 ],
             );
 
@@ -70,7 +100,10 @@ class KfcGridProviderTest extends TestCase
     {
         $this->connection->method('fetchAllAssociative')
             ->willReturnOnConsecutiveCalls(
-                [['id' => '1', 'text' => 'Empty grid']],
+                [[
+                    'id'   => '1',
+                    'text' => 'Empty grid',
+                ]],
                 [], // no cells
             );
 

--- a/symfony/tests/State/Kfc/KfcProductsProviderTest.php
+++ b/symfony/tests/State/Kfc/KfcProductsProviderTest.php
@@ -27,8 +27,18 @@ class KfcProductsProviderTest extends TestCase
     {
         $this->connection->method('fetchAllAssociative')
             ->willReturn([
-                ['id' => '42', 'nazev' => 'Tričko modré 2026', 'cena' => '250', 'zbyva' => '15'],
-                ['id' => '43', 'nazev' => 'Kostka 2026', 'cena' => '50', 'zbyva' => null],
+                [
+                    'id'    => '42',
+                    'nazev' => 'Tričko modré 2026',
+                    'cena'  => '250',
+                    'zbyva' => '15',
+                ],
+                [
+                    'id'    => '43',
+                    'nazev' => 'Kostka 2026',
+                    'cena'  => '50',
+                    'zbyva' => null,
+                ],
             ]);
 
         $result = $this->provider->provide(new GetCollection());

--- a/symfony/tests/State/Kfc/KfcSaleProcessorTest.php
+++ b/symfony/tests/State/Kfc/KfcSaleProcessorTest.php
@@ -37,7 +37,11 @@ class KfcSaleProcessorTest extends TestCase
     public function testSuccessfulSale(): void
     {
         $this->connection->method('fetchAssociative')
-            ->willReturn(['cena_aktualni' => '250.00', 'kusu_vyrobeno' => '100', 'nazev' => 'Tričko']);
+            ->willReturn([
+                'cena_aktualni' => '250.00',
+                'kusu_vyrobeno' => '100',
+                'nazev'         => 'Tričko',
+            ]);
 
         $this->connection->method('fetchOne')
             ->willReturn('10'); // 10 already sold
@@ -79,7 +83,11 @@ class KfcSaleProcessorTest extends TestCase
     public function testSaleThrowsWhenInsufficientStock(): void
     {
         $this->connection->method('fetchAssociative')
-            ->willReturn(['cena_aktualni' => '100.00', 'kusu_vyrobeno' => '10', 'nazev' => 'Kostka']);
+            ->willReturn([
+                'cena_aktualni' => '100.00',
+                'kusu_vyrobeno' => '10',
+                'nazev'         => 'Kostka',
+            ]);
 
         $this->connection->method('fetchOne')
             ->willReturn('9'); // 9 sold, only 1 remaining
@@ -99,7 +107,11 @@ class KfcSaleProcessorTest extends TestCase
     public function testSaleWithUnlimitedStock(): void
     {
         $this->connection->method('fetchAssociative')
-            ->willReturn(['cena_aktualni' => '50.00', 'kusu_vyrobeno' => null, 'nazev' => 'Vstupné']);
+            ->willReturn([
+                'cena_aktualni' => '50.00',
+                'kusu_vyrobeno' => null,
+                'nazev'         => 'Vstupné',
+            ]);
 
         // fetchOne should NOT be called (no stock check for unlimited)
         $this->connection->expects($this->never())
@@ -125,10 +137,19 @@ class KfcSaleProcessorTest extends TestCase
         $callCount = 0;
         $this->connection->method('fetchAssociative')
             ->willReturnCallback(function () use (&$callCount) {
-                $callCount++;
+                ++$callCount;
+
                 return match ($callCount) {
-                    1 => ['cena_aktualni' => '250.00', 'kusu_vyrobeno' => null, 'nazev' => 'Tričko'],
-                    2 => ['cena_aktualni' => '100.00', 'kusu_vyrobeno' => null, 'nazev' => 'Kostka'],
+                    1 => [
+                        'cena_aktualni' => '250.00',
+                        'kusu_vyrobeno' => null,
+                        'nazev'         => 'Tričko',
+                    ],
+                    2 => [
+                        'cena_aktualni' => '100.00',
+                        'kusu_vyrobeno' => null,
+                        'nazev'         => 'Kostka',
+                    ],
                     default => false,
                 };
             });

--- a/tests/Model/Uzivatel/CenikCharakterizacniTest.php
+++ b/tests/Model/Uzivatel/CenikCharakterizacniTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Uzivatel;
+
+use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\Pravo;
+use Gamecon\Shop\SqlStruktura\PredmetSqlStruktura as PredmetySql;
+use Gamecon\Shop\TypPredmetu;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Gamecon\Tests\Db\AbstractTestDb;
+use Gamecon\Uzivatel\Cenik;
+use Gamecon\Uzivatel\Finance;
+
+/**
+ * Pins the behaviour of Cenik before the discount rules move into data.
+ *
+ * Cenik decides what every participant pays and had no tests of its own — the only
+ * coverage went through Finance end to end. These tests are deliberately written
+ * against the current behaviour rather than against a specification: they exist to
+ * make the rewrite provable, so a change in the numbers below is a real change in
+ * what somebody is charged, not a test that needs adjusting.
+ *
+ * Six discount kinds, all keyed on a Pravo rather than a role:
+ *   dice / badge   100 % off, one each
+ *   t-shirt        100 % off from an earned bonus, or 1–2 by right
+ *   accommodation  100 % off, whole stay or a single named night
+ *   meal           100 % off, or a fixed amount from system settings
+ */
+class CenikCharakterizacniTest extends AbstractTestDb
+{
+    private const ID_UZIVATELE = 335;
+    private const ID_ROLE = -335335;
+
+    private const ID_KOSTKA = 33500;
+    private const ID_PLACKA = 33501;
+    private const ID_TRICKO_LEVNE = 33502;
+    private const ID_TRICKO_DRAHE = 33503;
+    private const ID_UBYTOVANI_STREDA = 33504;
+    private const ID_UBYTOVANI_CTVRTEK = 33505;
+    private const ID_JIDLO = 33506;
+    private const ID_OBYCEJNY_PREDMET = 33507;
+
+    protected static array $initQueries = [
+        <<<SQL
+INSERT INTO uzivatele_hodnoty SET id_uzivatele = 335, login_uzivatele = 'CenikTest', jmeno_uzivatele = 'Cenik', prijmeni_uzivatele = 'Test', email1_uzivatele = 'cenik.test@bio.org'
+SQL,
+        [
+            <<<SQL
+INSERT INTO role_seznam(id_role, kod_role, nazev_role, popis_role, rocnik_role, typ_role, vyznam_role)
+VALUES ($0, 'TEST_CENIK', 'Test role ceník', '', -1, 'trvala', '')
+SQL,
+            [
+                0 => self::ID_ROLE,
+            ],
+        ],
+        [
+            <<<SQL
+INSERT INTO uzivatele_role(id_uzivatele, id_role, posadil) VALUES ($0, $1, $0)
+SQL,
+            [
+                0 => self::ID_UZIVATELE,
+                1 => self::ID_ROLE,
+            ],
+        ],
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33500, nazev = 'Kostka testovací', kod_predmetu = CONCAT('kostka_test_', $0), cena_aktualni = 100, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33500, id FROM product_tag WHERE code = 'predmet'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33501, nazev = 'Placka testovací', kod_predmetu = CONCAT('placka_test_', $0), cena_aktualni = 50, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33501, id FROM product_tag WHERE code = 'predmet'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33502, nazev = 'Tričko levné testovací', kod_predmetu = CONCAT('tricko_levne_test_', $0), cena_aktualni = 300, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33502, id FROM product_tag WHERE code = 'tricko'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33503, nazev = 'Tričko drahé testovací', kod_predmetu = CONCAT('tricko_drahe_test_', $0), cena_aktualni = 500, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33503, id FROM product_tag WHERE code = 'tricko'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33504, nazev = 'Ubytování středa testovací', kod_predmetu = CONCAT('ubytovani_st_test_', $0), cena_aktualni = 400, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100, ubytovani_den = 0
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33504, id FROM product_tag WHERE code = 'ubytovani'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33505, nazev = 'Ubytování čtvrtek testovací', kod_predmetu = CONCAT('ubytovani_ct_test_', $0), cena_aktualni = 400, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100, ubytovani_den = 1
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33505, id FROM product_tag WHERE code = 'ubytovani'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33506, nazev = 'Oběd testovací', kod_predmetu = CONCAT('obed_test_', $0), cena_aktualni = 150, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100, ubytovani_den = 1
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33506, id FROM product_tag WHERE code = 'jidlo'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33507, nazev = 'Obyčejný předmět testovací', kod_predmetu = CONCAT('obycejny_test_', $0), cena_aktualni = 200, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33507, id FROM product_tag WHERE code = 'predmet'",
+    ];
+
+    private function udelPravo(int $idPrava): void
+    {
+        \dbQuery(
+            'INSERT IGNORE INTO prava_role(id_role, id_prava) VALUES ($0, $1)',
+            [
+                0 => self::ID_ROLE,
+                1 => $idPrava,
+            ],
+        );
+        \Uzivatel::smazCache();
+    }
+
+    private function cenik(): Cenik
+    {
+        $systemoveNastaveni = SystemoveNastaveni::zGlobals(ROCNIK, new DateTimeImmutableStrict());
+        $uzivatel = \Uzivatel::zIdUrcite(self::ID_UZIVATELE);
+
+        return new Cenik($uzivatel, new Finance($uzivatel, 0, $systemoveNastaveni), $systemoveNastaveni);
+    }
+
+    /**
+     * @return array<string, mixed> the row shape Cenik::cena() expects
+     */
+    private function radek(int $idPredmetu): array
+    {
+        $radek = \dbOneLine(
+            'SELECT * FROM shop_predmety_s_typem WHERE id_predmetu = $0',
+            [
+                0 => $idPredmetu,
+            ],
+        );
+        self::assertNotEmpty($radek, "Předmět {$idPredmetu} nenalezen");
+
+        return $radek;
+    }
+
+    /**
+     * @test
+     */
+    public function bezPravJeVsechnoZaPlnouCenu(): void
+    {
+        $cenik = $this->cenik();
+
+        self::assertSame(100.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+        self::assertSame(50.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+        self::assertSame(300.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+        self::assertSame(400.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_STREDA))->finalPrice);
+        self::assertSame(150.0, $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice);
+        self::assertSame(200.0, $cenik->cena($this->radek(self::ID_OBYCEJNY_PREDMET))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function kostkaZdarmaPlatiJenNaPrvniKostku(): void
+    {
+        $this->udelPravo(Pravo::KOSTKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        // Jedna kostka zdarma, druhá už za plnou cenu — čítač je jeden na instanci Ceníku.
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+        self::assertSame(100.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+
+        // Placku to neovlivní, ta má vlastní právo.
+        self::assertSame(50.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function plackaZdarmaPlatiJenNaPrvniPlacku(): void
+    {
+        $this->udelPravo(Pravo::PLACKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+        self::assertSame(50.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+        self::assertSame(100.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function cenaKostkyAPlackyNesnizujeCitac(): void
+    {
+        $this->udelPravo(Pravo::KOSTKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        // cenaKostky() se ptá "kolik by to stálo", ne "prodej mi to" — volá se
+        // s $omezPocet = false, takže vrací nulu opakovaně a nevyčerpá nárok.
+        self::assertSame(0, $cenik->cenaKostky($this->radek(self::ID_KOSTKA)));
+        self::assertSame(0, $cenik->cenaKostky($this->radek(self::ID_KOSTKA)));
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function jednoJakekolivTrickoZdarma(): void
+    {
+        $this->udelPravo(Pravo::JAKEKOLIV_TRICKO_ZDARMA);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+        self::assertSame(500.0, $cenik->cena($this->radek(self::ID_TRICKO_DRAHE))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function dveJakakolivTrickaZdarma(): void
+    {
+        $this->udelPravo(Pravo::DVE_JAKAKOLI_TRICKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_TRICKO_DRAHE))->finalPrice);
+        self::assertSame(300.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function ubytovaniZdarmaPlatiNaVsechnyDny(): void
+    {
+        $this->udelPravo(Pravo::UBYTOVANI_ZDARMA);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_STREDA))->finalPrice);
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_CTVRTEK))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function ubytovaniZdarmaJenNaJmenovanouNoc(): void
+    {
+        $this->udelPravo(Pravo::UBYTOVANI_STREDECNI_NOC_ZDARMA);
+        $cenik = $this->cenik();
+
+        // Právo je vázané na konkrétní noc, ostatní se platí.
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_STREDA))->finalPrice);
+        self::assertSame(400.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_CTVRTEK))->finalPrice);
+
+        // Na rozdíl od kostky se nárok nevyčerpá — platí na každou středeční noc.
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_UBYTOVANI_STREDA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function jidloZdarma(): void
+    {
+        $this->udelPravo(Pravo::JIDLO_ZDARMA);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice);
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function jidloSeSlevouOdectePevnouCastku(): void
+    {
+        $this->udelPravo(Pravo::JIDLO_SE_SLEVOU);
+        $systemoveNastaveni = SystemoveNastaveni::zGlobals(ROCNIK, new DateTimeImmutableStrict());
+        $sleva = $systemoveNastaveni->slevaOrguNaJidloCastka();
+        self::assertGreaterThan(0, $sleva, 'Sleva na jídlo musí být nastavená, jinak test nic neověří');
+
+        $cenik = $this->cenik();
+
+        // Pevná částka, ne procento — jediná sleva, která není 100 %.
+        self::assertSame(150.0 - $sleva, $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function slevaSeNeaplikujeNaJinyTypPredmetu(): void
+    {
+        $this->udelPravo(Pravo::JIDLO_ZDARMA);
+        $this->udelPravo(Pravo::UBYTOVANI_ZDARMA);
+        $cenik = $this->cenik();
+
+        // Práva na jídlo a ubytování nesmí zlevnit obyčejný předmět ani tričko.
+        self::assertSame(200.0, $cenik->cena($this->radek(self::ID_OBYCEJNY_PREDMET))->finalPrice);
+        self::assertSame(300.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function puvodniCenaPreferujeNakupniCenuPredKatalogovou(): void
+    {
+        $cenik = $this->cenik();
+        $radek = $this->radek(self::ID_KOSTKA);
+
+        self::assertSame(100.0, $cenik->puvodniCena($radek));
+
+        // Historický nákup se cení tím, co bylo zaplaceno, ne dnešním ceníkem.
+        $radek['cena_nakupni'] = 80;
+        self::assertSame(80.0, $cenik->puvodniCena($radek));
+    }
+
+    /**
+     * @test
+     */
+    public function aplikujSlevuNepretahujeDoZaporu(): void
+    {
+        $cena = 100.0;
+        $sleva = 30.0;
+        $vysledek = Cenik::aplikujSlevu($cena, $sleva);
+        self::assertSame(70.0, $vysledek['cena']);
+        self::assertSame(0.0, $vysledek['sleva']);
+
+        // Sleva větší než cena vynuluje cenu a zbytek slevy zůstane k použití jinde.
+        $cena = 40.0;
+        $sleva = 100.0;
+        $vysledek = Cenik::aplikujSlevu($cena, $sleva);
+        self::assertSame(0.0, $vysledek['cena']);
+        self::assertSame(60.0, $vysledek['sleva']);
+    }
+
+    /**
+     * @test
+     */
+    public function neznamyTypPredmetuSkonciVyjimkou(): void
+    {
+        $cenik = $this->cenik();
+        $radek = $this->radek(self::ID_KOSTKA);
+        $radek[PredmetySql::TYP] = null;
+
+        $this->expectException(\RuntimeException::class);
+        $cenik->cena($radek);
+    }
+
+    /**
+     * @test
+     */
+    public function typPredmetuRozhodujeOSleve(): void
+    {
+        $this->udelPravo(Pravo::JAKEKOLIV_TRICKO_ZDARMA);
+        $cenik = $this->cenik();
+
+        // Sleva na tričko se řídí typem, ne názvem ani kódem: obyčejný předmět
+        // přeznačený na typ TRICKO dostane tričkovou slevu.
+        $radek = $this->radek(self::ID_OBYCEJNY_PREDMET);
+        $radek[PredmetySql::TYP] = TypPredmetu::TRICKO;
+
+        self::assertSame(0.0, $cenik->cena($radek)->finalPrice);
+    }
+}

--- a/tests/Model/Uzivatel/CenikZobrazovaciCestaTest.php
+++ b/tests/Model/Uzivatel/CenikZobrazovaciCestaTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Uzivatel;
+
+use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\Pravo;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Gamecon\Tests\Db\AbstractTestDb;
+use Gamecon\Uzivatel\Cenik;
+use Gamecon\Uzivatel\Finance;
+
+/**
+ * Pins the price the storefront shows, as opposed to the price it charges.
+ *
+ * Shop asks two different questions of Cenik and they have different answers.
+ * renderPredmet() calls cenaKostky()/cenaPlacky() — "what would this cost" — which pass
+ * $omezPocet = false and leave the entitlement counters alone, so a rendered page does
+ * not consume anything. zapoctiShop() calls cena(), which sells and does consume.
+ *
+ * CenikCharakterizacniTest covers cena(). This covers the display side, so the two
+ * cannot drift apart while the rules move into data.
+ */
+class CenikZobrazovaciCestaTest extends AbstractTestDb
+{
+    private const ID_UZIVATELE = 336;
+    private const ID_ROLE = -336336;
+
+    private const ID_KOSTKA = 33600;
+    private const ID_PLACKA = 33601;
+    private const ID_JIDLO = 33602;
+
+    protected static array $initQueries = [
+        <<<SQL
+INSERT INTO uzivatele_hodnoty SET id_uzivatele = 336, login_uzivatele = 'CenikZobrazeni', jmeno_uzivatele = 'Cenik', prijmeni_uzivatele = 'Zobrazeni', email1_uzivatele = 'cenik.zobrazeni@bio.org'
+SQL,
+        [
+            <<<SQL
+INSERT INTO role_seznam(id_role, kod_role, nazev_role, popis_role, rocnik_role, typ_role, vyznam_role)
+VALUES ($0, 'TEST_CENIK_ZOBRAZENI', 'Test role ceník zobrazení', '', -1, 'trvala', '')
+SQL,
+            [
+                0 => self::ID_ROLE,
+            ],
+        ],
+        [
+            <<<SQL
+INSERT INTO uzivatele_role(id_uzivatele, id_role, posadil) VALUES ($0, $1, $0)
+SQL,
+            [
+                0 => self::ID_UZIVATELE,
+                1 => self::ID_ROLE,
+            ],
+        ],
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33600, nazev = 'Kostka zobrazovaci', kod_predmetu = CONCAT('kostka_zobraz_', $0), cena_aktualni = 100, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33600, id FROM product_tag WHERE code = 'predmet'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33601, nazev = 'Placka zobrazovaci', kod_predmetu = CONCAT('placka_zobraz_', $0), cena_aktualni = 50, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33601, id FROM product_tag WHERE code = 'predmet'",
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33602, nazev = 'Obed zobrazovaci', kod_predmetu = CONCAT('obed_zobraz_', $0), cena_aktualni = 150, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 100, ubytovani_den = 1
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33602, id FROM product_tag WHERE code = 'jidlo'",
+    ];
+
+    private function udelPravo(int $idPrava): void
+    {
+        \dbQuery(
+            'INSERT IGNORE INTO prava_role(id_role, id_prava) VALUES ($0, $1)',
+            [
+                0 => self::ID_ROLE,
+                1 => $idPrava,
+            ],
+        );
+        \Uzivatel::smazCache();
+    }
+
+    private function cenik(): Cenik
+    {
+        $systemoveNastaveni = SystemoveNastaveni::zGlobals(ROCNIK, new DateTimeImmutableStrict());
+        $uzivatel = \Uzivatel::zIdUrcite(self::ID_UZIVATELE);
+
+        return new Cenik($uzivatel, new Finance($uzivatel, 0, $systemoveNastaveni), $systemoveNastaveni);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function radek(int $idPredmetu): array
+    {
+        return \dbOneLine(
+            'SELECT * FROM shop_predmety_s_typem WHERE id_predmetu = $0',
+            [
+                0 => $idPredmetu,
+            ],
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function zobrazenaCenaKostkyNevycerpaNarok(): void
+    {
+        $this->udelPravo(Pravo::KOSTKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        // Vykreslení stránky se ptá "kolik by to stálo" a nesmí nárok spotřebovat,
+        // i kdyby se stejná kostka vykreslila desetkrát.
+        for ($i = 0; $i < 10; ++$i) {
+            self::assertSame(0, $cenik->cenaKostky($this->radek(self::ID_KOSTKA)));
+        }
+
+        // Teprve nákup nárok vyčerpá.
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+        self::assertSame(100.0, $cenik->cena($this->radek(self::ID_KOSTKA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function zobrazenaCenaPlackyNevycerpaNarok(): void
+    {
+        $this->udelPravo(Pravo::PLACKA_ZDARMA);
+        $cenik = $this->cenik();
+
+        for ($i = 0; $i < 10; ++$i) {
+            self::assertSame(0, $cenik->cenaPlacky($this->radek(self::ID_PLACKA)));
+        }
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+        self::assertSame(50.0, $cenik->cena($this->radek(self::ID_PLACKA))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function bezPravaJeZobrazenaCenaPlna(): void
+    {
+        $cenik = $this->cenik();
+
+        self::assertSame(100, $cenik->cenaKostky($this->radek(self::ID_KOSTKA)));
+        self::assertSame(50, $cenik->cenaPlacky($this->radek(self::ID_PLACKA)));
+    }
+
+    /**
+     * @test
+     */
+    public function zobrazenaCenaJidlaNemaCitac(): void
+    {
+        // Jídlo vykresluje Shop::jidloHtml() přes cena(), ne přes zvláštní metodu —
+        // je to bezpečné jen proto, že větev pro jídlo žádný čítač nemá.
+        $this->udelPravo(Pravo::JIDLO_SE_SLEVOU);
+        $systemoveNastaveni = SystemoveNastaveni::zGlobals(ROCNIK, new DateTimeImmutableStrict());
+        $sleva = $systemoveNastaveni->slevaOrguNaJidloCastka();
+        $cenik = $this->cenik();
+
+        for ($i = 0; $i < 5; ++$i) {
+            self::assertSame(
+                150.0 - $sleva,
+                $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice,
+                'Opakované vykreslení ceny jídla musí dávat pořád stejnou částku',
+            );
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function formatDvojiCenyOdpovidaZobrazeni(): void
+    {
+        // renderPredmet() skládá text "sleva/plná cena" jen když se liší; test drží
+        // ta dvě čísla, ze kterých ten text vzniká.
+        $this->udelPravo(Pravo::KOSTKA_ZDARMA);
+        $cenik = $this->cenik();
+        $radek = $this->radek(self::ID_KOSTKA);
+
+        $plnaCena = round((float) $radek['cena_aktualni']);
+        $cenaPoSleve = round((float) $cenik->cenaKostky($radek));
+
+        self::assertSame(100.0, $plnaCena);
+        self::assertSame(0.0, $cenaPoSleve);
+        self::assertNotSame($plnaCena, $cenaPoSleve, 'Liší se, takže se vypíšou obě');
+    }
+}


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Staví na větvi `1274-přepsat-e-shop` (a míří do ní), není to PR do `main`.

**První ze tří PR.** Tenhle nic nemění na tom, co kdo zaplatí — přidává datový model slev, pravidla jako data a spočítanou logiku, kterou zatím **nikdo nevolá**. Cutover (přepojení `Cenik`) a admin obrazovka jsou samostatné PR, aby riziková část měla vlastní review.

## Proč

Slevy jsou dnes větve v `Cenik::cena()`. To má tři důsledky, které nejdou obejít bez přepsání:

**Audit není možný.** `shop_nakupy` má sloupce `original_price`, `discount_amount` i `discount_reason`, ale **všech 71 709 řádků má nulovou slevu** a `cena_nakupni` rovnou katalogové ceně. Sleva existuje jen jako běhový výpočet v `Cenik`, který se pokaždé spočítá znovu. Změní se pravidlo nebo role a historie se tiše přepíše — zpětně se nedá zjistit, kdo co dostal a proč.

**Admin nemá kde vidět, co platí.** Parametry nejsou data: jsou to `if` větve, konstanty `Pravo`, klíče v `systemove_nastaveni` a joiny rolí na práva. Neexistuje dotaz, který by odpověděl „jaké slevy teď platí".

**Model to neuměl vyjádřit.** Původní `product_discount` je `(product, role, percent, max_quantity)`. Z šesti reálných druhů slev umí dva. Chybí pevná částka (sleva na jídlo je 25 Kč, ne procento), pravidla vázaná na *právo* místo role, čítače napříč košíkem a „nejlevnější tričko v košíku".

## Co je v PR

**Charakterizační testy `Cenik` (2 soubory, 20 testů).** Napsané *první*, proti současnému chování, ne proti specifikaci. `Cenik` rozhoduje, kolik kdo zaplatí, a neměl žádné vlastní testy — jediné pokrytí šlo oklikou přes `Finance`. Drží i detaily, které se při přepisu snadno ztratí:

- čítače jsou per-instance, takže **druhá kostka stojí plnou cenu**,
- `cenaKostky()` nárok **záměrně nevyčerpá** — odpovídá na „kolik by to stálo", ne „prodej mi to" (`$omezPocet = false`),
- nárok na konkrétní noc se **nevyčerpává** — platí na každou takovou noc, na rozdíl od kostky,
- sleva na jídlo je **pevná částka**, jediná, která není 100 %,
- sleva se řídí **typem předmětu**, ne názvem ani kódem.

Ověřeno mutací, že testy padají na změně chování (zvýšení kvóty kostek na 2; nárok na noc rozšířený na všechny noci; přepnutí zobrazovací cesty na spotřebovávající).

**Schéma.** Tabulka `discount_rule` + sloupec `shop_nakupy.discount_snapshot`. Sloupce, podle kterých admin filtruje a audit se ptá, jsou skutečné sloupce; proměnlivá část pravidla je JSON, protože těch šest druhů má **opravdu různý tvar** — pravidlo nad celým košíkem nemá produkt, noc potřebuje den, jídlo částku v Kč. Jako sloupce by většina byla u většiny řádků `NULL` a každý nový tvar by znamenal migraci.

**13 pravidel jako data**, čitelných jedním dotazem:

```
kostka_zdarma      1003  {"scope":"code_contains","effect":"free","codeFragment":"kostka","maxQuantity":1}
tricko_za_bonus    1012  {"scope":"tag_cheapest","effect":"free","tag":"tricko","maxQuantity":1,
                          "thresholdSetting":"freeShirtBonusThreshold"}
jidlo_se_slevou    1004  {"scope":"tag","effect":"fixed_amount","tag":"jidlo",
                          "amountSetting":"organizerMealDiscount"}
```

**Tři typované enumy místo holých stringů.** `DiscountScope`, `DiscountEffect` a `ProductTagCode` pro tagy, `DiscountSetting` pro odkaz na nastavení. Do JSON se ukládá hodnota, ne jméno case — kromě `DiscountSetting`, kde je to naopak schválně (viz níž).

**`DiscountCalculation`** — čistá funkce nad celým košíkem. Bez databáze, bez entity manageru, bez `Uzivatel`: pravidla, práva i získaný bonus dostane zvenčí, takže stejný kód může obsloužit nový košík i legacy `Cenik`, aniž by na sobě záviseli. Její testy zrcadlí charakterizační testy případ po případu se stejnými cenami — nejde o to, že třída funguje, ale že **dává stejná čísla jako to, co má nahradit**.

## Co si při review vzít popořadě

1. **`CenikCharakterizacniTest`** — jestli je špatně tady, je celý zbytek postavený na špatném základu.
2. **`DiscountCalculationTest`** vedle něj — dvojice testů je celý argument, proč je přepis bezpečný.
3. **Migrace `100012`/`100013`** — schéma a seed.
4. Zbytek jsou hodnotové objekty bez volajícího.

## Pozor

- **Nic z toho se zatím nevolá.** Deset commitů, nulová změna chování. To je záměr: riziko je soustředěné do dalšího PR, ne rozprostřené.
- **Migrace obsahuje jen literály** — žádné konstanty, enumy ani validaci přes aplikační kód. Původně tam byly `Pravo::` konstanty a validace přes `DiscountParameters`; obojí je špatně, protože migrace se přehrává na každé čerstvé databázi (tedy při každém běhu testů), takže přejmenování konstanty by shodilo léta starou migraci nad daty, která byla vždycky v pořádku. Pravidlo je nově zapsané v `CLAUDE.md`.
- **`DiscountSetting` ukládá do JSON jméno case (`organizerMealDiscount`), ne klíč nastavení.** Klíč `SLEVA_ORGU_NA_JIDLO_CASTKA` by byl string, který nikdo nekontroluje — po přejmenování konstanty by pravidlo tiše přestalo platit. Case names jsou camelCase schválně, aby si nikdo nemyslel, že se musí shodovat; test to hlídá.
- **Sleva na jídlo a práh bonusu zůstávají v `systemove_nastaveni`.** Zkopírovat čísla by je zmrazilo — admin by změnil nastavení, změnila by se legacy cena a pravidlo ne. Práh navíc čte i `Finance::maximalniPocetBonusovychTricekZdarma()`, což není cenotvorba.
- **Editovatelné jsou jen čísla.** `editableParameters()` je záměrně užší než `requiredParameters()`: změna tagu z `jidlo` na `tricko` pravidlo neladí, dělá z „jídla zdarma" trička zdarma pod původním názvem. Test hlídá, že žádná kombinace scope/effect nenabídne strukturální parametr.
- **Známé omezení do dalšího PR:** `tag_cheapest` (tričko za bonus) se nedá rozhodnout po jedné položce. Dnes to `Cenik` trefuje jen proto, že mu `Finance` posílá nákupy od nejlevnějšího (`ORDER BY nakupy.cena_nakupni`). `DiscountCalculation` si řadí sama, ale při cutoveru přes `Cenik::cena()` (jedna položka na volání) ta závislost na pořadí zůstane — bude to zdokumentované, ne opravené.
- **Práva se čtou z `uzivatele_role`, ne z pohledu `platne_role_uzivatelu`** — ten je definovaný natvrdo proti databázi `gamecon`, takže by pod testovací databází hlásil role vývojáře. Test drží volbu tabulky, protože špatná varianta lokálně projde.

## Ověření

Testy **1181 zeleně** (+62 oproti bázi), PHPStan `[OK] No errors`, ECS čistý. Seed je idempotentní — opakované spuštění nic nezmění (ověřeno otiskem MD5 nad všemi pravidly).

## Kde to naklikat

Tenhle PR nemá klikací plochu — nic se nevolá a nic se nezobrazuje. Ověření je:

```bash
./bin-docker/php ./bin/console dbal:run-sql "SELECT code, required_right, parameters FROM discount_rule WHERE year = 2026 ORDER BY code"
./bin-docker/php ./vendor/bin/phpunit tests/Model/Uzivatel/CenikCharakterizacniTest.php symfony/tests/Discount/
```
