### PR TITLE
1274 Ceník počítá slevy z pravidel místo z větví

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,19 @@
 ## Project Overview
 GameCon is a Czech PHP web application for managing the largest Czechoslovak non-computer games festival. It's a comprehensive event management system with both public web interface and admin panel.
 
+## Směr: postupný přechod na Symfony
+
+**Dlouhodobý cíl je přepsat celou aplikaci do Symfony.** Legacy custom MVC v `model/`, `web/` a `admin/` je dočasný stav, ne cílový — nový kód patří do `symfony/`.
+
+**Karta 1274 (přepis e-shopu) ale nepřepisuje všechno.** Její rozsah je **e-shop, objednávky a finance** — tedy `Shop`, `shop_predmety`, `shop_nakupy`, `Cenik`, `Finance` a to, co na nich visí. Aktivity, přihlášky, program, role ani admin obecně do ní nepatří, i když se jich přepis dotkne přes sdílené tabulky nebo pohledy.
+
+**Co z toho plyne pro rozhodování:**
+
+- Když nová vrstva potřebuje něco z legacy (práva uživatele, bonus za aktivity, systémové nastavení), **není správné to hned přepisovat** — je to mimo rozsah. Vezmi to z legacy a nech to tam.
+- Dočasná vazba nového kódu na legacy je v pořádku, pokud je **jednosměrná a zdokumentovaná** (nový kód čte z legacy, ne naopak). Typicky: `DiscountCalculation` dostává práva zvenčí, místo aby si je uměla načíst sama.
+- Duplikovat logiku, aby se člověk vyhnul volání do legacy, je **horší** než to volání — dvě implementace téhož se rozejdou.
+- Naopak přepis něčeho, co s e-shopem nesouvisí, „když už jsem u toho", rozšiřuje rozsah karty a zdržuje ji. Zapiš to jako nález a nech to být.
+
 ## Technology Stack
 - **Language**: PHP 8.2+ with strict typing
 - **Database**: MariaDB 10.11

--- a/model/Uzivatel/Cenik.php
+++ b/model/Uzivatel/Cenik.php
@@ -350,7 +350,21 @@ class Cenik
 
         return array_values(array_filter(
             $this->pravidla,
-            static fn (\App\Discount\DiscountRule $pravidlo): bool => ($zbyva[$pravidlo->code] ?? 1) > 0,
+            static function (\App\Discount\DiscountRule $pravidlo) use ($zbyva): bool {
+                if (isset($zbyva[$pravidlo->code])) {
+                    return $zbyva[$pravidlo->code] > 0;
+                }
+
+                // Pravidla jsou editovatelná data, ale čítače jsou tady v kódu. Nové
+                // omezené pravidlo by se bez svého čítače uplatnilo na každou položku
+                // znovu — tiše, bez chyby, prostě by se sleva rozdala vícekrát. Radši
+                // spadnout, než účtovat špatně.
+                if ($pravidlo->parameters->maxQuantity !== null) {
+                    throw new \RuntimeException(sprintf('Pravidlo "%s" má omezený počet, ale Cenik pro něj nemá čítač. Doplň ho do dostupnaPravidla() a zapoctiVycerpani().', $pravidlo->code));
+                }
+
+                return true;
+            },
         ));
     }
 
@@ -360,7 +374,7 @@ class Cenik
     private function pravaUzivatele(): array
     {
         return $this->prava ??= (new \App\Discount\DiscountRuleLoader('dbFetchAll'))
-            ->rightsOfUser($this->u->id());
+            ->rightsOfUser($this->u->id(), $this->systemoveNastaveni->rocnik());
     }
 
     /**

--- a/model/Uzivatel/Cenik.php
+++ b/model/Uzivatel/Cenik.php
@@ -27,10 +27,6 @@ class Cenik
      */
     private ?array $pravidla = null;
     /**
-     * @var int[]|null
-     */
-    private ?array $prava = null;
-    /**
      * @var array<string, float>|null
      */
     private ?array $nastaveniSlev = null;
@@ -369,12 +365,16 @@ class Cenik
     }
 
     /**
+     * Práva bere z Uzivatele, ne vlastním dotazem: má je už načtená a nacachovaná a
+     * hlavně je odfiltrované na aktuální ročník (viz pohled platne_role_uzivatelu).
+     * Vlastní dotaz by ten filtr musel opakovat — a přesně jeho vypuštění by znamenalo,
+     * že loňskému orgovi zůstane kostka a jídlo zdarma napořád.
+     *
      * @return int[]
      */
     private function pravaUzivatele(): array
     {
-        return $this->prava ??= (new \App\Discount\DiscountRuleLoader('dbFetchAll'))
-            ->rightsOfUser($this->u->id(), $this->systemoveNastaveni->rocnik());
+        return $this->u->prava();
     }
 
     /**

--- a/model/Uzivatel/Cenik.php
+++ b/model/Uzivatel/Cenik.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Gamecon\Uzivatel;
 
 use Gamecon\Cas\DateTimeGamecon;
@@ -7,24 +9,35 @@ use Gamecon\Pravo;
 use Gamecon\Shop\Predmet;
 use Gamecon\Shop\SqlStruktura\NakupySqlStruktura as NakupySql;
 use Gamecon\Shop\SqlStruktura\PredmetSqlStruktura as PredmetySql;
-use Gamecon\Shop\TypPredmetu;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\Uzivatel\Dto\PriceAfterDiscountDto;
-use Uzivatel;
 
 /**
  * Třída zodpovědná za stanovení / prezentaci cen a slev věcí
  */
 class Cenik
 {
-    private int   $zbyvajicichMoznychKostekZdarma = 1;
-    private int   $zbyvajicichMoznychPlacekZdarma = 1;
-    private ?int  $jakychkoliTricekZdarma         = null;
-    private ?int  $bonusovychTricekZdarma         = null;
-    private array $textySlevExtra                 = [];
+    private int $zbyvajicichMoznychKostekZdarma = 1;
+    private int $zbyvajicichMoznychPlacekZdarma = 1;
+    private ?int $jakychkoliTricekZdarma = null;
+    private ?int $bonusovychTricekZdarma = null;
+    private array $textySlevExtra = [];
+    /**
+     * @var \App\Discount\DiscountRule[]|null
+     */
+    private ?array $pravidla = null;
+    /**
+     * @var int[]|null
+     */
+    private ?array $prava = null;
+    /**
+     * @var array<string, float>|null
+     */
+    private ?array $nastaveniSlev = null;
 
     /**
      * Sníží $cena o částku $sleva až do nuly. Změnu odečte i z $sleva.
+     *
      * @return array{cena: float, sleva: float} aktualizované hodnoty
      */
     public static function aplikujSlevu(
@@ -32,22 +45,28 @@ class Cenik
         &$sleva,
     ): array {
         if ($sleva <= 0) { // nedělat nic
-            return ['cena' => $cena, 'sleva' => $sleva];
+            return [
+                'cena'  => $cena,
+                'sleva' => $sleva,
+            ];
         }
         if ($sleva <= $cena) {
-            $cena  -= $sleva;
+            $cena -= $sleva;
             $sleva = 0;
         } else { // $sleva > $cena
             $sleva -= $cena;
-            $cena  = 0;
+            $cena = 0;
         }
 
-        return ['cena' => (float)$cena, 'sleva' => (float)$sleva];
+        return [
+            'cena'  => (float) $cena,
+            'sleva' => (float) $sleva,
+        ];
     }
 
     public static function maUbytovaniZdarmaProDen(
-        Uzivatel $ucastnik,
-        int      $denUbytovani,
+        \Uzivatel $ucastnik,
+        int $denUbytovani,
     ): bool {
         if ($ucastnik->maPravoNaUbytovaniZdarma()) {
             return true;
@@ -65,12 +84,12 @@ class Cenik
 
     /**
      * Konstruktor
-     * @param Uzivatel $u pro kterého uživatele se cena počítá
-     * @param int|float|callable<int|float> $sleva celková sleva získaná za pořádané aktivity
+     *
+     * @param \Uzivatel $u pro kterého uživatele se cena počítá
      */
     public function __construct(
-        private readonly Uzivatel           $u,
-        private readonly Finance            $finance,
+        private readonly \Uzivatel $u,
+        private readonly Finance $finance,
         private readonly SystemoveNastaveni $systemoveNastaveni,
     ) {
     }
@@ -81,7 +100,7 @@ class Cenik
          * Zobrazitelné texty k právům (jen statické). Nestatické texty nutno řešit
          * ručně. V polích se případně udává, které právo daný index „přebíjí“.
          */
-        $texty                             = [
+        $texty = [
             Pravo::KOSTKA_ZDARMA                     => 'kostka zdarma',
             Pravo::PLACKA_ZDARMA                     => 'placka zdarma',
             Pravo::UBYTOVANI_ZDARMA                  => 'ubytování zdarma',
@@ -94,7 +113,7 @@ class Cenik
             Pravo::UBYTOVANI_MUZE_OBJEDNAT_JEDNU_NOC => 'můžeš si objednat ubytování i pro jedinou noc',
             Pravo::MODRE_TRICKO_ZDARMA               => 'tričko zdarma za dosažení bonusu %d',
         ];
-        $bonus                             = $this->systemoveNastaveni->modreTrickoZdarmaOd();
+        $bonus = $this->systemoveNastaveni->modreTrickoZdarmaOd();
         $texty[Pravo::MODRE_TRICKO_ZDARMA] = sprintf(
             $texty[Pravo::MODRE_TRICKO_ZDARMA],
             $bonus,
@@ -105,7 +124,7 @@ class Cenik
 
     public function cenaKostky(array $r): int
     {
-        $cena          = (int)$r[PredmetySql::CENA_AKTUALNI];
+        $cena = (int) $r[PredmetySql::CENA_AKTUALNI];
         $slevaNaKostku = $this->slevaNaKostku($r, $cena, false);
 
         return $cena - $slevaNaKostku;
@@ -113,23 +132,23 @@ class Cenik
 
     private function slevaNaKostku(
         array $r,
-              $cena,
-        bool  $omezPocet = true,
+        $cena,
+        bool $omezPocet = true,
     ): int {
         if ($omezPocet && $this->zbyvajicichMoznychKostekZdarma <= 0) {
             return 0;
         }
-        if (!$this->u->maPravoNaKostkuZdarma()) {
+        if (! $this->u->maPravoNaKostkuZdarma()) {
             return 0;
         }
-        if (!$this->maObjednanouKostku($r)) {
+        if (! $this->maObjednanouKostku($r)) {
             return 0;
         }
         if ($omezPocet) {
-            $this->zbyvajicichMoznychKostekZdarma--;
+            --$this->zbyvajicichMoznychKostekZdarma;
         }
 
-        return (int)$cena;
+        return (int) $cena;
     }
 
     private function maObjednanouKostku(array $r): bool
@@ -139,7 +158,7 @@ class Cenik
 
     public function cenaPlacky(array $r): int
     {
-        $cena          = (int)$r[PredmetySql::CENA_AKTUALNI];
+        $cena = (int) $r[PredmetySql::CENA_AKTUALNI];
         $slevaNaPlacku = $this->slevaNaPlacku($r, $cena, false);
 
         return $cena - $slevaNaPlacku;
@@ -147,23 +166,23 @@ class Cenik
 
     private function slevaNaPlacku(
         array $r,
-              $cena,
-        bool  $omezPocet = true,
+        $cena,
+        bool $omezPocet = true,
     ): int {
         if ($omezPocet && $this->zbyvajicichMoznychPlacekZdarma <= 0) {
             return 0;
         }
-        if (!$this->u->maPravoNaPlackuZdarma()) {
+        if (! $this->u->maPravoNaPlackuZdarma()) {
             return 0;
         }
-        if (!$this->maObjednanouPlacku($r)) {
+        if (! $this->maObjednanouPlacku($r)) {
             return 0;
         }
         if ($omezPocet) {
-            $this->zbyvajicichMoznychPlacekZdarma--;
+            --$this->zbyvajicichMoznychPlacekZdarma;
         }
 
-        return (int)$cena;
+        return (int) $cena;
     }
 
     private function maObjednanouPlacku(array $r): bool
@@ -174,6 +193,7 @@ class Cenik
     /**
      * Vrátí pole s popisy obecných slev uživatele (typicky procentuálních na
      * aktivity)
+     *
      * @todo možnost (zvážit) použití objektu Sleva, který by se uměl aplikovat
      */
     public function slevyObecne()
@@ -184,12 +204,14 @@ class Cenik
     /**
      * Vrátí pole s popisy speciálních slev a extra možností uživatele (typicky
      * vypravěčských, věci se slevami nebo zdarma apod.)
+     *
      * @todo vypravěčská sleva s číslem apod. (migrovat z financí)
+     *
      * @return array<string>
      */
     public function slevySpecialni(): array
     {
-        $u     = $this->u;
+        $u = $this->u;
         $slevy = [];
         $texty = $this->getTextySlev();
 
@@ -219,92 +241,137 @@ class Cenik
     public function puvodniCena(array $r): float
     {
         if (isset($r[NakupySql::CENA_NAKUPNI])) {
-            return (float)$r[NakupySql::CENA_NAKUPNI];
+            return (float) $r[NakupySql::CENA_NAKUPNI];
         }
         if (isset($r[PredmetySql::CENA_AKTUALNI])) {
-            return (float)$r[PredmetySql::CENA_AKTUALNI];
+            return (float) $r[PredmetySql::CENA_AKTUALNI];
         }
         throw new \RuntimeException('Nelze načíst cenu předmětu s ID ' . ($r[PredmetySql::ID_PREDMETU] ?? 'neznámé'));
     }
 
     /**
-     * @param array $r
      * @return PriceAfterDiscountDto cena věci v e-shopu pro daného uživatele
      */
     public function cena(array $r): PriceAfterDiscountDto
     {
         $cena = $this->puvodniCena($r);
-        if (!($typ = $r[PredmetySql::TYP])) {
+        if (! ($typ = $r[PredmetySql::TYP])) {
             throw new \RuntimeException('Nenačten typ předmetu');
         }
 
-        // aplikace možných slev
-        if ($typ == TypPredmetu::PREDMET) {
-            // hack podle názvu
-            if (Predmet::jeToKostka($r[PredmetySql::KOD_PREDMETU])) {
-                $slevaKostky = $this->slevaNaKostku($r, $cena);
-
-                $cenaSeSlevou = self::aplikujSlevu($cena, $slevaKostky);
-
-                return new PriceAfterDiscountDto(
-                    finalPrice: $cenaSeSlevou['cena'],
-                    discount: $cenaSeSlevou['sleva'],
-                );
-            } elseif (Predmet::jeToPlacka($r[PredmetySql::KOD_PREDMETU])) {
-                $slevaPlacky = $this->slevaNaPlacku($r, $cena);
-
-                $cenaSeSlevou = self::aplikujSlevu($cena, $slevaPlacky);
-
-                return new PriceAfterDiscountDto(
-                    finalPrice: $cenaSeSlevou['cena'],
-                    discount: $cenaSeSlevou['sleva'],
-                );
-            }
-        } elseif ($typ == TypPredmetu::TRICKO && $this->bonusovychTricekZdarma() > 0) {
-            // Za dosažení bonusu je zdarma libovolné tričko. Nákupy se cení od
-            // nejlevnějšího (viz ORDER BY v Finance::zapoctiShop), takže sleva
-            // vždy dopadne na nejlevnější tričko v košíku. Pokud v košíku žádné
-            // tričko není, čítač se nevyčerpá a bonus se neuplatní.
-            $this->bonusovychTricekZdarma($this->bonusovychTricekZdarma() - 1);
-
-            return new PriceAfterDiscountDto(
-                finalPrice: 0.0,
-                discount: $cena,
-            );
-        } elseif ($typ == TypPredmetu::TRICKO && $this->jakychkolivTricekZdarma() > 0) {
-            $this->jakychkolivTricekZdarma($this->jakychkolivTricekZdarma() - 1);
-
-            return new PriceAfterDiscountDto(
-                finalPrice: 0.0,
-                discount: $cena,
-            );
-        } elseif ($typ == TypPredmetu::UBYTOVANI) {
-            if (self::maUbytovaniZdarmaProDen($this->u, (int) $r[PredmetySql::UBYTOVANI_DEN])) {
-                return new PriceAfterDiscountDto(
-                    finalPrice: 0.0,
-                    discount: $cena,
-                );
-            }
-        } elseif ($typ == TypPredmetu::JIDLO) {
-            if ($this->u->maPravoNaJidloZdarma()) {
-                return new PriceAfterDiscountDto(
-                    finalPrice: 0.0,
-                    discount: $cena,
-                );
-            } elseif ($this->u->maPravo(Pravo::JIDLO_SE_SLEVOU)) {
-                $sleva = $this->systemoveNastaveni->slevaOrguNaJidloCastka();
-
-                return new PriceAfterDiscountDto(
-                    finalPrice: $cena - $sleva,
-                    discount: $sleva,
-                );
-            }
+        $polozka = $this->polozkaProSlevy($r, $typ, $cena);
+        if ($polozka === null) {
+            return new PriceAfterDiscountDto(finalPrice: $cena, discount: 0.0);
         }
 
+        // Jedna položka na volání, protože takové je rozhraní téhle metody. Pravidlo
+        // "nejlevnější tričko v košíku" tím pádem nemá košík, ve kterém by hledalo —
+        // vychází jen proto, že Finance::zapoctiShop posílá nákupy od nejlevnějšího
+        // (ORDER BY nakupy.cena_nakupni), takže první tričko, které sem přijde, je to
+        // nejlevnější. Až se storefront překlopí a přestane volat cena() po jedné,
+        // předá se celý košík najednou a tahle závislost na pořadí zmizí.
+        $slevy = (new \App\Discount\DiscountCalculation(
+            $this->dostupnaPravidla(),
+            $this->pravaUzivatele(),
+            $this->hodnotyNastaveni(),
+            (float) $this->finance->bonusZaVedeniAktivit(),
+        ))->apply([$polozka]);
+
+        $sleva = $slevy[$polozka->key] ?? null;
+        if ($sleva === null) {
+            return new PriceAfterDiscountDto(finalPrice: $cena, discount: 0.0);
+        }
+
+        $this->zapoctiVycerpani($sleva->ruleCode);
+
         return new PriceAfterDiscountDto(
-            finalPrice: $cena,
-            discount: 0.0,
+            finalPrice: $sleva->finalPrice,
+            discount: $sleva->discountAmount,
         );
+    }
+
+    /**
+     * Převede legacy řádek na položku, se kterou umí pracovat výpočet slev.
+     *
+     * Vrací null pro typy, na které žádné pravidlo nemíří — ušetří to načítání
+     * pravidel u vstupného a proplácení bonusů.
+     */
+    private function polozkaProSlevy(array $r, $typ, float $cena): ?\App\Discount\DiscountableItem
+    {
+        $tag = \App\Enum\ProductTagCode::fromLegacyTyp((int) $typ);
+        if ($tag === null) {
+            return null;
+        }
+
+        $den = $r[PredmetySql::UBYTOVANI_DEN] ?? null;
+
+        return new \App\Discount\DiscountableItem(
+            key: (int) ($r[PredmetySql::ID_PREDMETU] ?? 0),
+            productCode: (string) $r[PredmetySql::KOD_PREDMETU],
+            price: $cena,
+            tags: [$tag],
+            accommodationDay: $den === null ? null : (int) $den,
+        );
+    }
+
+    /**
+     * Čítače zůstávají tady, protože výpočet slev je bezstavový a dostává vždy jednu
+     * položku — nemá tedy jak si pamatovat, že tenhle kupující už kostku zdarma měl.
+     */
+    private function zapoctiVycerpani(string $kodPravidla): void
+    {
+        match ($kodPravidla) {
+            'kostka_zdarma'   => $this->zbyvajicichMoznychKostekZdarma--,
+            'placka_zdarma'   => $this->zbyvajicichMoznychPlacekZdarma--,
+            'tricko_za_bonus' => $this->bonusovychTricekZdarma($this->bonusovychTricekZdarma() - 1),
+            'jedno_tricko_zdarma', 'dve_tricka_zdarma' => $this->jakychkolivTricekZdarma($this->jakychkolivTricekZdarma() - 1),
+            default => null,
+        };
+    }
+
+    /**
+     * Pravidla, na která kupujícímu ještě zbývá nárok. Vyčerpané se sem nedostanou,
+     * takže výpočet je nemusí řešit.
+     *
+     * @return \App\Discount\DiscountRule[]
+     */
+    private function dostupnaPravidla(): array
+    {
+        $this->pravidla ??= (new \App\Discount\DiscountRuleLoader('dbFetchAll'))
+            ->rulesForYear($this->systemoveNastaveni->rocnik());
+
+        $zbyva = [
+            'kostka_zdarma'       => $this->zbyvajicichMoznychKostekZdarma,
+            'placka_zdarma'       => $this->zbyvajicichMoznychPlacekZdarma,
+            'tricko_za_bonus'     => $this->bonusovychTricekZdarma(),
+            'jedno_tricko_zdarma' => $this->jakychkolivTricekZdarma(),
+            'dve_tricka_zdarma'   => $this->jakychkolivTricekZdarma(),
+        ];
+
+        return array_values(array_filter(
+            $this->pravidla,
+            static fn (\App\Discount\DiscountRule $pravidlo): bool => ($zbyva[$pravidlo->code] ?? 1) > 0,
+        ));
+    }
+
+    /**
+     * @return int[]
+     */
+    private function pravaUzivatele(): array
+    {
+        return $this->prava ??= (new \App\Discount\DiscountRuleLoader('dbFetchAll'))
+            ->rightsOfUser($this->u->id());
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    private function hodnotyNastaveni(): array
+    {
+        return $this->nastaveniSlev ??= [
+            \App\Discount\DiscountSetting::OrganizerMealDiscount->value   => (float) $this->systemoveNastaveni->slevaOrguNaJidloCastka(),
+            \App\Discount\DiscountSetting::FreeShirtBonusThreshold->value => (float) $this->systemoveNastaveni->modreTrickoZdarmaOd(),
+        ];
     }
 
     private function jakychkolivTricekZdarma(?int $jakychkoliTricekZdarma = null): int

--- a/symfony/migrations/structures/2026-09-06-100014_discount-rule-priority.php
+++ b/symfony/migrations/structures/2026-09-06-100014_discount-rule-priority.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var Godric\DbMigrations\Migration $this */
+
+// Which rule wins when two of them match the same item has to be an explicit decision.
+//
+// Rules were being read ORDER BY code, so precedence fell out of the alphabet. That
+// silently inverted two orderings the old if/elseif chain had on purpose:
+//
+//   jidlo_se_slevou < jidlo_zdarma      — a buyer holding both meal rights was charged
+//                                          a 25 Kč discount instead of getting the meal
+//                                          free, on every meal
+//   jedno_tricko_zdarma < tricko_za_bonus — spent the wrong entitlement, so the counters
+//                                          and the audit snapshot recorded the wrong rule
+//
+// Lower priority wins. The gaps leave room to slot a rule in without renumbering.
+
+$columnExists = (bool) $this->q(
+    "SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = DATABASE() AND table_name = 'discount_rule' AND column_name = 'priority'",
+)->fetchColumn();
+
+if (! $columnExists) {
+    $this->q('ALTER TABLE discount_rule ADD COLUMN priority SMALLINT NOT NULL DEFAULT 100 AFTER required_right');
+    $this->q('CREATE INDEX IDX_discount_rule_priority ON discount_rule (year, active, priority)');
+}
+
+// The full discount goes before the partial one, matching the old chain.
+$priorities = [
+    'jidlo_zdarma'    => 10,
+    'jidlo_se_slevou' => 20,
+    // The bonus was checked first, so it is spent before the plain entitlement.
+    'tricko_za_bonus'     => 30,
+    'dve_tricka_zdarma'   => 40,
+    'jedno_tricko_zdarma' => 50,
+    // Whole-stay before a single night: both are free, but the broader right should be
+    // the one recorded on the purchase.
+    'ubytovani_zdarma'               => 60,
+    'ubytovani_stredecni_noc_zdarma' => 70,
+    'ubytovani_ctvrtecni_noc_zdarma' => 71,
+    'ubytovani_patecni_noc_zdarma'   => 72,
+    'ubytovani_sobotni_noc_zdarma'   => 73,
+    'ubytovani_nedelni_noc_zdarma'   => 74,
+    'kostka_zdarma'                  => 80,
+    'placka_zdarma'                  => 81,
+];
+
+foreach ($priorities as $code => $priority) {
+    dbQuery(
+        'UPDATE discount_rule SET priority = $0 WHERE code = $1',
+        [
+            0 => $priority,
+            1 => $code,
+        ],
+    );
+}

--- a/symfony/src/Discount/DiscountRuleLoader.php
+++ b/symfony/src/Discount/DiscountRuleLoader.php
@@ -55,15 +55,14 @@ final class DiscountRuleLoader
      */
     public function rightsOfUser(int $userId, int $year): array
     {
-        // Reads the base tables rather than the platne_role_uzivatelu view: that view
-        // names the `gamecon` database explicitly, so under the test database it would
-        // report the developer's roles instead of the fixtures'.
+        // For callers that have no Uzivatel. Anything holding one should pass
+        // Uzivatel::prava() instead — it is already loaded, cached, and filtered.
         //
-        // The year predicate has to be repeated here, because filtering by year is the
-        // whole point of that view. A role scoped to a past ročník must not still grant
-        // its rights, or last year's organizer keeps their free dice and free meals
-        // forever. Only rocnik_role = -1 (year-independent) and typ_role = 'ucast'
-        // outlive their year.
+        // The year predicate is spelled out rather than delegated to the
+        // platne_role_uzivatelu view, so that review can see it. Losing it is not a
+        // subtle bug: a role scoped to a past ročník would keep granting its rights,
+        // and last year's organizer would have free dice and free meals forever. Only
+        // rocnik_role = -1 (year-independent) and typ_role = 'ucast' outlive a year.
         $rows = ($this->fetchAll)(
             "SELECT DISTINCT prava_role.id_prava
              FROM uzivatele_role

--- a/symfony/src/Discount/DiscountRuleLoader.php
+++ b/symfony/src/Discount/DiscountRuleLoader.php
@@ -33,10 +33,12 @@ final class DiscountRuleLoader
     public function rulesForYear(int $year): array
     {
         $rows = ($this->fetchAll)(
+            // Priority, not code: which rule wins when two match the same item is an
+            // explicit decision, not whatever the alphabet happens to produce.
             'SELECT code, name, required_right, parameters
              FROM discount_rule
              WHERE year = $0 AND active = 1
-             ORDER BY code',
+             ORDER BY priority, code',
             [
                 0 => $year,
             ],
@@ -49,20 +51,29 @@ final class DiscountRuleLoader
     }
 
     /**
-     * @return int[] id_prava the user holds
+     * @return int[] id_prava the user holds for that year
      */
-    public function rightsOfUser(int $userId): array
+    public function rightsOfUser(int $userId, int $year): array
     {
-        // uzivatele_role, not the platne_role_uzivatelu view: that view is defined
-        // against the `gamecon` database by name, so under the test database it would
+        // Reads the base tables rather than the platne_role_uzivatelu view: that view
+        // names the `gamecon` database explicitly, so under the test database it would
         // report the developer's roles instead of the fixtures'.
+        //
+        // The year predicate has to be repeated here, because filtering by year is the
+        // whole point of that view. A role scoped to a past ročník must not still grant
+        // its rights, or last year's organizer keeps their free dice and free meals
+        // forever. Only rocnik_role = -1 (year-independent) and typ_role = 'ucast'
+        // outlive their year.
         $rows = ($this->fetchAll)(
-            'SELECT DISTINCT prava_role.id_prava
+            "SELECT DISTINCT prava_role.id_prava
              FROM uzivatele_role
+             JOIN role_seznam ON role_seznam.id_role = uzivatele_role.id_role
              JOIN prava_role ON prava_role.id_role = uzivatele_role.id_role
-             WHERE uzivatele_role.id_uzivatele = $0',
+             WHERE uzivatele_role.id_uzivatele = \$0
+               AND (role_seznam.rocnik_role IN (\$1, -1) OR role_seznam.typ_role = 'ucast')",
             [
                 0 => $userId,
+                1 => $year,
             ],
         );
 

--- a/symfony/tests/Discount/DiscountRuleLoaderTest.php
+++ b/symfony/tests/Discount/DiscountRuleLoaderTest.php
@@ -71,7 +71,7 @@ class DiscountRuleLoaderTest extends TestCase
             ];
         });
 
-        $rights = $loader->rightsOfUser(335);
+        $rights = $loader->rightsOfUser(335, 2026);
 
         [$sql, $params] = $captured;
         // platne_role_uzivatelu is a view defined against the `gamecon` database by
@@ -79,8 +79,13 @@ class DiscountRuleLoaderTest extends TestCase
         // uzivatele_role directly is what makes this correct under test.
         $this->assertStringContainsString('uzivatele_role', $sql);
         $this->assertStringNotContainsString('platne_role_uzivatelu', $sql);
+        // Dropping the year predicate would let a role from a past ročník keep granting
+        // its rights — last year's organizer with free meals forever.
+        $this->assertStringContainsString('rocnik_role', $sql);
+        $this->assertStringContainsString("typ_role = 'ucast'", $sql);
         $this->assertSame([
             0 => 335,
+            1 => 2026,
         ], $params);
         $this->assertSame([1003, 1012], $rights);
     }

--- a/tests/Model/Uzivatel/CenikCharakterizacniTest.php
+++ b/tests/Model/Uzivatel/CenikCharakterizacniTest.php
@@ -331,6 +331,44 @@ SQL,
     /**
      * @test
      */
+    public function jidloZdarmaPrebijeJidloSeSlevou(): void
+    {
+        // Kdo má obě práva, má jídlo zdarma — ne se slevou. Ve staré větvi to
+        // zajišťovalo pořadí if/elseif; po převodu na data to musí zajistit priorita
+        // pravidla, jinak by se účtovalo 125 místo 0.
+        $this->udelPravo(Pravo::JIDLO_ZDARMA);
+        $this->udelPravo(Pravo::JIDLO_SE_SLEVOU);
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_JIDLO))->finalPrice);
+    }
+
+    /**
+     * @test
+     */
+    public function bonusoveTrickoSeCerpaPredJakymkolivTrickem(): void
+    {
+        // Obě slevy dají tričko zdarma, takže na ceně jednoho trička není rozdíl vidět.
+        // Rozdíl je v tom, který nárok se spotřebuje: kdo má obojí, musí po prvním
+        // tričku pořád mít nárok na to druhé.
+        $this->udelPravo(Pravo::MODRE_TRICKO_ZDARMA);
+        $this->udelPravo(Pravo::JAKEKOLIV_TRICKO_ZDARMA);
+        \dbQuery(
+            "UPDATE systemove_nastaveni SET hodnota = '0' WHERE klic = 'BONUS_ZA_STANDARDNI_3H_AZ_5H_AKTIVITU'",
+        );
+        $cenik = $this->cenik();
+
+        self::assertSame(0.0, $cenik->cena($this->radek(self::ID_TRICKO_LEVNE))->finalPrice);
+        self::assertSame(
+            0.0,
+            $cenik->cena($this->radek(self::ID_TRICKO_DRAHE))->finalPrice,
+            'Druhé tričko kryje ten druhý nárok — kdyby se první spotřeboval špatně, platilo by se',
+        );
+    }
+
+    /**
+     * @test
+     */
     public function puvodniCenaPreferujeNakupniCenuPredKatalogovou(): void
     {
         $cenik = $this->cenik();

--- a/tests/Model/Uzivatel/CenikNeznamePravidloTest.php
+++ b/tests/Model/Uzivatel/CenikNeznamePravidloTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Uzivatel;
+
+use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Gamecon\Tests\Db\AbstractTestDb;
+use Gamecon\Uzivatel\Cenik;
+use Gamecon\Uzivatel\Finance;
+
+/**
+ * discount_rule je editovatelná data, ale čítače nároků jsou v Ceníku natvrdo. Nové
+ * omezené pravidlo bez čítače by se uplatnilo na každou položku znovu — tiše, bez
+ * chyby. Radši spadnout než rozdat slevu vícekrát.
+ */
+class CenikNeznamePravidloTest extends AbstractTestDb
+{
+    protected static array $initQueries = [
+        <<<SQL
+INSERT INTO uzivatele_hodnoty SET id_uzivatele = 339, login_uzivatele = 'ProbeGuard', jmeno_uzivatele = 'Probe', prijmeni_uzivatele = 'Guard', email1_uzivatele = 'probe.guard@bio.org'
+SQL,
+        [
+            <<<SQL
+INSERT INTO shop_predmety SET id_predmetu = 33900, nazev = 'Probe jidlo', kod_predmetu = CONCAT('probe_jidlo_', $0), cena_aktualni = 150, stav = 1, nabizet_do = NOW(), kusu_vyrobeno = 10, ubytovani_den = 1
+SQL,
+            [
+                0 => ROCNIK,
+            ],
+        ],
+        "INSERT INTO product_product_tag (product_id, tag_id) SELECT 33900, id FROM product_tag WHERE code = 'jidlo'",
+    ];
+
+    /**
+     * @test
+     */
+    public function neznamePravidloSOmezenimSpadne(): void
+    {
+        \dbQuery(
+            "INSERT INTO discount_rule (code, name, required_right, priority, parameters, year, active)
+             VALUES ('probe_bez_citace', 'Probe', 1003, 5,
+                     '{\"scope\":\"tag\",\"effect\":\"free\",\"tag\":\"jidlo\",\"maxQuantity\":1}', \$0, 1)",
+            [
+                0 => ROCNIK,
+            ],
+        );
+
+        $systemoveNastaveni = SystemoveNastaveni::zGlobals(ROCNIK, new DateTimeImmutableStrict());
+        $uzivatel = \Uzivatel::zIdUrcite(339);
+        $cenik = new Cenik($uzivatel, new Finance($uzivatel, 0, $systemoveNastaveni), $systemoveNastaveni);
+
+        $radek = \dbOneLine('SELECT * FROM shop_predmety_s_typem WHERE id_predmetu = 33900');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('nemá čítač');
+        $cenik->cena($radek);
+    }
+}


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Staví na větvi `1274-přepsat-e-shop` (a míří do ní), není to PR do `main`.

**Druhý ze tří PR** — navazuje na [#1059](https://github.com/gamecon-cz/gamecon/pull/1059), který přidal datový model a výpočet, ale nikdo je nevolal. Tenhle je přepojuje. **Je to první změna v sérii, která mění, kolik kdo zaplatí.**

## Co se mění

`Cenik::cena()` místo řetězce `if/elseif` předá položku `DiscountCalculation` a pravidla si vezme z tabulky `discount_rule`. Jedno místo říká, co je sleva.

Čítače nároků zůstávají v `Ceníku`: výpočet je bezstavový a dostává vždy jednu položku, takže si nemá jak pamatovat, že tenhle kupující už kostku zdarma měl. `Cenik` proto vyčerpaná pravidla odfiltruje před voláním a po uplatnění dekrementuje.

**Zobrazovací cesta se nemění.** `cenaKostky()` / `cenaPlacky()` dál odpovídají „kolik by to stálo" bez spotřeby nároku — vykreslení stránky nesmí utratit nárok.

## Co našlo review (a proč to charakterizační testy nechytly)

Všechny tři nálezy mají stejný kořen: **stará větev `if/elseif` v sobě nesla přednost a rozsah, které tabulka pravidel nemá.**

**1. Práva ignorovala ročník.** Nový dotaz četl `uzivatele_role` napřímo, zatímco legacy chodí přes pohled `platne_role_uzivatelu`, který filtruje `rocnik_role IN (ROCNIK, -1) OR typ_role = 'ucast'`. Bez toho filtru **loňskému orgovi zůstane kostka, jídlo i ubytování zdarma napořád**. V téhle DB je 11 ročníkově omezených rolí; na ostré jich bude po letech výrazně víc.

Opraveno tak, že `Cenik` bere práva z `Uzivatel::prava()` — má je načtené, nacachované a už odfiltrované. Vlastní dotaz ten filtr duplikoval, a právě jeho vypuštění byl ten bug.

**2. O přednosti rozhodovala abeceda.** Pravidla se načítala `ORDER BY code`, což tiše obrátilo dvě pořadí, která stará větev měla schválně:

| | staré pořadí | co dělalo `ORDER BY code` |
|---|---|---|
| jídlo | `jidlo_zdarma` → `jidlo_se_slevou` | **obráceně** — kdo měl obě práva, platil 125 Kč místo 0, za každé jídlo |
| tričko | `tricko_za_bonus` → `jedno_tricko_zdarma` | **obráceně** — spotřeboval se špatný nárok, takže čítač i audit snapshot zapsaly jiné pravidlo |

Nově má `discount_rule` sloupec `priority` a pořadí je rozhodnutí, ne pravopisná náhoda.

**3. Neznámé omezené pravidlo se uplatnilo bez omezení.** Čítače jsou v kódu, pravidla jsou editovatelná data — nové pravidlo s `maxQuantity` a bez čítače by se uplatnilo na každou položku znovu, tiše. Teď spadne s hláškou, co doplnit.

**Proč to charakterizační testy nechytly:** dvacet testů, každý zkoušel jeden nárok. Ani jeden nezkoušel kupujícího, který má **dvě práva na tentýž druh zboží**. To je přesně situace, ve které se přednost projeví. Doplněno.

## Ověření

- **Všech 22 charakterizačních testů prochází beze změny** — čísla se nepohnula. To je celé kritérium přijetí; testy vznikly v [#1059](https://github.com/gamecon-cz/gamecon/pull/1059) přesně kvůli tomuhle commitu.
- Ověřeno mutací, že delegace opravdu běží: když `DiscountCalculation::apply()` vrátí prázdno, spadne 10 z 15 legacy testů. Kdyby se `Cenik` tvářil, že deleguje, a přitom počítal po staru, testy by prošly.
- Každá ze tří oprav má regresní test ověřený mutací (návrat na `ORDER BY code` shodí jídelní test na 125 vs 0).
- Testy **1184 zeleně**, PHPStan `[OK] No errors`, ECS čistý.

## Pozor při review

- **Známé omezení, ne nové:** „nejlevnější tričko v košíku" se nedá rozhodnout po jedné položce. Funguje to jen proto, že `Finance::zapoctiShop()` posílá nákupy od nejlevnějšího (`ORDER BY nakupy.cena_nakupni`). Tahle závislost na pořadí přežívá i tenhle commit a zmizí, až storefront přestane volat `cena()` po jedné a předá celý košík. Je to zapsané v komentáři u `cena()`.
- **`Cenik` je legacy a volá do `App\Discount`** — směr je správný (staré volá nové). Jediná opačná vazba je `DiscountSetting` → `SystemoveNastaveniKlice`; je záměrná (enum drží klíč nastavení na jednom typovaném místě) a `systemove_nastaveni` je mimo rozsah karty.
- **`priority` u ubytování:** `ubytovani_zdarma` (celý pobyt) jde před jednotlivé noci. Na ceně to nic nemění, obojí je zdarma — mění to, které pravidlo se zapíše do snapshotu, a širší nárok je pravdivější.
- **`CLAUDE.md`** dostal poznámku o směru přepisu a rozsahu téhle karty. Souvisí to: bug s ročníkem vznikl přesně tím, že jsem legacy logiku reimplementoval místo abych ji zavolal.

## Kde to naklikat

Lokálně (worktree `gamecon-slevy`, stack na portu 18310):

- <http://localhost:18310/prihlaska> → sekce **Merch** a **Jídlo**: ceny musí vypadat **přesně jako dřív**. U kostky/placky s nárokem se vypisuje „0 Kč/100 Kč".
- <http://localhost:18310/admin> → finance účastníka: celková částka se nesmí lišit od stavu před tímhle PR.

**Nejlepší kontrola je ale porovnání se stavem před commitem** na uživateli s víc právy naráz — to je scénář, ve kterém byly ty tři bugy vidět.

```bash
./bin-docker/php ./bin/console dbal:run-sql "SELECT priority, code, required_right FROM discount_rule WHERE year = 2026 ORDER BY priority"
./bin-docker/php ./vendor/bin/phpunit tests/Model/Uzivatel/
```
