### PR TITLE
1274 Serialization groups as entity constants

### DIFF
--- a/symfony/src/Entity/Product.php
+++ b/symfony/src/Entity/Product.php
@@ -64,10 +64,10 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
     ],
     normalizationContext: [
-        'groups' => ['product:read'],
+        'groups' => [self::READ],
     ],
     denormalizationContext: [
-        'groups' => ['product:write'],
+        'groups' => [self::WRITE],
     ],
     paginationItemsPerPage: 30,
 )]
@@ -82,69 +82,75 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[AppAssert\BreakfastIncludedRequiresAccommodation]
 class Product
 {
+    public const LIST = 'product:list';
+
+    public const READ = 'product:read';
+
+    public const WRITE = 'product:write';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(name: 'id_predmetu', type: Types::BIGINT, options: [
         'unsigned' => true,
     ])]
-    #[Groups(['product:list', 'product:read'])]
+    #[Groups([self::LIST, self::READ])]
     #[ApiProperty(identifier: true)]
     private ?int $id = null;
 
     #[ORM\Column(name: 'nazev', type: Types::STRING, length: 255, nullable: false)]
     #[Assert\NotBlank(message: 'Název produktu nesmí být prázdný')]
     #[Assert\Length(max: 255, maxMessage: 'Název může mít maximálně {{ limit }} znaků')]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private string $name;
 
     #[ORM\Column(name: 'kod_predmetu', type: Types::STRING, length: 255, nullable: false)]
     #[Assert\NotBlank(message: 'Kód produktu nesmí být prázdný')]
     #[Assert\Length(max: 255, maxMessage: 'Kód může mít maximálně {{ limit }} znaků')]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private string $code;
 
     #[ORM\Column(name: 'cena_aktualni', type: Types::DECIMAL, precision: 6, scale: 2, nullable: false)]
     #[Assert\NotBlank(message: 'Cena musí být vyplněna')]
     #[Assert\PositiveOrZero(message: 'Cena musí být kladné číslo nebo nula')]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private string $currentPrice;
 
     #[ORM\Column(name: 'stav', type: Types::SMALLINT, nullable: false, enumType: ProductStateEnum::class)]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private ProductStateEnum $state;
 
     #[ORM\Column(name: 'nabizet_do', type: Types::DATETIME_IMMUTABLE, nullable: true)]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private ?\DateTimeImmutable $availableUntil = null;
 
     #[ORM\Column(name: 'kusu_vyrobeno', type: Types::SMALLINT, nullable: true)]
     #[Assert\PositiveOrZero(message: 'Počet vyrobených kusů musí být kladné číslo nebo nula')]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private ?int $producedQuantity = null;
 
     #[ORM\Column(name: 'ubytovani_den', type: Types::SMALLINT, nullable: true)]
     #[Assert\Range(notInRangeMessage: 'Den ubytování musí být 0-4 (St-Ne)', min: 0, max: 4)]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private ?int $accommodationDay = null;
 
     #[ORM\Column(name: 'breakfast_included', type: Types::BOOLEAN, nullable: false, options: [
         'default' => false,
     ])]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private bool $breakfastIncluded = false;
 
     #[ORM\Column(name: 'popis', type: Types::STRING, length: 2000, nullable: false)]
     #[Assert\Length(max: 2000, maxMessage: 'Popis může mít maximálně {{ limit }} znaků')]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private string $description = '';
 
     #[ORM\Column(name: 'archived_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
-    #[Groups(['product:read'])]
+    #[Groups([self::READ])]
     private ?\DateTimeImmutable $archivedAt = null;
 
     #[ORM\Column(name: 'reserved_for_organizers', type: Types::INTEGER, nullable: true)]
     #[Assert\PositiveOrZero(message: 'Rezervace pro organizátory musí být kladné číslo nebo nula')]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private ?int $reservedForOrganizers = null;
 
     /**
@@ -154,7 +160,7 @@ class Product
     #[ORM\Column(name: 'vedlejsi', type: Types::BOOLEAN, nullable: false, options: [
         'default' => false,
     ])]
-    #[Groups(['product:list', 'product:read', 'product:write'])]
+    #[Groups([self::LIST, self::READ, self::WRITE])]
     private bool $secondary = false;
 
     /**
@@ -164,7 +170,7 @@ class Product
     #[ORM\JoinTable(name: 'product_product_tag')]
     #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id_predmetu')]
     #[ORM\InverseJoinColumn(name: 'tag_id', referencedColumnName: 'id')]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private Collection $tags;
 
     /**
@@ -174,7 +180,7 @@ class Product
     #[ORM\OrderBy([
         'position' => 'ASC',
     ])]
-    #[Groups(['product:read', 'product:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private Collection $variants;
 
     /**

--- a/symfony/src/Entity/ProductTag.php
+++ b/symfony/src/Entity/ProductTag.php
@@ -64,13 +64,15 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
     ],
     normalizationContext: [
-        'groups' => ['product_tag:read'],
+        'groups' => [self::READ],
     ],
     paginationEnabled: false,
 )]
 class ProductTag implements WithTimestampsInterface
 {
     use WithTimestampsTrait;
+
+    public const READ = 'product_tag:read';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -86,15 +88,15 @@ class ProductTag implements WithTimestampsInterface
         pattern: '/^[a-z0-9\-]+$/',
         message: 'Kód tagu může obsahovat pouze malá písmena, číslice a pomlčky'
     )]
-    #[Groups(['product:read', 'product:list', 'product_tag:read'])]
+    #[Groups([Product::READ, Product::LIST, self::READ])]
     private string $code;
 
     #[ORM\Column(type: Types::STRING, nullable: true)]
-    #[Groups(['product:read', 'product:list', 'product_tag:read'])]
+    #[Groups([Product::READ, Product::LIST, self::READ])]
     private ?string $name;
 
     #[ORM\Column(type: Types::STRING, nullable: true)]
-    #[Groups(['product_tag:read'])]
+    #[Groups([self::READ])]
     private ?string $description = null;
 
     /**

--- a/symfony/src/Entity/ProductVariant.php
+++ b/symfony/src/Entity/ProductVariant.php
@@ -59,63 +59,67 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
     ],
     normalizationContext: [
-        'groups' => ['variant:read'],
+        'groups' => [self::READ],
     ],
     denormalizationContext: [
-        'groups' => ['variant:write'],
+        'groups' => [self::WRITE],
     ],
 )]
 class ProductVariant
 {
+    public const READ = 'variant:read';
+
+    public const WRITE = 'variant:write';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT, options: [
         'unsigned' => true,
     ])]
-    #[Groups(['product:read', 'variant:read'])]
+    #[Groups([Product::READ, self::READ])]
     private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Product::class, inversedBy: 'variants')]
     #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id_predmetu', nullable: false, onDelete: 'CASCADE')]
-    #[Groups(['variant:read', 'variant:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private Product $product;
 
     #[ORM\Column(type: Types::STRING, length: 255, nullable: false)]
     #[Assert\NotBlank(message: 'Název varianty nesmí být prázdný')]
     #[Assert\Length(max: 255)]
-    #[Groups(['product:read', 'variant:read', 'variant:write'])]
+    #[Groups([Product::READ, self::READ, self::WRITE])]
     private string $name;
 
     #[ORM\Column(type: Types::STRING, length: 255, nullable: false)]
     #[Assert\NotBlank(message: 'Kód varianty nesmí být prázdný')]
     #[Assert\Length(max: 255)]
-    #[Groups(['product:read', 'variant:read', 'variant:write'])]
+    #[Groups([Product::READ, self::READ, self::WRITE])]
     private string $code;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 6, scale: 2, nullable: true)]
     #[Assert\PositiveOrZero(message: 'Cena musí být kladné číslo nebo nula')]
-    #[Groups(['product:read', 'variant:read', 'variant:write'])]
+    #[Groups([Product::READ, self::READ, self::WRITE])]
     private ?string $price = null;
 
     #[ORM\Column(name: 'remaining_quantity', type: Types::INTEGER, nullable: true)]
     #[Assert\PositiveOrZero(message: 'Zbývající množství musí být kladné číslo nebo nula')]
-    #[Groups(['product:read', 'variant:read', 'variant:write'])]
+    #[Groups([Product::READ, self::READ, self::WRITE])]
     private ?int $remainingQuantity = null;
 
     #[ORM\Column(name: 'reserved_for_organizers', type: Types::INTEGER, nullable: true)]
     #[Assert\PositiveOrZero(message: 'Rezervace pro organizátory musí být kladné číslo nebo nula')]
-    #[Groups(['variant:read', 'variant:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private ?int $reservedForOrganizers = null;
 
     #[ORM\Column(name: 'accommodation_day', type: Types::SMALLINT, nullable: true)]
     #[Assert\Range(notInRangeMessage: 'Den ubytování musí být 0-4 (St-Ne)', min: 0, max: 4)]
-    #[Groups(['product:read', 'variant:read', 'variant:write'])]
+    #[Groups([Product::READ, self::READ, self::WRITE])]
     private ?int $accommodationDay = null;
 
     #[ORM\Column(type: Types::SMALLINT, nullable: false, options: [
         'default' => 0,
     ])]
-    #[Groups(['variant:read', 'variant:write'])]
+    #[Groups([self::READ, self::WRITE])]
     private int $position = 0;
 
     /**


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Built on `1274-přepsat-e-shop` (and targets it), not a PR into `main`.

## Why

Serialization group names were string literals scattered across attributes — `'product:read'` in twenty places, `'variant:write'` in nine. A typo does not fail: API Platform simply does not know that group, so the field silently stops being serialized and the bug surfaces in the UI instead of the build.

## What changed

Each group is now a constant on the entity that owns it:

| Entity | Constants |
|---|---|
| `Product` | `LIST`, `READ`, `WRITE` |
| `ProductTag` | `READ` |
| `ProductVariant` | `READ`, `WRITE` |

`self::` within an entity, the explicit class name across entities:

```php
#[Groups([Product::READ, self::READ, self::WRITE])]   // in ProductVariant
```

That second form is a side benefit: the attribute never showed that `ProductVariant` is also serialized into the product detail. Now the coupling is visible.

## Behaviour is unchanged

Verified mechanically rather than by reading the diff: for both revisions the group membership of every property was dumped via reflection and compared. **27 properties, identical 1:1**, and so are `normalizationContext` / `denormalizationContext` on all three entities. The API payload is byte-identical.

## Implementation notes

- **The constants are untyped.** PiercingApp writes them as `public const string READ`, but typed class constants are PHP 8.3+ and this project's `composer.json` pins `">=8.2"` — with the type it would be a fatal error.
- **The tests keep their string literals on purpose.** `ProductListSerializationTest` and `ProductTagTest` assert the group name as it goes over the wire; using the constant would make a rename invisible to them and they would stop guarding the one thing they exist for.
- Only entity-owned groups were converted. This project has no generic groups (PiercingApp's `read_list` and friends).

## How to verify

Nothing to click — only how the names are written, not what they do.

```bash
./bin-docker/php ./vendor/bin/phpunit symfony/tests/Entity/
./bin-docker/docker-bash bin/phpstan.sh
./bin-docker/docker-bash bin/ecs.sh --fix
```

## Out of scope

`Product::LIST` (`product:list`) is carried by seven properties, but no operation uses it as a `normalizationContext` — it is a dormant group. That is true before this PR as well; naming it just makes it greppable, so it can be decided later whether the product listing was meant to use it.
