### PR TITLE
1274 Product state as an enum

### DIFF
--- a/model/Shop/StavPredmetu.php
+++ b/model/Shop/StavPredmetu.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Gamecon\Shop;
 
+use App\Enum\ProductStateEnum;
+
+/**
+ * @deprecated Use App\Enum\ProductStateEnum. Kept so legacy call sites that compare
+ *             against the raw int from `shop_predmety`.`stav` keep working; the values
+ *             come from the enum, so the two cannot drift apart.
+ */
 class StavPredmetu
 {
-    public const MIMO        = 0;
-    public const VEREJNY     = 1;
-    public const PODPULTOVY  = 2;
-    public const POZASTAVENY = 3;
+    public const MIMO        = ProductStateEnum::RETIRED->value;
+    public const VEREJNY     = ProductStateEnum::PUBLIC->value;
+    public const PODPULTOVY  = ProductStateEnum::RESTRICTED->value;
+    public const POZASTAVENY = ProductStateEnum::SUSPENDED->value;
 }

--- a/symfony/src/Entity/Product.php
+++ b/symfony/src/Entity/Product.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use App\Enum\ProductStateEnum;
 use App\Enum\ProductTagCode;
 use App\Repository\ProductRepository;
 use App\Validator as AppAssert;
@@ -504,34 +505,24 @@ class Product
             return false;
         }
 
-        // State: 0=MIMO, 1=VEŘEJNÝ, 2=PODPULTOVÝ, 3=POZASTAVENÝ
-        if ($this->state === 0) {
+        if ($this->getStateEnum() === ProductStateEnum::RETIRED) {
             return false;
         }
 
-        // Check time-based availability
         return ! ($this->availableUntil instanceof \DateTimeImmutable && $this->availableUntil < new \DateTime());
     }
 
-    /**
-     * Check if product is publicly available (state=1)
-     */
     public function isPublic(): bool
     {
-        return $this->isAvailable() && $this->state === 1;
+        return $this->isAvailable() && $this->getStateEnum() === ProductStateEnum::PUBLIC;
     }
 
     /**
-     * Get human-readable state name
+     * Null rather than an exception: `stav` is a plain int column with no foreign key, so
+     * a value outside the four known states is bad data to report, not a crash.
      */
-    public function getStateName(): string
+    public function getStateEnum(): ?ProductStateEnum
     {
-        return match ($this->state) {
-            0       => 'Mimo',
-            1       => 'Veřejný',
-            2       => 'Podpultový',
-            3       => 'Pozastavený',
-            default => 'Neznámý',
-        };
+        return ProductStateEnum::tryFrom($this->state);
     }
 }

--- a/symfony/src/Enum/ProductStateEnum.php
+++ b/symfony/src/Enum/ProductStateEnum.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * Values of shop_predmety.stav. There is no lookup table and no foreign key, so the set
+ * is closed — nothing outside the code can add a state.
+ *
+ * The column comment still names the original Czech states ('0-mimo, 1-veřejný,
+ * 2-podpultový, 3-pozastavený'); the cases here are named for what the shop actually
+ * does with each value, which has drifted from those labels.
+ *
+ * Supersedes Gamecon\Shop\StavPredmetu.
+ */
+enum ProductStateEnum: int
+{
+    /**
+     * Off the catalogue. The shop's query is `stav > RETIRED OR` an existing purchase, so
+     * it is gone for everyone except the people who already bought one, whose orders and
+     * reports keep working.
+     */
+    case RETIRED = 0;
+
+    /** The only state that is on sale by default. */
+    case PUBLIC = 1;
+
+    /**
+     * On sale only to customers holding the right Pravo — blue and red t-shirts. The entry
+     * fee reuses the value for a second meaning: the payment is not late yet.
+     */
+    case RESTRICTED = 2;
+
+    /**
+     * Sale is locked, but the product stays listed and stays visible to those who already
+     * bought it. A product whose `nabizet_do` has passed is treated as this, and the
+     * `jidloBezZamku` / `ubytovaniBezZamku` settings unlock it again.
+     */
+    case SUSPENDED = 3;
+}

--- a/symfony/src/Repository/ProductRepository.php
+++ b/symfony/src/Repository/ProductRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Product;
+use App\Enum\ProductStateEnum;
 use App\Enum\ProductTagCode;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -105,9 +106,10 @@ class ProductRepository extends ServiceEntityRepository
         $now = new \DateTime();
 
         return $this->createQueryBuilder('product')
-            ->where('product.state = 1')
+            ->where('product.state = :publicState')
             ->andWhere('product.archivedAt IS NULL')
             ->andWhere('product.availableUntil IS NULL OR product.availableUntil > :now')
+            ->setParameter('publicState', ProductStateEnum::PUBLIC->value)
             ->setParameter('now', $now)
             ->orderBy('product.name', 'ASC')
             ->getQuery()

--- a/symfony/src/Service/EntryFeeService.php
+++ b/symfony/src/Service/EntryFeeService.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
  * prices come from the product.
  *
  * A second product for payments made late ("pozdě" in the name) is no longer offered — it sits at
- * StavPredmetu::MIMO and was last charged in 2022 — so nothing here writes to it, the same as for
+ * ProductStateEnum::RETIRED and was last charged in 2022 — so nothing here writes to it, the same as for
  * any other discontinued product. Purchases people already made keep their values and keep counting
  * towards their total; only this year's product is ever written.
  */

--- a/symfony/tests/Entity/ProductTest.php
+++ b/symfony/tests/Entity/ProductTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Entity;
 
 use App\Entity\Product;
 use App\Entity\ProductTag;
+use App\Enum\ProductStateEnum;
 use PHPUnit\Framework\TestCase;
 
 class ProductTest extends TestCase
@@ -137,18 +138,24 @@ class ProductTest extends TestCase
         $this->assertFalse($this->product->isPublic());
     }
 
-    public function testGetStateName(): void
+    public function testGetStateEnum(): void
     {
         $this->product->setState(0);
-        $this->assertSame('Mimo', $this->product->getStateName());
+        $this->assertSame(ProductStateEnum::RETIRED, $this->product->getStateEnum());
 
         $this->product->setState(1);
-        $this->assertSame('Veřejný', $this->product->getStateName());
+        $this->assertSame(ProductStateEnum::PUBLIC, $this->product->getStateEnum());
 
         $this->product->setState(2);
-        $this->assertSame('Podpultový', $this->product->getStateName());
+        $this->assertSame(ProductStateEnum::RESTRICTED, $this->product->getStateEnum());
 
         $this->product->setState(3);
-        $this->assertSame('Pozastavený', $this->product->getStateName());
+        $this->assertSame(ProductStateEnum::SUSPENDED, $this->product->getStateEnum());
+    }
+
+    public function testGetStateEnumIsNullForAValueOutsideTheKnownStates(): void
+    {
+        $this->product->setState(9);
+        $this->assertNull($this->product->getStateEnum());
     }
 }


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Built on `1274-přepsat-e-shop` (and targets it), not a PR into `main`.

Preparation for the merch storefront section, which needs to ask "is this product on sale?" and found no vocabulary for it.

## Why

`shop_predmety`.`stav` had no enum on the Symfony side. `ProductRepository::findPublic()` compared against a bare `1`, and `Product` compared against `0`/`1`/`2`/`3` under a hand-written comment restating what the values mean:

```php
// State: 0=MIMO, 1=VEŘEJNÝ, 2=PODPULTOVÝ, 3=POZASTAVENÝ
if ($this->state === 0) {
```

So every new caller had to invent its own constant — which is exactly what happened while writing the merch provider.

## What changed

`App\Enum\ProductStateEnum` (int-backed, four cases) is now the single definition. `Gamecon\Shop\StavPredmetu` stays as a `@deprecated` alias whose constants read from the enum, so the ~40 legacy call sites in `model/` and `tests/` keep comparing the raw int and the two definitions cannot drift apart.

The states are a closed set: the column is `tinyint(4) NOT NULL COMMENT '0-mimo, 1-veřejný, 2-podpultový, 3-pozastavený'`, with no lookup table and no foreign key, so nothing outside the code can add one.

The cases are named for what the shop **does** with each value, not translated from the Czech labels — those have drifted from the behaviour. Each was checked against `model/Shop/Shop.php`:

| Value | Case | Why that name |
|---|---|---|
| 0 | `RETIRED` | Off the catalogue: the query is `stav > 0 OR` an existing purchase, so buyers keep theirs. Not "outside" |
| 1 | `PUBLIC` | The only state that is on sale by default |
| 2 | `RESTRICTED` | Not hidden but permission-gated — blue/red t-shirts unlock via a `Pravo`. The entry fee reuses the value to mean "not late yet" |
| 3 | `SUSPENDED` | Sale locked, product still listed and still visible to owners. An expired `nabizet_do` becomes this; `jidloBezZamku` / `ubytovaniBezZamku` unlock it |

The enum carries no display strings. `Product::getStateName()`, which returned Czech labels straight out of the entity, is gone — it had no production caller, only a test written for it. When a state has to be shown to a user, that belongs in a service or a translation catalogue, not in an entity or an enum.

## Behaviour is unchanged

Values are still `0,1,2,3` through the alias and `=== 1` still holds, so legacy comparisons are untouched. The riskiest shape — `Shop::STAV_* = StavPredmetu::*`, a const-to-const chain evaluated at compile time — resolves correctly, as do default parameter values in tests.

`Product::getStateEnum()` uses `tryFrom()` and returns null for a value outside the four states: `stav` is a plain int column with no foreign key, so bad data stays reportable instead of throwing.

## How to verify

No clickable surface — types and constants only.

```bash
./bin-docker/php ./vendor/bin/phpunit symfony/tests/Entity/ProductTest.php   # covers all four states + an unknown one
./bin-docker/docker-bash bin/phpstan.sh
./bin-docker/docker-bash bin/ecs.sh --fix
```
