### PR TITLE
1274 Map product state as a Doctrine enum

### DIFF
--- a/model/Shop/EshopImporter.php
+++ b/model/Shop/EshopImporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Gamecon\Shop;
 
+use App\Enum\ProductStateEnum;
 use OpenSpout\Reader\XLSX\Reader as XLSXReader;
 
 class EshopImporter
@@ -114,11 +115,25 @@ class EshopImporter
                 }
                 $tagsByKodPredmetu[$kodPredmetu] = $tag;
 
+                $stav = (string) ($radek[$indexStav] ?? '');
+                // Checked as a string, not cast: (int) would turn an empty cell or "abc"
+                // into 0 and silently import the product as RETIRED.
+                if (!ctype_digit($stav) || ProductStateEnum::tryFrom((int) $stav) === null) {
+                    $chyby[] = sprintf(
+                        'Na řádku %d je neplatný stav "%s" v %d. sloupci, povolené jsou %s',
+                        $poradiRadku,
+                        $stav,
+                        $indexStav + 1,
+                        implode(', ', array_column(ProductStateEnum::cases(), 'value')),
+                    );
+                    continue;
+                }
+
                 $sqlValuesArray[] = '(' . dbQa([
                         $radek[$indexNazev],
                         $kodPredmetu,
                         $radek[$indexCenaAktualni],
-                        $radek[$indexStav],
+                        (int) $stav,
                         $radek[$indexNabizetDo],
                         $cisloNeboNull($radek[$indexKusuVyrobeno]),
                         $cisloNeboNull($radek[$indexUbytovaniDen]),

--- a/symfony/src/Entity/Product.php
+++ b/symfony/src/Entity/Product.php
@@ -109,13 +109,9 @@ class Product
     #[Groups(['product:list', 'product:read', 'product:write'])]
     private string $currentPrice;
 
-    #[ORM\Column(name: 'stav', type: Types::SMALLINT, nullable: false)]
-    #[Assert\Choice(
-        choices: [0, 1, 2, 3],
-        message: 'Neplatný stav (0=MIMO, 1=VEŘEJNÝ, 2=PODPULTOVÝ, 3=POZASTAVENÝ)'
-    )]
+    #[ORM\Column(name: 'stav', type: Types::SMALLINT, nullable: false, enumType: ProductStateEnum::class)]
     #[Groups(['product:list', 'product:read', 'product:write'])]
-    private int $state;
+    private ProductStateEnum $state;
 
     #[ORM\Column(name: 'nabizet_do', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     #[Groups(['product:read', 'product:write'])]
@@ -241,12 +237,12 @@ class Product
         return $this;
     }
 
-    public function getState(): int
+    public function getState(): ProductStateEnum
     {
         return $this->state;
     }
 
-    public function setState(int $state): self
+    public function setState(ProductStateEnum $state): self
     {
         $this->state = $state;
 
@@ -496,16 +492,13 @@ class Product
         return $this->hasTag(ProductTagCode::UBYTOVANI->value);
     }
 
-    /**
-     * Check if product is available (not archived, state is public/private)
-     */
     public function isAvailable(): bool
     {
         if ($this->isArchived()) {
             return false;
         }
 
-        if ($this->getStateEnum() === ProductStateEnum::RETIRED) {
+        if ($this->state === ProductStateEnum::RETIRED) {
             return false;
         }
 
@@ -514,15 +507,6 @@ class Product
 
     public function isPublic(): bool
     {
-        return $this->isAvailable() && $this->getStateEnum() === ProductStateEnum::PUBLIC;
-    }
-
-    /**
-     * Null rather than an exception: `stav` is a plain int column with no foreign key, so
-     * a value outside the four known states is bad data to report, not a crash.
-     */
-    public function getStateEnum(): ?ProductStateEnum
-    {
-        return ProductStateEnum::tryFrom($this->state);
+        return $this->isAvailable() && $this->state === ProductStateEnum::PUBLIC;
     }
 }

--- a/symfony/src/Repository/ProductRepository.php
+++ b/symfony/src/Repository/ProductRepository.php
@@ -85,7 +85,7 @@ class ProductRepository extends ServiceEntityRepository
      *
      * @return Product[]
      */
-    public function findByState(int $state): array
+    public function findByState(ProductStateEnum $state): array
     {
         return $this->createQueryBuilder('product')
             ->where('product.state = :state')
@@ -109,7 +109,7 @@ class ProductRepository extends ServiceEntityRepository
             ->where('product.state = :publicState')
             ->andWhere('product.archivedAt IS NULL')
             ->andWhere('product.availableUntil IS NULL OR product.availableUntil > :now')
-            ->setParameter('publicState', ProductStateEnum::PUBLIC->value)
+            ->setParameter('publicState', ProductStateEnum::PUBLIC)
             ->setParameter('now', $now)
             ->orderBy('product.name', 'ASC')
             ->getQuery()

--- a/symfony/src/Service/ProductService.php
+++ b/symfony/src/Service/ProductService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\Product;
 use App\Entity\ProductVariant;
 use App\Entity\User;
+use App\Enum\ProductStateEnum;
 use App\Enum\ProductTagCode;
 use App\Enum\RoleMeaning;
 use App\Repository\ProductRepository;
@@ -44,7 +45,7 @@ class ProductService
         string $name,
         string $code,
         string $price,
-        int $state,
+        ProductStateEnum $state,
         array $tags = [],
         ?string $description = null,
     ): Product {
@@ -230,7 +231,7 @@ class ProductService
      *
      * @param array{
      *     tags?: ProductTagCode[],
-     *     state?: int,
+     *     state?: ProductStateEnum,
      *     archived?: bool,
      *     search?: string
      * } $criteria

--- a/symfony/tests/Api/ProductApiTest.php
+++ b/symfony/tests/Api/ProductApiTest.php
@@ -14,6 +14,7 @@ use App\Tests\AbstractDatabaseKernelTestCase;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Gamecon\Tests\Factory\UserFactory;
+use App\Enum\ProductStateEnum;
 
 /**
  * Tests for the Symfony Product API endpoint.
@@ -94,7 +95,7 @@ class ProductApiTest extends AbstractDatabaseKernelTestCase
         $product->setName('API test product ' . uniqid());
         $product->setCode('API-TEST-' . strtoupper(uniqid()));
         $product->setCurrentPrice('1.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         return $product;

--- a/symfony/tests/Dto/CartItemOutputDtoTest.php
+++ b/symfony/tests/Dto/CartItemOutputDtoTest.php
@@ -11,6 +11,7 @@ use App\Entity\ProductBundle;
 use App\Entity\ProductVariant;
 use App\Entity\User;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class CartItemOutputDtoTest extends TestCase
 {
@@ -20,7 +21,7 @@ class CartItemOutputDtoTest extends TestCase
         $product->setName('Oběd pátek');
         $product->setCode('obed-patek');
         $product->setCurrentPrice('150.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         $variant = new ProductVariant();
@@ -54,7 +55,7 @@ class CartItemOutputDtoTest extends TestCase
         $product->setName('Test');
         $product->setCode('TEST');
         $product->setCurrentPrice('100.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         $item = new OrderItem();
@@ -85,7 +86,7 @@ class CartItemOutputDtoTest extends TestCase
         $product->setName('Test');
         $product->setCode('TEST');
         $product->setCurrentPrice('100.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         $item = new OrderItem();

--- a/symfony/tests/Entity/ProductListSerializationTest.php
+++ b/symfony/tests/Entity/ProductListSerializationTest.php
@@ -10,6 +10,7 @@ use App\Entity\ProductTag;
 use App\Entity\ProductVariant;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Annotation\Groups;
+use App\Enum\ProductStateEnum;
 
 /**
  * Verifies serialization groups for product listing and
@@ -103,7 +104,7 @@ class ProductListSerializationTest extends TestCase
         $product->setName('Oběd — pátek');
         $product->setCode('obed-patek');
         $product->setCurrentPrice('120.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
         $product->setAccommodationDay(2);
 
@@ -132,7 +133,7 @@ class ProductListSerializationTest extends TestCase
         $product->setName('Test');
         $product->setCode('TEST');
         $product->setCurrentPrice('100.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
         $product->setAccommodationDay(1);
 

--- a/symfony/tests/Entity/ProductTest.php
+++ b/symfony/tests/Entity/ProductTest.php
@@ -19,7 +19,7 @@ class ProductTest extends TestCase
         $this->product->setName('Test Product');
         $this->product->setCode('TEST-001');
         $this->product->setCurrentPrice('100.00');
-        $this->product->setState(1);
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->product->setDescription('Test description');
     }
 
@@ -37,7 +37,7 @@ class ProductTest extends TestCase
         $this->assertSame('Test Product', $this->product->getName());
         $this->assertSame('TEST-001', $this->product->getCode());
         $this->assertSame('100.00', $this->product->getCurrentPrice());
-        $this->assertSame(1, $this->product->getState());
+        $this->assertSame(ProductStateEnum::PUBLIC, $this->product->getState());
         $this->assertSame('Test description', $this->product->getDescription());
     }
 
@@ -102,16 +102,14 @@ class ProductTest extends TestCase
 
     public function testIsAvailable(): void
     {
-        // State 1 = VEŘEJNÝ (public)
-        $this->product->setState(1);
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->assertTrue($this->product->isAvailable());
 
-        // State 0 = MIMO (not available)
-        $this->product->setState(0);
+        $this->product->setState(ProductStateEnum::RETIRED);
         $this->assertFalse($this->product->isAvailable());
 
         // Archived product
-        $this->product->setState(1);
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->product->setArchivedAt(new \DateTimeImmutable());
         $this->assertFalse($this->product->isAvailable());
 
@@ -127,35 +125,35 @@ class ProductTest extends TestCase
 
     public function testIsPublic(): void
     {
-        $this->product->setState(1); // VEŘEJNÝ
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->assertTrue($this->product->isPublic());
 
-        $this->product->setState(2); // PODPULTOVÝ
+        $this->product->setState(ProductStateEnum::RESTRICTED);
         $this->assertFalse($this->product->isPublic());
 
-        $this->product->setState(1);
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->product->setArchivedAt(new \DateTimeImmutable());
         $this->assertFalse($this->product->isPublic());
     }
 
-    public function testGetStateEnum(): void
+    public function testGetState(): void
     {
-        $this->product->setState(0);
-        $this->assertSame(ProductStateEnum::RETIRED, $this->product->getStateEnum());
-
-        $this->product->setState(1);
-        $this->assertSame(ProductStateEnum::PUBLIC, $this->product->getStateEnum());
-
-        $this->product->setState(2);
-        $this->assertSame(ProductStateEnum::RESTRICTED, $this->product->getStateEnum());
-
-        $this->product->setState(3);
-        $this->assertSame(ProductStateEnum::SUSPENDED, $this->product->getStateEnum());
+        foreach (ProductStateEnum::cases() as $state) {
+            $this->product->setState($state);
+            $this->assertSame($state, $this->product->getState());
+        }
     }
 
-    public function testGetStateEnumIsNullForAValueOutsideTheKnownStates(): void
+    /**
+     * The backing values are what `shop_predmety`.`stav` already holds, and
+     * Gamecon\Shop\StavPredmetu re-exports them for legacy comparisons against the raw
+     * int. Renumbering a case would silently change the meaning of every stored row.
+     */
+    public function testBackingValuesMatchTheStoredColumn(): void
     {
-        $this->product->setState(9);
-        $this->assertNull($this->product->getStateEnum());
+        $this->assertSame(0, ProductStateEnum::RETIRED->value);
+        $this->assertSame(1, ProductStateEnum::PUBLIC->value);
+        $this->assertSame(2, ProductStateEnum::RESTRICTED->value);
+        $this->assertSame(3, ProductStateEnum::SUSPENDED->value);
     }
 }

--- a/symfony/tests/Entity/ProductVariantTest.php
+++ b/symfony/tests/Entity/ProductVariantTest.php
@@ -8,6 +8,7 @@ use App\Entity\Product;
 use App\Entity\ProductVariant;
 use App\Enum\RoleMeaning;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class ProductVariantTest extends TestCase
 {
@@ -19,7 +20,7 @@ class ProductVariantTest extends TestCase
         $this->product->setName('Tričko modré');
         $this->product->setCode('TRICKO-MODRE');
         $this->product->setCurrentPrice('250.00');
-        $this->product->setState(1);
+        $this->product->setState(ProductStateEnum::PUBLIC);
         $this->product->setReservedForOrganizers(5);
     }
 

--- a/symfony/tests/Service/BulkCancelServiceTest.php
+++ b/symfony/tests/Service/BulkCancelServiceTest.php
@@ -17,6 +17,7 @@ use App\Service\CurrentYearProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class BulkCancelServiceTest extends TestCase
 {
@@ -274,7 +275,7 @@ class BulkCancelServiceTest extends TestCase
         $product->setName('Test');
         $product->setCode('TEST');
         $product->setCurrentPrice('250.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         return $product;

--- a/symfony/tests/Service/CapacityManagerTest.php
+++ b/symfony/tests/Service/CapacityManagerTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class CapacityManagerTest extends TestCase
 {
@@ -213,7 +214,7 @@ class CapacityManagerTest extends TestCase
         $product->setName('Test Product');
         $product->setCode('TEST-001');
         $product->setCurrentPrice('100.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setReservedForOrganizers($reservedForOrganizers);
 
         return $product;

--- a/symfony/tests/Service/CartServiceTest.php
+++ b/symfony/tests/Service/CartServiceTest.php
@@ -20,6 +20,7 @@ use App\Service\DiscountCalculator;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class CartServiceTest extends TestCase
 {
@@ -176,7 +177,7 @@ class CartServiceTest extends TestCase
     public function testAddItemThrowsWhenProductUnavailable(): void
     {
         $product = $this->createProduct();
-        $product->setState(0); // MIMO
+        $product->setState(ProductStateEnum::RETIRED);
 
         $variant = $this->createVariant($product, 'M', 'TRICKO-M', 10);
         $order = new Order();
@@ -492,7 +493,7 @@ class CartServiceTest extends TestCase
         $product->setName('Tričko');
         $product->setCode('TRICKO');
         $product->setCurrentPrice('250.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         return $product;

--- a/symfony/tests/Service/DiscountCalculatorTest.php
+++ b/symfony/tests/Service/DiscountCalculatorTest.php
@@ -15,6 +15,7 @@ use App\Repository\ProductDiscountRepository;
 use App\Service\DiscountCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use App\Enum\ProductStateEnum;
 
 class DiscountCalculatorTest extends TestCase
 {
@@ -219,7 +220,7 @@ class DiscountCalculatorTest extends TestCase
         $product->setName('Test Product');
         $product->setCode('TEST-001');
         $product->setCurrentPrice($price);
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
 
         return $product;
     }

--- a/symfony/tests/State/Cart/AddToCartProcessorTest.php
+++ b/symfony/tests/State/Cart/AddToCartProcessorTest.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use App\Enum\ProductStateEnum;
 
 class AddToCartProcessorTest extends TestCase
 {
@@ -122,7 +123,7 @@ class AddToCartProcessorTest extends TestCase
         $product->setName('Test');
         $product->setCode('TEST');
         $product->setCurrentPrice('100.00');
-        $product->setState(1);
+        $product->setState(ProductStateEnum::PUBLIC);
         $product->setDescription('');
 
         $variant = new ProductVariant();

--- a/tests/Shop/EshopImporterTest.php
+++ b/tests/Shop/EshopImporterTest.php
@@ -322,6 +322,31 @@ SQL,
     }
 
     /**
+     * Doctrine hydrates stav with from(), so a value outside the enum would make every
+     * later read of that product throw rather than just look odd.
+     *
+     * @test
+     */
+    public function importChybaKdyzJeStavMimoRozsah(): void
+    {
+        // '' and 'abc' would cast to 0 and import as RETIRED if the check used (int).
+        foreach ([9, -1, '', 'abc', '1.9'] as $neplatnyStav) {
+            $soubor = $this->createXlsxSoubor([
+                $this->defaultniRadek([
+                    'stav' => $neplatnyStav,
+                ]),
+            ]);
+
+            try {
+                (new EshopImporter($soubor))->importuj();
+                self::fail(sprintf('Stav %s měl být odmítnut', var_export($neplatnyStav, true)));
+            } catch (\Chyba $chyba) {
+                self::assertMatchesRegularExpression('/řádku 2.*stav/s', $chyba->getMessage());
+            }
+        }
+    }
+
+    /**
      * @test
      */
     public function importZpracujeNullHodnoty(): void

--- a/tests/Shop/EshopIntegrationTest.php
+++ b/tests/Shop/EshopIntegrationTest.php
@@ -11,6 +11,7 @@ use App\Entity\ProductVariant;
 use App\Entity\Role;
 use App\Entity\User;
 use App\Entity\UserRole;
+use App\Enum\ProductStateEnum;
 use App\Enum\ProductTagCode;
 use App\Enum\RoleMeaning;
 use App\Repository\OrderRepository;
@@ -70,7 +71,7 @@ class EshopIntegrationTest extends AbstractTestDb
                 $product->setName('Tričko modré');
                 $product->setCode('eshoptest-tricko-modre');
                 $product->setCurrentPrice('250.00');
-                $product->setState(1);
+                $product->setState(ProductStateEnum::PUBLIC);
                 $product->setDescription('Modré tričko');
                 $product->setAvailableUntil(new \DateTimeImmutable('+1 year'));
                 $product->setReservedForOrganizers(2);


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Built on `1274-přepsat-e-shop` (and targets it), not a PR into `main`.

Follow-up to the `ProductStateEnum` PR, which introduced the enum but left the column mapped as an `int`.

## Why

`Product::$state` was an `int` with an `Assert\Choice` listing `[0, 1, 2, 3]`, so every caller passed a magic number and the entity needed a `getStateEnum()` shim doing `tryFrom()` to reach the enum. Doctrine supports backed enums natively, and this project already uses that — `Role::$vyznamRole` and `User::$pohlavi` both map with `enumType:`. The product state was simply the one column that never got converted.

## What changed

```php
#[ORM\Column(name: 'stav', type: Types::SMALLINT, nullable: false, enumType: ProductStateEnum::class)]
private ProductStateEnum $state;
```

Doctrine converts on hydrate and persist, so `getState()`/`setState()` are enum-typed and the shim is gone. `Assert\Choice` goes with it: an invalid state is now unrepresentable rather than merely rejected.

Also updated: `ProductRepository::findByState()`, `ProductService::createProduct()` and its `findProducts()` array shape, plus ~27 test call sites.

## Checked before switching

`from()`, not `tryFrom()`, is what Doctrine uses to hydrate (`EnumPropertyAccessor.php:78`), so an unknown value throws rather than degrading. Production data was verified first:

| | |
|---|---|
| Rows in `shop_predmety` | 1135 |
| Outside 0–3 | 0 |
| NULL | 0 |
| Distribution | `0`→951, `1`→118, `2`→46, `3`→20 |

So nothing currently stored fails to hydrate.

## The import guard

That left a hole for *future* data. `EshopImporter` wrote the `stav` column straight from the spreadsheet, and the column is a plain `SMALLINT` with no `CHECK` constraint — so one bad row would turn every later read of that product into an uncaught `ValueError`, i.e. a 500 on the whole listing rather than one odd-looking product.

The importer now rejects an out-of-range `stav` per row, the same way it already rejects a missing tag, so the rest of the file still imports. It validates the cell as a string rather than casting: `(int) ''` and `(int) 'abc'` are both `0`, which is a valid `RETIRED`, so a cast would have silently imported a typo as a retired product.

## No migration

`enumType` does not change the generated column type — `SchemaTool` only copies it into the mapping options — so the column stays `SMALLINT` and `doctrine:schema:validate` produces no diff.

## API shape is unchanged

`state` is in the `product:write` group and used by `SearchFilter`/`OrderFilter`, so this was checked rather than assumed. Symfony's `BackedEnumNormalizer` emits the backing value, so the JSON stays `"state": 1` in both directions and the Preact side needs no change. An out-of-range write is still a client error (a 400 from the normalizer instead of the previous 422), not a crash — the Czech validation message is lost, which is the one user-visible regression here.

## How to verify

No clickable surface — types and an import guard.

```bash
./bin-docker/php ./vendor/bin/phpunit symfony/tests/Entity/ProductTest.php tests/Shop/EshopImporterTest.php
./bin-docker/docker-bash bin/phpstan.sh
./bin-docker/docker-bash bin/ecs.sh --fix
```
