### PR TITLE
1274 Accommodation as product variants + read endpoint

### DIFF
--- a/MISSING_FEATURES.md
+++ b/MISSING_FEATURES.md
@@ -2,6 +2,11 @@
 
 Tento dokument obsahuje **funkce ze současného e-shopu (OLD_ESHOP.md), které nejsou zmíněny v plánu nového e-shopu (NEW_ESHOP.md)**.
 
+> **Stav ověřen proti kódu 2026-09-08.** Dokument vznikl jako seznam otázek „co s tím",
+> ne jako plán, takže původně bylo ❌ i to, co je dnes hotové. Značky níž jsou ověřené:
+> ✅ hotové (u každého je uvedeno čím), 🟡 rozpracované, ❌ neřešené.
+> Otázky „Rozhodnutí potřeba" u hotových položek zůstávají jako záznam, jak se rozhodlo.
+
 ---
 
 ## ⚠️ KRITICKÉ FUNKCE - Musí být v novém e-shopu
@@ -10,7 +15,12 @@ Tento dokument obsahuje **funkce ze současného e-shopu (OLD_ESHOP.md), které 
 
 Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které nejsou pokryty v NEW_ESHOP.md:
 
-#### ❌ **UBYTOVÁNÍ (typ 2)**
+#### 🟡 **UBYTOVÁNÍ (typ 2)**
+> **Rozpracováno.** Rozhodnuto: varianty normálního produktu. Migrace
+> `2026-09-08-100016_accommodation-days-into-variants.php` sloučila 40 řádků na
+> 8 produktů × 5 nočních variant (`ProductVariant.accommodationDay`, zásoba po nocích).
+> Zbývá storefront (čtecí endpoint + mřížka) a zápisová cesta; spolubydlící a
+> „nechci ubytování" se mají přesunout z účtu na objednávku.
 **Co to je:**
 - Ubytování po dnech (St, Čt, Pá, So, Ne)
 - Každý den je samostatná položka
@@ -29,7 +39,9 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ---
 
-#### ❌ **JIDLO (typ 4)**
+#### ✅ **JIDLO (typ 4)**
+> **Hotovo.** Tag `jidlo` + varianty; `MealProductsProvider`, `GET /cart/meals`,
+> matice `ui/src/pages/jidlo/JídloMatice.tsx`.
 **Co to je:**
 - Jídla po dnech a typech (snídaně, oběd, večeře)
 - Matrixový výběr (dny × typy jídel)
@@ -45,7 +57,9 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ---
 
-#### ❌ **VSTUPNE (typ 5) - Dobrovolné vstupné**
+#### ✅ **VSTUPNE (typ 5) - Dobrovolné vstupné**
+> **Hotovo.** `EntryFeeService`, `GET`/`POST /cart/entry-fee`,
+> `ui/src/pages/vstupne/Vstupne.tsx`.
 **Co to je:**
 - Pay-what-you-want - zákazník si zvolí částku (0-∞)
 - Dvě varianty: "včas" a "pozdě" (podle data platby)
@@ -63,7 +77,8 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ---
 
-#### ❌ **PARCON (typ 6)**
+#### ✅ **PARCON (typ 6)**
+> **Hotovo jako tag.** `ProductTagCode::PARCON` — normální produkt, ne speciální typ.
 **Co to je:**
 - ParCon mini-akce
 - Samostatný typ produktu
@@ -72,7 +87,8 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ---
 
-#### ❌ **PROPLACENI_BONUSU (typ 7)**
+#### ✅ **PROPLACENI_BONUSU (typ 7)**
+> **Hotovo jako tag.** `ProductTagCode::PROPLACENI_BONUSU`.
 **Co to je:**
 - Virtuální "produkt" pro převod organizátorského bonusu na peníze
 - **Ne pro přímý prodej**
@@ -89,7 +105,9 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ### 2. Multi-year produktové modely
 
-#### ❌ **Pole `model_rok` - Verze produktů napříč roky**
+#### ✅ **Pole `model_rok` - Verze produktů napříč roky**
+> **Vyřešeno zrušením.** Sloupec v DB ani v entitě není; ročník nese `archived_at`
+> (NULL = aktuální). Produkt existuje trvale, nezakládá se každý rok znovu.
 **Co to je:**
 - Každý produkt má pole `model_rok` (např. 2023, 2024, 2025)
 - Stejná položka (např. "Kostka GameCon") existuje ve více ročnících
@@ -109,7 +127,8 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ---
 
-#### ❌ **Pole `je_letosni_hlavni` - Označení hlavní verze roku**
+#### ✅ **Pole `je_letosni_hlavni` - Označení hlavní verze roku**
+> **Vyřešeno zrušením.** Bez multi-year verzí produktu nemá co označovat.
 **Co to je:**
 - Boolean flag označující "hlavní" verzi produktu v daném roce
 - Používá se při výběru, která verze se má zobrazit/použít
@@ -120,7 +139,9 @@ Současný e-shop má **7 speciálních typů položek** (`TypPredmetu`), které
 
 ### 3. Časově omezená dostupnost
 
-#### ❌ **Pole `nabizet_do` - Automatické pozastavení prodeje**
+#### ✅ **Pole `nabizet_do` - Automatické pozastavení prodeje**
+> **Hotovo.** `Product::$availableUntil`; `isAvailable()` po uplynutí data vrací false
+> a `ProductRepository::findPublic()` takový produkt nevrací.
 **Co to je:**
 - Datum a čas, do kdy se produkt nabízí
 - Po vypršení se stav automaticky změní na `POZASTAVENY`
@@ -144,7 +165,9 @@ if ($r['nabizet_do'] && strtotime($r['nabizet_do']) < time()) {
 
 ### 4. Speciální slevy podle položky
 
-#### ❌ **Slevy na konkrétní produkty podle kódu**
+#### ✅ **Slevy na konkrétní produkty podle kódu**
+> **Hotovo.** `DiscountCalculator` + tabulka `discount_rule` (pravidla podle role,
+> s limitem počtu kusů) místo natvrdo psaných větví v `Cenik`.
 **Současný systém:**
 - Kostka zdarma (1 na uživatele)
 - Placka zdarma (1 na uživatele)
@@ -183,7 +206,9 @@ if (Predmet::jeToKostka($r['kod_predmetu'])) {
 
 ### 5. Admin funkce - Prodej
 
-#### ❌ **Mřížkové prodejní rozhraní (KFC)**
+#### ✅ **Mřížkové prodejní rozhraní (KFC)**
+> **Hotovo.** `KfcGridProvider`, `KfcGridProcessor`, `KfcSaleProcessor`,
+> `ui/src/pages/obchod/`.
 **Co to je:**
 - Speciální admin rozhraní pro prodej na místě
 - Rychlý prodej bez plného checkoutu
@@ -199,7 +224,9 @@ if (Predmet::jeToKostka($r['kod_predmetu'])) {
 
 ---
 
-#### ❌ **Import položek e-shopu z externích zdrojů**
+#### ✅ **Import položek e-shopu z externích zdrojů**
+> **Hotovo (zůstalo v legacy).** `EshopImporter` čte XLSX; validuje tag i `stav`
+> (hodnota mimo `ProductStateEnum` řádek odmítne).
 **Co to je:**
 - Možnost importovat produkty z externího souboru/API
 - Soubor: `admin/scripts/modules/finance/_import-eshopu.php`
@@ -279,7 +306,9 @@ if (Predmet::jeToKostka($r['kod_predmetu'])) {
 
 ### 8. Hromadné operace - Bulk actions
 
-#### ❌ **Hromadné zrušení objednávek**
+#### ✅ **Hromadné zrušení objednávek**
+> **Hotovo.** `BulkCancelService` + `BulkCancelProcessor`; vrací zásobu přes
+> `CapacityManager`.
 **Současné metody:**
 - `Shop::zrusObjednavkyPro($uzivatele, $typ)` - zruší objednávky daného typu pro více uživatelů
 - `Shop::zrusLetosniObjednaneUbytovani($zdrojZruseni)` - zruší ubytování
@@ -296,7 +325,9 @@ if (Predmet::jeToKostka($r['kod_predmetu'])) {
 
 ---
 
-#### ❌ **Archiv zrušených nákupů s důvodem**
+#### ✅ **Archiv zrušených nákupů s důvodem**
+> **Hotovo.** Entita `CancelledOrderItem` nad `shop_nakupy_zrusene` — nese cenu,
+> datum nákupu i zrušení a `cancellationReason`.
 **Co to je:**
 - Tabulka `shop_nakupy_zrusene`
 - Ukládá důvod zrušení (`zdroj_zruseni`)
@@ -311,7 +342,8 @@ if (Predmet::jeToKostka($r['kod_predmetu'])) {
 
 ### 9. Admin prodej za jiného uživatele
 
-#### ❌ **Rozlišení zákazníka a objednatele**
+#### ✅ **Rozlišení zákazníka a objednatele**
+> **Hotovo.** `OrderItem` mapuje `id_objednatele` zvlášť od `id_uzivatele`.
 **Co to je:**
 - Pole `id_uzivatele` (zákazník - komu patří nákup)
 - Pole `id_objednatele` (objednatel - kdo provedl nákup, může být admin)
@@ -359,7 +391,8 @@ $chceNove = array_diff($nove, $stare); // co přidat
 
 ### 11. Speciální UI komponenty
 
-#### ❌ **Matrixový výběr jídel**
+#### ✅ **Matrixový výběr jídel**
+> **Hotovo.** `JídloMatice.tsx` — každé kliknutí ukládá přes API.
 **Co to je:**
 - Tabulka s dny v sloupcích a typy jídel v řádcích
 - Checkboxy pro výběr (např. "Oběd v pátek")
@@ -370,7 +403,9 @@ $chceNove = array_diff($nove, $stare); // co přidat
 
 ---
 
-#### ❌ **Dynamické přidávání triček**
+#### 🟡 **Dynamické přidávání triček**
+> **Rozpracováno.** Velikosti jsou varianty (migrace `100011`), ale výběr triček a
+> mikin zatím jede přes legacy formulář — nová mřížka pokrývá jen ostatní merch.
 **Co to je:**
 - Dropdown s tričky
 - JavaScript pro přidání dalšího dropdownu
@@ -383,7 +418,8 @@ $chceNove = array_diff($nove, $stare); // co přidat
 
 ---
 
-#### ❌ **Posuvník pro dobrovolné vstupné s gama korekcí**
+#### ✅ **Posuvník pro dobrovolné vstupné s gama korekcí**
+> **Hotovo.** `ui/src/pages/vstupne/Vstupne.tsx`.
 **Co to je:**
 - Nelineární posuvník (gama korekce 0.5)
 - Dynamické smajlíky podle částky
@@ -399,29 +435,37 @@ $chceNove = array_diff($nove, $stare); // co přidat
 
 ### 12. Pole v databázi
 
-#### ❌ **`shop_nakupy.id_objednatele`**
+#### ✅ **`shop_nakupy.id_objednatele`**
+> **Zachováno**, mapováno na `OrderItem`.
 - ID uživatele, který provedl objednávku (může být jiný než zákazník)
 
-#### ❌ **`shop_predmety.kod_predmetu`**
+#### ✅ **`shop_predmety.kod_predmetu`**
+> **Zachováno.** `Product::$code`, UNIQUE; nese i strukturu variant
+> (`Hs-2L-ct` = typ + noc), takže se z něj dá číst bez parsování názvu.
 - SKU/kód produktu
 - Používá se pro detekci typu (kostka, placka...)
 - Unikátní omezení s `model_rok`
 
-#### ❌ **`shop_predmety.model_rok`**
+#### ✅ **`shop_predmety.model_rok`**
+> **Zrušeno**, viz výš.
 - Rok verze produktu
 - Multi-year produkty
 
-#### ❌ **`shop_predmety.nabizet_do`**
+#### ✅ **`shop_predmety.nabizet_do`**
+> **Zachováno** jako `Product::$availableUntil`.
 - Časově omezená dostupnost
 
-#### ❌ **`shop_predmety.je_letosni_hlavni`**
+#### ✅ **`shop_predmety.je_letosni_hlavni`**
+> **Zrušeno**, viz výš.
 - Boolean flag pro hlavní verzi roku
 
-#### ❌ **`shop_predmety.ubytovani_den`**
+#### ✅ **`shop_predmety.ubytovani_den`**
+> **Zachováno** a nově i na variantě (`ProductVariant::$accommodationDay`).
 - Den ubytování (0-4 pro St-Ne)
 - Používá se jen pro typ UBYTOVANI
 
-#### ❌ **`shop_nakupy.rok`**
+#### ✅ **`shop_nakupy.rok`**
+> **Zachováno.** `OrderItem::$year` (`rok`), včetně indexu `IDX_rok_id_uzivatele`.
 - Rok nákupu (např. 2025)
 - Pro multi-year management
 
@@ -506,12 +550,31 @@ $chceNove = array_diff($nove, $stare); // co přidat
 
 ## Doporučení
 
-1. **OKAMŽITĚ** rozhodnout o speciálních typech produktů (UBYTOVANI, JIDLO, VSTUPNE...)
-2. **OKAMŽITĚ** rozhodnout o multi-year produktech
-3. Detailně specifikovat **integraci s Finance** systémem
-4. Rozhodnout o **admin prodejním rozhraní** (KFC)
-5. Rozhodnout o **hromadných operacích** pro automatické skripty
+Body 1, 2, 4 a 5 z původního seznamu jsou rozhodnuté a hotové — speciální typy produktů
+nahradily tagy plus varianty, multi-year verze se zrušily ve prospěch `archived_at`,
+KFC mřížka i hromadné rušení objednávek existují. Zbývá:
+
+1. **Integrace s `Finance`** — dosud jediná velká nedořešená vazba; nový e-shop počítá
+   ceny a slevy, ale zůstatek a platby drží legacy `Finance`.
+2. **QR platby a reporty BFSR/BFGR** — zůstávají v legacy. Rozhodnout, jestli se
+   překlápějí, nebo tam zůstanou natrvalo.
+3. **Dokončit ubytování** — čtecí endpoint a mřížka, pak zápis; spolubydlící a
+   „nechci ubytování" přesunout z účtu na objednávku.
+4. **Odstranit legacy formulář přihlášky** — až budou všechny sekce na novém e-shopu.
+   Merch už z něj vypadl, trička a mikiny v něm zatím zůstávají.
+
+### Nice to have: převést i starší ročníky na varianty
+
+Migrace na varianty (velikosti `100011`, ubytování `100016`) záměrně řeší jen aktuální
+ročník. Starší ročníky používají jinou konvenci kódů i názvů (`Dvojlůžák středa` bez
+strukturovaného `kod_predmetu`), takže by každý potřeboval vlastní čtení — proto jim
+zůstala jedna výchozí varianta na produkt.
+
+Nespěchá to: staré produkty se už neprodávají, jen se z nich čtou reporty, a ty jedou
+přes `shop_nakupy` se snapshotem názvu, ne přes strukturu produktu. Kdyby se to někdy
+dělalo, dává smysl jeden ročník po druhém a s ověřením proti reportům daného roku, ne
+jedna migrace na všechno.
 
 ---
 
-**Poznámka:** Tento dokument by měl být probrán na meetingu a každé rozhodnutí označeno.
+**Poznámka:** Stav položek výš je ověřený proti kódu (2026-09-08), ne odhad.

--- a/model/Shop/EshopImporter.php
+++ b/model/Shop/EshopImporter.php
@@ -253,6 +253,13 @@ SQL,
 
             // A re-import may rename a product or change its stock; the default variant mirrors it,
             // so it has to follow, otherwise the cart keeps showing (and snapshotting) the old label.
+            //
+            // Only a product whose single variant IS that default may be synced. A product
+            // with real variants (t-shirt sizes, accommodation nights) has variants that
+            // carry their own name and stock, and one of them still matches the parent's
+            // code — for accommodation that is the night the owner was picked from, so this
+            // would rename "neděle" to the whole type and overwrite its per-night stock
+            // with the type total.
             dbQuery(<<<SQL
 UPDATE product_variant
 JOIN shop_predmety ON shop_predmety.id_predmetu = product_variant.product_id
@@ -261,6 +268,10 @@ SET product_variant.name = shop_predmety.nazev,
     product_variant.remaining_quantity = shop_predmety.kusu_vyrobeno,
     product_variant.accommodation_day = shop_predmety.ubytovani_den
 WHERE product_variant.code = shop_predmety.kod_predmetu
+  AND (
+      SELECT COUNT(*) FROM product_variant AS sourozenci
+      WHERE sourozenci.product_id = shop_predmety.id_predmetu
+  ) = 1
 SQL,
             );
 

--- a/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
+++ b/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
@@ -38,7 +38,10 @@ SQL;
 
 $this->q(<<<SQL
 CREATE TEMPORARY TABLE tmp_accommodation_groups (
-    kod_varianty VARCHAR(255)    NOT NULL PRIMARY KEY,
+    -- Collation pinned to match shop_predmety.kod_predmetu / product_variant.code, which
+    -- are utf8mb4_czech_ci while the database default is utf8mb4_general_ci — the join
+    -- below is an "illegal mix of collations" error without it.
+    kod_varianty VARCHAR(255) COLLATE utf8mb4_czech_ci NOT NULL PRIMARY KEY,
     owner_id     BIGINT UNSIGNED NOT NULL,
     den          SMALLINT        NOT NULL,
     INDEX (owner_id)

--- a/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
+++ b/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var Godric\DbMigrations\Migration $this */
+
+// Legacy has no concept of an accommodation type: each night of each room type is its own
+// product row, and the type is recovered by regex-stripping the Czech day name off the
+// product name (Shop::bezDne). The new model expresses that as one product per type with
+// a variant per night, which is what lets the storefront render a day grid instead of a
+// list of forty products.
+//
+// The structure is already machine-readable in kod_predmetu: `Hs-2L-ct` is type `Hs-2L`,
+// day `ct`. The suffix agrees with ubytovani_den on every current row, so the grouping
+// keys on the code and never reads the name.
+//
+// Only current (non-archived) products are converted. Older seasons use a different
+// convention entirely ("Dvojlůžák středa", no structured code) and each would need its
+// own reading; they are never sold again, only read by reports, so they keep the single
+// default variant migration 100010 gave them.
+//
+// Product names keep their day suffix on purpose: Shop::bezDne still parses them for the
+// legacy registration form, which stays until that form is removed.
+
+// The day is the last code segment after "-" or "_"; both separators occur
+// (`1L_st` vs `Hs-2L-ct`).
+$kodDne = <<<SQL
+SUBSTRING_INDEX(shop_predmety.kod_predmetu, IF(shop_predmety.kod_predmetu LIKE '%\\_%', '_', '-'), -1)
+SQL;
+
+// The type is everything before that segment — the group key.
+$kodTypu = <<<SQL
+LEFT(shop_predmety.kod_predmetu, CHAR_LENGTH(shop_predmety.kod_predmetu) - CHAR_LENGTH({$kodDne}) - 1)
+SQL;
+
+// Current accommodation: tagged `ubytovani`, not archived. Both `typ` and `model_rok`
+// are gone from this table — the tag replaced the first, archived_at the second.
+$jeAktualniUbytovani = <<<SQL
+shop_predmety.archived_at IS NULL
+AND EXISTS (
+    SELECT 1
+    FROM product_product_tag
+    JOIN product_tag ON product_tag.id = product_product_tag.tag_id
+    WHERE product_product_tag.product_id = shop_predmety.id_predmetu
+      AND product_tag.code = 'ubytovani'
+)
+SQL;
+
+$this->q(<<<SQL
+CREATE TEMPORARY TABLE tmp_accommodation_groups (
+    product_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    owner_id   BIGINT UNSIGNED NOT NULL,
+    den        SMALLINT        NOT NULL,
+    INDEX (owner_id)
+) ENGINE=InnoDB
+SQL);
+
+// Owner of each type: the lowest product id, so a rerun picks the same one.
+$this->q(<<<SQL
+INSERT INTO tmp_accommodation_groups (product_id, owner_id, den)
+SELECT shop_predmety.id_predmetu,
+       owners.owner_id,
+       shop_predmety.ubytovani_den
+FROM shop_predmety
+JOIN (
+    SELECT {$kodTypu} AS kod_typu, MIN(shop_predmety.id_predmetu) AS owner_id
+    FROM shop_predmety
+    WHERE {$jeAktualniUbytovani}
+    GROUP BY kod_typu
+) AS owners ON owners.kod_typu = {$kodTypu}
+WHERE {$jeAktualniUbytovani}
+  AND shop_predmety.ubytovani_den IS NOT NULL
+SQL);
+
+// Move each night's variant onto its type's owner. Variant ids do not change, so the
+// shop_nakupy rows pointing at them still resolve — only the parent product changes.
+// The variant already carries this night's own remaining_quantity, set by 100010.
+$this->q(<<<SQL
+UPDATE product_variant
+JOIN tmp_accommodation_groups ON tmp_accommodation_groups.product_id = product_variant.product_id
+SET product_variant.product_id        = tmp_accommodation_groups.owner_id,
+    product_variant.name              = ELT(tmp_accommodation_groups.den + 1,
+                                            'středa', 'čtvrtek', 'pátek', 'sobota', 'neděle'),
+    product_variant.accommodation_day = tmp_accommodation_groups.den,
+    product_variant.position          = tmp_accommodation_groups.den
+SQL);
+
+// The owner keeps whichever day it happened to be (the lowest id is Sunday's row), so
+// without this the product would read "Postel na 3L koleji neděle" while carrying all
+// five nights. Only the 8 owners are renamed; the 32 absorbed rows keep their suffix,
+// which is what the legacy form still reads. Shop::bezDne is idempotent, so a stripped
+// name lands in the same type bucket there as a suffixed one.
+$this->q(<<<SQL
+UPDATE shop_predmety
+JOIN tmp_accommodation_groups ON tmp_accommodation_groups.product_id = shop_predmety.id_predmetu
+    AND tmp_accommodation_groups.owner_id = shop_predmety.id_predmetu
+SET shop_predmety.nazev = TRIM(REGEXP_REPLACE(
+        shop_predmety.nazev,
+        ' ?(pondělí|úterý|středa|čtvrtek|pátek|sobota|neděle)\$',
+        ''
+    ))
+SQL);
+
+// The snapshot on existing purchases should read the way the product does now.
+$this->q(<<<SQL
+UPDATE shop_nakupy
+JOIN product_variant ON product_variant.id = shop_nakupy.variant_id
+JOIN shop_predmety ON shop_predmety.id_predmetu = product_variant.product_id
+SET shop_nakupy.product_name = shop_predmety.nazev,
+    shop_nakupy.variant_name = product_variant.name
+WHERE shop_nakupy.variant_id IS NOT NULL
+SQL);
+
+$this->q('DROP TEMPORARY TABLE IF EXISTS tmp_accommodation_groups');

--- a/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
+++ b/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
@@ -37,6 +37,9 @@ SQL;
 // are gone from this table — the tag replaced the first, archived_at the second.
 $jeAktualniUbytovani = <<<SQL
 shop_predmety.archived_at IS NULL
+-- A code with no separator has no day segment to strip, so LEFT() would yield '' and
+-- every such type would collapse into one group. Skip them rather than merge them.
+AND shop_predmety.kod_predmetu REGEXP '[-_]'
 AND EXISTS (
     SELECT 1
     FROM product_product_tag
@@ -48,19 +51,28 @@ SQL;
 
 $this->q(<<<SQL
 CREATE TEMPORARY TABLE tmp_accommodation_groups (
-    product_id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
-    owner_id   BIGINT UNSIGNED NOT NULL,
-    den        SMALLINT        NOT NULL,
+    kod_varianty VARCHAR(255)    NOT NULL PRIMARY KEY,
+    owner_id     BIGINT UNSIGNED NOT NULL,
+    den          SMALLINT        NOT NULL,
     INDEX (owner_id)
 ) ENGINE=InnoDB
 SQL);
 
-// Owner of each type: the lowest product id, so a rerun picks the same one.
+// Keyed on the variant code, which never changes, and the day is read out of that code
+// rather than out of the product row. Both matter for a rerun: after the first pass the
+// variants sit on the owner, so joining on product_id would hand every variant the
+// OWNER's day (Sunday, the lowest id) and flatten all five nights into one.
 $this->q(<<<SQL
-INSERT INTO tmp_accommodation_groups (product_id, owner_id, den)
-SELECT shop_predmety.id_predmetu,
+INSERT INTO tmp_accommodation_groups (kod_varianty, owner_id, den)
+SELECT shop_predmety.kod_predmetu,
        owners.owner_id,
-       shop_predmety.ubytovani_den
+       CASE {$kodDne}
+           WHEN 'st' THEN 0
+           WHEN 'ct' THEN 1
+           WHEN 'pa' THEN 2
+           WHEN 'so' THEN 3
+           WHEN 'ne' THEN 4
+       END
 FROM shop_predmety
 JOIN (
     SELECT {$kodTypu} AS kod_typu, MIN(shop_predmety.id_predmetu) AS owner_id
@@ -69,7 +81,7 @@ JOIN (
     GROUP BY kod_typu
 ) AS owners ON owners.kod_typu = {$kodTypu}
 WHERE {$jeAktualniUbytovani}
-  AND shop_predmety.ubytovani_den IS NOT NULL
+  AND {$kodDne} IN ('st', 'ct', 'pa', 'so', 'ne')
 SQL);
 
 // Move each night's variant onto its type's owner. Variant ids do not change, so the
@@ -77,7 +89,7 @@ SQL);
 // The variant already carries this night's own remaining_quantity, set by 100010.
 $this->q(<<<SQL
 UPDATE product_variant
-JOIN tmp_accommodation_groups ON tmp_accommodation_groups.product_id = product_variant.product_id
+JOIN tmp_accommodation_groups ON tmp_accommodation_groups.kod_varianty = product_variant.code
 SET product_variant.product_id        = tmp_accommodation_groups.owner_id,
     product_variant.name              = ELT(tmp_accommodation_groups.den + 1,
                                             'středa', 'čtvrtek', 'pátek', 'sobota', 'neděle'),
@@ -92,8 +104,8 @@ SQL);
 // name lands in the same type bucket there as a suffixed one.
 $this->q(<<<SQL
 UPDATE shop_predmety
-JOIN tmp_accommodation_groups ON tmp_accommodation_groups.product_id = shop_predmety.id_predmetu
-    AND tmp_accommodation_groups.owner_id = shop_predmety.id_predmetu
+JOIN tmp_accommodation_groups ON tmp_accommodation_groups.owner_id = shop_predmety.id_predmetu
+    AND tmp_accommodation_groups.kod_varianty = shop_predmety.kod_predmetu
 SET shop_predmety.nazev = TRIM(REGEXP_REPLACE(
         shop_predmety.nazev,
         ' ?(pondělí|úterý|středa|čtvrtek|pátek|sobota|neděle)\$',

--- a/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
+++ b/symfony/migrations/structures/2026-09-08-100016_accommodation-days-into-variants.php
@@ -4,23 +4,10 @@ declare(strict_types=1);
 
 /** @var Godric\DbMigrations\Migration $this */
 
-// Legacy has no concept of an accommodation type: each night of each room type is its own
-// product row, and the type is recovered by regex-stripping the Czech day name off the
-// product name (Shop::bezDne). The new model expresses that as one product per type with
-// a variant per night, which is what lets the storefront render a day grid instead of a
-// list of forty products.
-//
-// The structure is already machine-readable in kod_predmetu: `Hs-2L-ct` is type `Hs-2L`,
-// day `ct`. The suffix agrees with ubytovani_den on every current row, so the grouping
-// keys on the code and never reads the name.
-//
-// Only current (non-archived) products are converted. Older seasons use a different
-// convention entirely ("Dvojlůžák středa", no structured code) and each would need its
-// own reading; they are never sold again, only read by reports, so they keep the single
-// default variant migration 100010 gave them.
-//
-// Product names keep their day suffix on purpose: Shop::bezDne still parses them for the
-// legacy registration form, which stays until that form is removed.
+// Groups one product per night into one product per room type with a variant per night.
+// Keys on kod_predmetu (`Hs-2L-ct` = type `Hs-2L`, day `ct`), never on the name: older
+// seasons use an unstructured convention and are left with their single default variant.
+// Absorbed rows keep their day suffix, which Shop::bezDne still parses for the legacy form.
 
 // The day is the last code segment after "-" or "_"; both separators occur
 // (`1L_st` vs `Hs-2L-ct`).
@@ -78,6 +65,11 @@ JOIN (
     SELECT {$kodTypu} AS kod_typu, MIN(shop_predmety.id_predmetu) AS owner_id
     FROM shop_predmety
     WHERE {$jeAktualniUbytovani}
+      -- The same day filter as the outer query. Without it a row whose last segment is
+      -- not a day could win MIN(id) and become the owner, and would then never be
+      -- renamed or given a day — it is filtered out of this table — while every real
+      -- night of the type got reparented onto it.
+      AND {$kodDne} IN ('st', 'ct', 'pa', 'so', 'ne')
     GROUP BY kod_typu
 ) AS owners ON owners.kod_typu = {$kodTypu}
 WHERE {$jeAktualniUbytovani}

--- a/symfony/src/ApiResource/CartResource.php
+++ b/symfony/src/ApiResource/CartResource.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
+use App\Dto\Cart\AccommodationOutputDto;
 use App\Dto\Cart\AddToCartInputDto;
 use App\Dto\Cart\CartOutputDto;
 use App\Dto\Cart\CheckoutInputDto;
@@ -17,6 +18,7 @@ use App\Dto\Cart\EntryFeeOutputDto;
 use App\Dto\Cart\MealProductOutputDto;
 use App\Dto\Cart\MerchProductOutputDto;
 use App\Dto\Cart\SetEntryFeeInputDto;
+use App\State\Cart\AccommodationProvider;
 use App\State\Cart\AddToCartProcessor;
 use App\State\Cart\CartProvider;
 use App\State\Cart\CheckoutProcessor;
@@ -36,6 +38,16 @@ use App\State\Cart\SetEntryFeeProcessor;
             openapi: new Operation(
                 summary: 'List available meals',
                 description: 'Returns flat list of meal products with variant info for the meal matrix UI.',
+            ),
+        ),
+        new Get(
+            uriTemplate: '/cart/accommodation',
+            output: AccommodationOutputDto::class,
+            provider: AccommodationProvider::class,
+            security: "is_granted('ROLE_USER')",
+            openapi: new Operation(
+                summary: 'Accommodation grid',
+                description: 'Nights by room type, with what the customer already holds. One payload: the nights of a booking must be consecutive, so they are chosen as a set.',
             ),
         ),
         new GetCollection(

--- a/symfony/src/Dto/Cart/AccommodationCellOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationCellOutputDto.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Dto\Cart;
 
-/** One night of one room type. */
 class AccommodationCellOutputDto
 {
     public int $variantId;

--- a/symfony/src/Dto/Cart/AccommodationCellOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationCellOutputDto.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Cart;
+
+/** One night of one room type. */
+class AccommodationCellOutputDto
+{
+    public int $variantId;
+
+    public bool $selected = false;
+
+    /**
+     * Null means unlimited — dorm beds are effectively uncapped and the grid shows no
+     * number for them.
+     */
+    public ?int $remaining = null;
+
+    public bool $soldOut = false;
+
+    /**
+     * Cannot be ticked: sold out, past the deadline, or a night this customer may not
+     * order (Sunday needs its own right). Already-booked nights stay selectable so the
+     * customer can drop them.
+     */
+    public bool $locked = false;
+}

--- a/symfony/src/Dto/Cart/AccommodationDayOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationDayOutputDto.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Dto\Cart;
 
-/** A column header of the accommodation grid: one night. */
 class AccommodationDayOutputDto
 {
     /**

--- a/symfony/src/Dto/Cart/AccommodationDayOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationDayOutputDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Cart;
+
+/** A column header of the accommodation grid: one night. */
+class AccommodationDayOutputDto
+{
+    /**
+     * 0 = Wednesday … 4 = Sunday, matching shop_predmety.ubytovani_den.
+     */
+    public int $day;
+
+    public string $name;
+}

--- a/symfony/src/Dto/Cart/AccommodationOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationOutputDto.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Cart;
+
+/**
+ * The accommodation section as one payload: the day/type grid plus the state that belongs
+ * to the booking as a whole. The grid is not a list of independent items — the nights of
+ * one booking must be consecutive — so it is served and (later) saved as a set.
+ */
+class AccommodationOutputDto
+{
+    /**
+     * Days the customer may see, in festival order.
+     *
+     * @var AccommodationDayOutputDto[]
+     */
+    public array $days = [];
+
+    /**
+     * Room types offered, in the order the legacy grid used (dorms before hotel).
+     *
+     * @var AccommodationTypeOutputDto[]
+     */
+    public array $types = [];
+
+    /**
+     * Chosen nights per type, keyed by variant id — what the grid renders as ticked.
+     *
+     * @var int[]
+     */
+    public array $selectedVariantIds = [];
+
+    /**
+     * Fewer nights than this is refused unless the customer may book a single night.
+     */
+    public int $minimumNights = 2;
+
+    /**
+     * Whole section is past its deadline: everything renders read-only.
+     */
+    public bool $saleClosed = false;
+
+    public ?string $roommate = null;
+
+    public bool $declined = false;
+}

--- a/symfony/src/Dto/Cart/AccommodationOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationOutputDto.php
@@ -19,14 +19,15 @@ class AccommodationOutputDto
     public array $days = [];
 
     /**
-     * Room types offered, in the order the legacy grid used (dorms before hotel).
+     * Room types offered, ordered by name.
      *
      * @var AccommodationTypeOutputDto[]
      */
     public array $types = [];
 
     /**
-     * Chosen nights per type, keyed by variant id — what the grid renders as ticked.
+     * Variant ids of every night already booked, flattened across types — what the grid
+     * renders as ticked.
      *
      * @var int[]
      */

--- a/symfony/src/Dto/Cart/AccommodationTypeOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationTypeOutputDto.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto\Cart;
+
+/** One row of the accommodation grid: a room type, with a cell per night. */
+class AccommodationTypeOutputDto
+{
+    public int $productId;
+
+    public string $name;
+
+    public string $description = '';
+
+    public string $price;
+
+    /**
+     * Room types differ in price only, so the whole row shares one figure.
+     */
+    public string $discountedPrice;
+
+    /**
+     * Cells keyed by day index (0 = Wednesday). A day the type is not offered on has no
+     * entry rather than a disabled one — the grid renders those as blank.
+     *
+     * @var array<int, AccommodationCellOutputDto>
+     */
+    public array $nights = [];
+}

--- a/symfony/src/Dto/Cart/AccommodationTypeOutputDto.php
+++ b/symfony/src/Dto/Cart/AccommodationTypeOutputDto.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Dto\Cart;
 
-/** One row of the accommodation grid: a room type, with a cell per night. */
 class AccommodationTypeOutputDto
 {
     public int $productId;
@@ -16,7 +15,7 @@ class AccommodationTypeOutputDto
     public string $price;
 
     /**
-     * Room types differ in price only, so the whole row shares one figure.
+     * One figure for the whole row: the discount applies to the type, not to a single night.
      */
     public string $discountedPrice;
 

--- a/symfony/src/Repository/OrderItemRepository.php
+++ b/symfony/src/Repository/OrderItemRepository.php
@@ -60,12 +60,9 @@ class OrderItemRepository extends ServiceEntityRepository
     }
 
     /**
-     * How many of each variant were sold this year, keyed by variant id.
-     *
-     * Needed because `product_variant.remaining_quantity` is only decremented by
-     * CapacityManager, i.e. by the new cart. Anything the legacy form still sells —
-     * accommodation, for now — writes shop_nakupy directly and leaves that column at its
-     * original capacity, so reading it would report a fully booked room as empty.
+     * Counts both sale paths, since OrderItem maps to shop_nakupy. Pair it only with
+     * {@see ProductRepository::producedQuantityByVariantCode()}, never with
+     * remaining_quantity — CapacityManager already decrements that for new-cart sales.
      *
      * @param int[] $variantIds
      *
@@ -93,5 +90,39 @@ class OrderItemRepository extends ServiceEntityRepository
         }
 
         return $prodano;
+    }
+
+    /**
+     * Added back into the remaining count, as legacy does, so the last bed still reads as
+     * available once it is yours instead of sold out under its own ticked checkbox.
+     *
+     * @param int[] $variantIds
+     *
+     * @return array<int, int>
+     */
+    public function countHeldByCustomer(array $variantIds, User $customer, int $year): array
+    {
+        if ($variantIds === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('oi')
+            ->select('IDENTITY(oi.variant) AS variantId', 'COUNT(oi.id) AS held')
+            ->where('oi.variant IN (:variantIds)')
+            ->andWhere('oi.year = :year')
+            ->andWhere('oi.customer = :customer')
+            ->groupBy('oi.variant')
+            ->setParameter('variantIds', $variantIds)
+            ->setParameter('year', $year)
+            ->setParameter('customer', $customer)
+            ->getQuery()
+            ->getArrayResult();
+
+        $drzeno = [];
+        foreach ($rows as $row) {
+            $drzeno[(int) $row['variantId']] = (int) $row['held'];
+        }
+
+        return $drzeno;
     }
 }

--- a/symfony/src/Repository/OrderItemRepository.php
+++ b/symfony/src/Repository/OrderItemRepository.php
@@ -58,4 +58,40 @@ class OrderItemRepository extends ServiceEntityRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    /**
+     * How many of each variant were sold this year, keyed by variant id.
+     *
+     * Needed because `product_variant.remaining_quantity` is only decremented by
+     * CapacityManager, i.e. by the new cart. Anything the legacy form still sells —
+     * accommodation, for now — writes shop_nakupy directly and leaves that column at its
+     * original capacity, so reading it would report a fully booked room as empty.
+     *
+     * @param int[] $variantIds
+     *
+     * @return array<int, int>
+     */
+    public function countSoldByVariant(array $variantIds, int $year): array
+    {
+        if ($variantIds === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('oi')
+            ->select('IDENTITY(oi.variant) AS variantId', 'COUNT(oi.id) AS sold')
+            ->where('oi.variant IN (:variantIds)')
+            ->andWhere('oi.year = :year')
+            ->groupBy('oi.variant')
+            ->setParameter('variantIds', $variantIds)
+            ->setParameter('year', $year)
+            ->getQuery()
+            ->getArrayResult();
+
+        $prodano = [];
+        foreach ($rows as $row) {
+            $prodano[(int) $row['variantId']] = (int) $row['sold'];
+        }
+
+        return $prodano;
+    }
 }

--- a/symfony/src/Repository/ProductRepository.php
+++ b/symfony/src/Repository/ProductRepository.php
@@ -174,4 +174,39 @@ class ProductRepository extends ServiceEntityRepository
             ->getQuery()
             ->execute();
     }
+
+    /**
+     * The accommodation migration leaves each night's own shop_predmety row alone, so
+     * kusu_vyrobeno matched by variant code is still that night's capacity — and unlike
+     * remaining_quantity no sale ever touches it.
+     *
+     * @param string[] $codes
+     *
+     * @return array<string, int|null> null means unlimited
+     */
+    public function producedQuantityByVariantCode(array $codes): array
+    {
+        if ($codes === []) {
+            return [];
+        }
+
+        $rows = $this->getEntityManager()->getConnection()->fetchAllAssociative(
+            'SELECT kod_predmetu, kusu_vyrobeno FROM shop_predmety WHERE kod_predmetu IN (:codes)',
+            [
+                'codes' => $codes,
+            ],
+            [
+                'codes' => \Doctrine\DBAL\ArrayParameterType::STRING,
+            ],
+        );
+
+        $vyrobeno = [];
+        foreach ($rows as $row) {
+            $vyrobeno[(string) $row['kod_predmetu']] = $row['kusu_vyrobeno'] === null
+                ? null
+                : (int) $row['kusu_vyrobeno'];
+        }
+
+        return $vyrobeno;
+    }
 }

--- a/symfony/src/State/Cart/AccommodationProvider.php
+++ b/symfony/src/State/Cart/AccommodationProvider.php
@@ -11,7 +11,6 @@ use App\Dto\Cart\AccommodationDayOutputDto;
 use App\Dto\Cart\AccommodationOutputDto;
 use App\Dto\Cart\AccommodationTypeOutputDto;
 use App\Entity\Product;
-use App\Entity\ProductVariant;
 use App\Entity\User;
 use App\Enum\ProductTagCode;
 use App\Repository\OrderItemRepository;
@@ -58,22 +57,23 @@ readonly class AccommodationProvider implements ProviderInterface
         $year = $this->currentYearProvider->getCurrentYear();
         $nastaveni = SystemoveNastaveni::zGlobals();
         $prodejUkoncen = $nastaveni->prodejUbytovaniUkoncen();
+        // Every accommodation right lives in the legacy permission system. Failing beats
+        // degrading to "no rights", which would drop an organizer's Sunday night with a 200.
         $legacyUzivatel = $this->legacySession->getCurrentUser();
+        if ($legacyUzivatel === null) {
+            throw new AccessDeniedHttpException('Ubytování vyžaduje přihlášení na webu GameConu.');
+        }
 
-        $muzeNedeli = $legacyUzivatel !== null && (
-            $legacyUzivatel->maPravo(Pravo::UBYTOVANI_NEDELNI_NOC_NABIZET)
+        $muzeNedeli = $legacyUzivatel->maPravo(Pravo::UBYTOVANI_NEDELNI_NOC_NABIZET)
             || $legacyUzivatel->maPravo(Pravo::UBYTOVANI_NEDELNI_NOC_ZDARMA)
-            || $legacyUzivatel->jeOrganizator()
-        );
-        $muzeJednuNoc = $legacyUzivatel !== null
-            && $legacyUzivatel->maPravo(Pravo::UBYTOVANI_MUZE_OBJEDNAT_JEDNU_NOC);
-        $jeOrganizator = $legacyUzivatel !== null && $legacyUzivatel->jeOrganizator();
+            || $legacyUzivatel->jeOrganizator();
+        $muzeJednuNoc = $legacyUzivatel->maPravo(Pravo::UBYTOVANI_MUZE_OBJEDNAT_JEDNU_NOC);
 
         $dto = new AccommodationOutputDto();
         $dto->saleClosed = $prodejUkoncen;
         $dto->minimumNights = $muzeJednuNoc ? 1 : 2;
-        $dto->roommate = $legacyUzivatel?->ubytovanS() ?: null;
-        $dto->declined = (bool) $legacyUzivatel?->nechceUbytovani();
+        $dto->roommate = $legacyUzivatel->ubytovanS() ?: null;
+        $dto->declined = (bool) $legacyUzivatel->nechceUbytovani();
 
         foreach (self::NAZVY_DNU as $den => $nazev) {
             if ($den === self::DEN_NEDELE && ! $muzeNedeli) {
@@ -99,11 +99,11 @@ readonly class AccommodationProvider implements ProviderInterface
         }
 
         $viditelneDny = array_column($dto->days, 'day');
-        $prodano = $this->prodanoPoVariantach($year);
+        [$prodano, $drzeno, $kapacity] = $this->obsazenostVariant($user, $year);
 
         foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
             $typDto = $this->toTypeDto(
-                $product, $user, $year, $viditelneDny, $prodejUkoncen, $koupeneVarianty, $prodano, $jeOrganizator,
+                $product, $user, $year, $viditelneDny, $prodejUkoncen, $koupeneVarianty, $prodano, $drzeno, $kapacity,
             );
             if ($typDto !== null) {
                 $dto->types[] = $typDto;
@@ -114,9 +114,11 @@ readonly class AccommodationProvider implements ProviderInterface
     }
 
     /**
-     * @param int[]          $viditelneDny
-     * @param int[]          $koupeneVarianty
-     * @param array<int,int> $prodano         sold count per variant id
+     * @param int[]                  $viditelneDny
+     * @param int[]                  $koupeneVarianty
+     * @param array<int,int>         $prodano         sold count per variant id
+     * @param array<int,int>         $drzeno          count this customer holds, per variant id
+     * @param array<string,int|null> $kapacity        produced count per variant code
      */
     private function toTypeDto(
         Product $product,
@@ -126,7 +128,8 @@ readonly class AccommodationProvider implements ProviderInterface
         bool $prodejUkoncen,
         array $koupeneVarianty,
         array $prodano,
-        bool $jeOrganizator,
+        array $drzeno,
+        array $kapacity,
     ): ?AccommodationTypeOutputDto {
         // The nights absorbed by the day-variant migration are still products in their own
         // right — the legacy form reads them — but they carry no variants and must not
@@ -156,12 +159,14 @@ readonly class AccommodationProvider implements ProviderInterface
                 continue;
             }
 
-            // remaining_quantity still holds the produced count for anything the legacy
-            // form sells, so derive what is left the way legacy does.
-            $kapacita = $variant->getRemainingQuantity();
-            $zbyva = $kapacita === null
+            // Legacy's own arithmetic. remaining_quantity is deliberately not used:
+            // CapacityManager decrements it for sales shop_nakupy already counts.
+            $vyrobeno = $kapacity[(string) $variant->getCode()] ?? null;
+            $zbyva = $vyrobeno === null
                 ? null
-                : max(0, $kapacita - ($prodano[$variant->getId()] ?? 0) - $this->rezervovanoProOrganizatory($variant, $jeOrganizator));
+                : max(0, $vyrobeno
+                    - ($prodano[$variant->getId()] ?? 0)
+                    + ($drzeno[$variant->getId()] ?? 0));
             $vyprodano = $zbyva !== null && $zbyva <= 0;
 
             $koupeno = in_array($variant->getId(), $koupeneVarianty, true);
@@ -182,29 +187,30 @@ readonly class AccommodationProvider implements ProviderInterface
     }
 
     /**
-     * Organizer-reserved places are not on offer to anyone else, mirroring what
-     * CapacityManager::purchase() enforces on the write path.
+     * Gathered in one pass, so the grid costs three queries rather than three per night.
+     *
+     * @return array{0: array<int,int>, 1: array<int,int>, 2: array<string,int|null>}
+     *                                                                                sold per variant id, held by this customer per variant id, produced per variant code
      */
-    private function rezervovanoProOrganizatory(ProductVariant $variant, bool $jeOrganizator): int
-    {
-        return $jeOrganizator ? 0 : ($variant->getEffectiveReservedForOrganizers() ?? 0);
-    }
-
-    /**
-     * @return array<int, int> sold count per accommodation variant id
-     */
-    private function prodanoPoVariantach(int $year): array
+    private function obsazenostVariant(User $user, int $year): array
     {
         $variantIds = [];
+        $kody = [];
         foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
             foreach ($product->getVariants() as $variant) {
-                if ($variant->getId() !== null) {
-                    $variantIds[] = $variant->getId();
+                if ($variant->getId() === null) {
+                    continue;
                 }
+                $variantIds[] = $variant->getId();
+                $kody[] = (string) $variant->getCode();
             }
         }
 
-        return $this->orderItemRepository->countSoldByVariant($variantIds, $year);
+        return [
+            $this->orderItemRepository->countSoldByVariant($variantIds, $year),
+            $this->orderItemRepository->countHeldByCustomer($variantIds, $user, $year),
+            $this->productRepository->producedQuantityByVariantCode($kody),
+        ];
     }
 
     /**

--- a/symfony/src/State/Cart/AccommodationProvider.php
+++ b/symfony/src/State/Cart/AccommodationProvider.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State\Cart;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Dto\Cart\AccommodationCellOutputDto;
+use App\Dto\Cart\AccommodationDayOutputDto;
+use App\Dto\Cart\AccommodationOutputDto;
+use App\Dto\Cart\AccommodationTypeOutputDto;
+use App\Entity\Product;
+use App\Entity\ProductVariant;
+use App\Entity\User;
+use App\Enum\ProductTagCode;
+use App\Repository\OrderItemRepository;
+use App\Repository\ProductRepository;
+use App\Service\CurrentYearProviderInterface;
+use App\Service\DiscountCalculator;
+use App\Service\LegacySessionService;
+use Gamecon\Pravo;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Serves the logged-in customer's own grid. Legacy tells the occupant apart from the
+ * orderer (an infopult worker books for someone else and their own organizer status then
+ * unlocks Sunday); this endpoint has no such parameter, so ordering on behalf of another
+ * person stays on the legacy form for now.
+ *
+ * @implements ProviderInterface<AccommodationOutputDto>
+ */
+readonly class AccommodationProvider implements ProviderInterface
+{
+    private const NAZVY_DNU = ['středa', 'čtvrtek', 'pátek', 'sobota', 'neděle'];
+
+    private const DEN_NEDELE = 4;
+
+    public function __construct(
+        private ProductRepository $productRepository,
+        private OrderItemRepository $orderItemRepository,
+        private DiscountCalculator $discountCalculator,
+        private CurrentYearProviderInterface $currentYearProvider,
+        private LegacySessionService $legacySession,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): AccommodationOutputDto
+    {
+        $user = $this->security->getUser();
+        if (! $user instanceof User) {
+            throw new AccessDeniedHttpException('Pro zobrazení ubytování je nutné přihlášení.');
+        }
+
+        $year = $this->currentYearProvider->getCurrentYear();
+        $nastaveni = SystemoveNastaveni::zGlobals();
+        $prodejUkoncen = $nastaveni->prodejUbytovaniUkoncen();
+        $legacyUzivatel = $this->legacySession->getCurrentUser();
+
+        $muzeNedeli = $legacyUzivatel !== null && (
+            $legacyUzivatel->maPravo(Pravo::UBYTOVANI_NEDELNI_NOC_NABIZET)
+            || $legacyUzivatel->maPravo(Pravo::UBYTOVANI_NEDELNI_NOC_ZDARMA)
+            || $legacyUzivatel->jeOrganizator()
+        );
+        $muzeJednuNoc = $legacyUzivatel !== null
+            && $legacyUzivatel->maPravo(Pravo::UBYTOVANI_MUZE_OBJEDNAT_JEDNU_NOC);
+        $jeOrganizator = $legacyUzivatel !== null && $legacyUzivatel->jeOrganizator();
+
+        $dto = new AccommodationOutputDto();
+        $dto->saleClosed = $prodejUkoncen;
+        $dto->minimumNights = $muzeJednuNoc ? 1 : 2;
+        $dto->roommate = $legacyUzivatel?->ubytovanS() ?: null;
+        $dto->declined = (bool) $legacyUzivatel?->nechceUbytovani();
+
+        foreach (self::NAZVY_DNU as $den => $nazev) {
+            if ($den === self::DEN_NEDELE && ! $muzeNedeli) {
+                continue;
+            }
+            $denDto = new AccommodationDayOutputDto();
+            $denDto->day = $den;
+            $denDto->name = $nazev;
+            $dto->days[] = $denDto;
+        }
+
+        [$koupeneVarianty, $koupeneDny] = $this->koupeneNoci($user, $year);
+        $dto->selectedVariantIds = array_values($koupeneVarianty);
+
+        // A night the customer already holds always gets a cell, even on a day they could
+        // not newly order — otherwise the booking they own is invisible and the write path
+        // would drop it, leaving the rest non-consecutive.
+        if (! $muzeNedeli && in_array(self::DEN_NEDELE, $koupeneDny, true)) {
+            $denDto = new AccommodationDayOutputDto();
+            $denDto->day = self::DEN_NEDELE;
+            $denDto->name = self::NAZVY_DNU[self::DEN_NEDELE];
+            $dto->days[] = $denDto;
+        }
+
+        $viditelneDny = array_column($dto->days, 'day');
+        $prodano = $this->prodanoPoVariantach($year);
+
+        foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
+            $typDto = $this->toTypeDto(
+                $product, $user, $year, $viditelneDny, $prodejUkoncen, $koupeneVarianty, $prodano, $jeOrganizator,
+            );
+            if ($typDto !== null) {
+                $dto->types[] = $typDto;
+            }
+        }
+
+        return $dto;
+    }
+
+    /**
+     * @param int[]          $viditelneDny
+     * @param int[]          $koupeneVarianty
+     * @param array<int,int> $prodano         sold count per variant id
+     */
+    private function toTypeDto(
+        Product $product,
+        User $user,
+        int $year,
+        array $viditelneDny,
+        bool $prodejUkoncen,
+        array $koupeneVarianty,
+        array $prodano,
+        bool $jeOrganizator,
+    ): ?AccommodationTypeOutputDto {
+        // The nights absorbed by the day-variant migration are still products in their own
+        // right — the legacy form reads them — but they carry no variants and must not
+        // appear as rows of their own here.
+        $variants = $product->getVariants();
+        if ($variants->isEmpty()) {
+            return null;
+        }
+
+        // Legacy offers a night only when the product is VEREJNY and still within
+        // nabizet_do; isPublic() covers both. A RESTRICTED type stays visible so an
+        // existing booking can be seen, but no new night can be ticked.
+        $nabizeno = $product->isPublic();
+
+        $discount = $this->discountCalculator->calculateDiscount($product, $user, $year);
+
+        $typDto = new AccommodationTypeOutputDto();
+        $typDto->productId = (int) $product->getId();
+        $typDto->name = $product->getName();
+        $typDto->description = $product->getDescription();
+        $typDto->price = $product->getCurrentPrice();
+        $typDto->discountedPrice = $discount['finalPrice'];
+
+        foreach ($variants as $variant) {
+            $den = $variant->getAccommodationDay();
+            if ($den === null || ! in_array($den, $viditelneDny, true) || $variant->getId() === null) {
+                continue;
+            }
+
+            // remaining_quantity still holds the produced count for anything the legacy
+            // form sells, so derive what is left the way legacy does.
+            $kapacita = $variant->getRemainingQuantity();
+            $zbyva = $kapacita === null
+                ? null
+                : max(0, $kapacita - ($prodano[$variant->getId()] ?? 0) - $this->rezervovanoProOrganizatory($variant, $jeOrganizator));
+            $vyprodano = $zbyva !== null && $zbyva <= 0;
+
+            $koupeno = in_array($variant->getId(), $koupeneVarianty, true);
+
+            $cell = new AccommodationCellOutputDto();
+            $cell->variantId = $variant->getId();
+            $cell->selected = $koupeno;
+            $cell->remaining = $zbyva;
+            $cell->soldOut = $vyprodano;
+            // A night already booked stays selectable, otherwise the customer could not
+            // drop it — the same reason the legacy grid never disables a ticked box.
+            $cell->locked = ! $koupeno && ($prodejUkoncen || $vyprodano || ! $nabizeno);
+
+            $typDto->nights[$den] = $cell;
+        }
+
+        return $typDto->nights === [] ? null : $typDto;
+    }
+
+    /**
+     * Organizer-reserved places are not on offer to anyone else, mirroring what
+     * CapacityManager::purchase() enforces on the write path.
+     */
+    private function rezervovanoProOrganizatory(ProductVariant $variant, bool $jeOrganizator): int
+    {
+        return $jeOrganizator ? 0 : ($variant->getEffectiveReservedForOrganizers() ?? 0);
+    }
+
+    /**
+     * @return array<int, int> sold count per accommodation variant id
+     */
+    private function prodanoPoVariantach(int $year): array
+    {
+        $variantIds = [];
+        foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
+            foreach ($product->getVariants() as $variant) {
+                if ($variant->getId() !== null) {
+                    $variantIds[] = $variant->getId();
+                }
+            }
+        }
+
+        return $this->orderItemRepository->countSoldByVariant($variantIds, $year);
+    }
+
+    /**
+     * @return array{0: int[], 1: int[]} variant ids and day indexes of this year's
+     *                                   accommodation the customer already holds
+     */
+    private function koupeneNoci(User $user, int $year): array
+    {
+        $varianty = [];
+        $dny = [];
+        foreach ($this->orderItemRepository->findByCustomerAndYear($user, $year) as $item) {
+            $variant = $item->getVariant();
+            if ($variant === null || $variant->getAccommodationDay() === null) {
+                continue;
+            }
+            // The tag check is what actually selects accommodation: meals carry
+            // accommodation_day too (it doubles as "which festival day"), so filtering on
+            // that alone would count a bought breakfast as a booked night.
+            if (! $variant->getProduct()->hasTag(ProductTagCode::UBYTOVANI->value)) {
+                continue;
+            }
+            $varianty[] = (int) $variant->getId();
+            $dny[] = (int) $variant->getAccommodationDay();
+        }
+
+        return [$varianty, array_unique($dny)];
+    }
+}

--- a/symfony/tests/State/Cart/AccommodationProviderTest.php
+++ b/symfony/tests/State/Cart/AccommodationProviderTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\State\Cart;
+
+use ApiPlatform\Metadata\Get;
+use App\Entity\Product;
+use App\Entity\ProductVariant;
+use App\Entity\User;
+use App\Enum\ProductStateEnum;
+use App\Enum\ProductTagCode;
+use App\Repository\OrderItemRepository;
+use App\Repository\ProductRepository;
+use App\Service\CurrentYearProviderInterface;
+use App\Service\DiscountCalculator;
+use App\Service\LegacySessionService;
+use App\State\Cart\AccommodationProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class AccommodationProviderTest extends TestCase
+{
+    private const ROK = 2026;
+
+    private const DEN_CTVRTEK = 1;
+
+    private const ID_VARIANTY = 50;
+
+    private MockObject $productRepository;
+
+    private MockObject $orderItemRepository;
+
+    private MockObject $legacySession;
+
+    private MockObject $security;
+
+    private AccommodationProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->productRepository = $this->createMock(ProductRepository::class);
+        $this->orderItemRepository = $this->createMock(OrderItemRepository::class);
+        $this->legacySession = $this->createMock(LegacySessionService::class);
+        $this->security = $this->createMock(Security::class);
+
+        $discountCalculator = $this->createMock(DiscountCalculator::class);
+        $discountCalculator->method('calculateDiscount')->willReturn([
+            'finalPrice'     => '1300.00',
+            'discount'       => null,
+            'discountAmount' => null,
+            'reason'         => null,
+        ]);
+
+        $currentYearProvider = $this->createMock(CurrentYearProviderInterface::class);
+        $currentYearProvider->method('getCurrentYear')->willReturn(self::ROK);
+
+        $this->provider = new AccommodationProvider(
+            $this->productRepository,
+            $this->orderItemRepository,
+            $discountCalculator,
+            $currentYearProvider,
+            $this->legacySession,
+            $this->security,
+        );
+    }
+
+    public function testMissingLegacySessionIsRefused(): void
+    {
+        $this->security->method('getUser')->willReturn($this->createMock(User::class));
+        $this->legacySession->method('getCurrentUser')->willReturn(null);
+
+        // Degrading to "no rights" would silently drop an organizer's Sunday night
+        // behind a 200, so the endpoint has to refuse instead.
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->provider->provide(new Get());
+    }
+
+    /**
+     * The regression this pins: OrderItem maps to shop_nakupy, so the sold count already
+     * covers the new cart, whose sales CapacityManager has also taken off
+     * remaining_quantity. Deriving from remaining_quantity double-counts them.
+     */
+    public function testRemainingIsProducedMinusSoldRegardlessOfRemainingQuantity(): void
+    {
+        $this->prepareUser();
+
+        // remaining_quantity is deliberately absurd: reading it would show 999 free beds.
+        $variant = $this->prepareGrid(remainingQuantity: 999, produced: 10, sold: 3, held: 0);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertSame(7, $cell->remaining);
+        $this->assertFalse($cell->soldOut);
+        $this->assertSame($variant->getId(), $cell->variantId);
+    }
+
+    public function testFullyBookedNightIsSoldOut(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: 10, produced: 10, sold: 10, held: 0);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertSame(0, $cell->remaining);
+        $this->assertTrue($cell->soldOut);
+    }
+
+    public function testOwnBookedNightIsNotSoldOut(): void
+    {
+        $this->prepareUser();
+
+        // The last bed, taken by this very customer: legacy adds it back so the row does
+        // not render sold out under its own ticked checkbox.
+        $this->prepareGrid(remainingQuantity: 0, produced: 10, sold: 10, held: 1);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertSame(1, $cell->remaining);
+        $this->assertFalse($cell->soldOut);
+    }
+
+    public function testUnlimitedNightHasNoRemainingCount(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: null, produced: null, sold: 4, held: 0);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertNull($cell->remaining);
+        $this->assertFalse($cell->soldOut);
+    }
+
+    public function testOverbookedNightDoesNotReportNegativeRemaining(): void
+    {
+        $this->prepareUser();
+
+        // Both write paths feed shop_nakupy and kusu_vyrobeno is admin-editable, so sold
+        // can exceed produced. The grid must not offer "-2 beds".
+        $this->prepareGrid(remainingQuantity: 0, produced: 10, sold: 12, held: 0);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertSame(0, $cell->remaining);
+        $this->assertTrue($cell->soldOut);
+    }
+
+    public function testVariantWithoutLegacyRowCountsAsUnlimited(): void
+    {
+        $this->prepareUser();
+
+        // Sold and held are keyed by variant id but produced by variant code, so a variant
+        // whose code has no shop_predmety row falls back to unlimited rather than to zero.
+        $this->prepareGrid(remainingQuantity: 5, produced: null, sold: 2, held: 0);
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertNull($cell->remaining);
+    }
+
+    public function testVariantlessProductIsNotARow(): void
+    {
+        $this->prepareUser();
+
+        // The nights absorbed by the day-variant migration stay products for the legacy
+        // form to read, but carry no variants and must not become rows of their own.
+        $product = $this->createProduct(1, 'Hotel');
+        $this->productRepository->method('findByTag')->willReturn([$product]);
+        $this->orderItemRepository->method('countSoldByVariant')->willReturn([]);
+        $this->orderItemRepository->method('countHeldByCustomer')->willReturn([]);
+        $this->productRepository->method('producedQuantityByVariantCode')->willReturn([]);
+        $this->orderItemRepository->method('findByCustomerAndYear')->willReturn([]);
+
+        $this->assertSame([], $this->provider->provide(new Get())->types);
+    }
+
+    private function prepareUser(): void
+    {
+        $this->security->method('getUser')->willReturn($this->createMock(User::class));
+
+        $legacyUzivatel = $this->createMock(\Uzivatel::class);
+        $legacyUzivatel->method('maPravo')->willReturn(false);
+        $legacyUzivatel->method('jeOrganizator')->willReturn(false);
+        $legacyUzivatel->method('ubytovanS')->willReturn('');
+        $legacyUzivatel->method('nechceUbytovani')->willReturn(false);
+
+        $this->legacySession->method('getCurrentUser')->willReturn($legacyUzivatel);
+    }
+
+    /**
+     * One room type with a single Thursday night, wired through every lookup the
+     * remaining-count arithmetic reads.
+     */
+    private function prepareGrid(
+        ?int $remainingQuantity,
+        ?int $produced,
+        int $sold,
+        int $held,
+        ?string $kodJinehoRadku = null,
+    ): ProductVariant {
+        $product = $this->createProduct(1, 'Hotel');
+
+        $variant = new ProductVariant();
+        $variant->setProduct($product);
+        $variant->setCode('Hd-2L-ct');
+        $variant->setName('čtvrtek');
+        $variant->setAccommodationDay(self::DEN_CTVRTEK);
+        $variant->setRemainingQuantity($remainingQuantity);
+        $this->setId($variant, self::ID_VARIANTY);
+        $product->addVariant($variant);
+
+        $this->productRepository->method('findByTag')
+            ->with(ProductTagCode::UBYTOVANI)
+            ->willReturn([$product]);
+        $this->orderItemRepository->method('countSoldByVariant')->willReturn([
+            50 => $sold,
+        ]);
+        $this->orderItemRepository->method('countHeldByCustomer')->willReturn([
+            50 => $held,
+        ]);
+        $this->productRepository->method('producedQuantityByVariantCode')
+            ->willReturn([
+                ($kodJinehoRadku ?? 'Hd-2L-ct') => $produced,
+            ]);
+        $this->orderItemRepository->method('findByCustomerAndYear')->willReturn([]);
+
+        return $variant;
+    }
+
+    private function createProduct(int $id, string $name): Product
+    {
+        $product = new Product();
+        $product->setName($name);
+        $product->setCurrentPrice('1300.00');
+        $product->setDescription('');
+        $product->setState(ProductStateEnum::PUBLIC);
+        $this->setId($product, $id);
+
+        return $product;
+    }
+
+    private function setId(object $entity, int $id): void
+    {
+        $reflection = new \ReflectionProperty($entity, 'id');
+        $reflection->setValue($entity, $id);
+    }
+}

--- a/symfony/tests/State/Cart/AccommodationProviderTest.php
+++ b/symfony/tests/State/Cart/AccommodationProviderTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\State\Cart;
 
 use ApiPlatform\Metadata\Get;
+use App\Entity\OrderItem;
 use App\Entity\Product;
+use App\Entity\ProductTag;
 use App\Entity\ProductVariant;
 use App\Entity\User;
 use App\Enum\ProductStateEnum;
@@ -16,6 +18,8 @@ use App\Service\CurrentYearProviderInterface;
 use App\Service\DiscountCalculator;
 use App\Service\LegacySessionService;
 use App\State\Cart\AccommodationProvider;
+use Gamecon\Cas\DateTimeImmutableStrict;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -39,8 +43,12 @@ class AccommodationProviderTest extends TestCase
 
     private AccommodationProvider $provider;
 
+    private ?SystemoveNastaveni $puvodniNastaveni = null;
+
     protected function setUp(): void
     {
+        $this->puvodniNastaveni = $GLOBALS['systemoveNastaveni'] ?? null;
+
         $this->productRepository = $this->createMock(ProductRepository::class);
         $this->orderItemRepository = $this->createMock(OrderItemRepository::class);
         $this->legacySession = $this->createMock(LegacySessionService::class);
@@ -65,6 +73,45 @@ class AccommodationProviderTest extends TestCase
             $this->legacySession,
             $this->security,
         );
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['systemoveNastaveni'] = $this->puvodniNastaveni;
+    }
+
+    public function testSaleClosedAfterTheDeadline(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: 10, produced: 10, sold: 0, held: 0);
+        $this->posunCas('2099-01-01 00:00:00');
+
+        $this->assertTrue($this->provider->provide(new Get())->saleClosed);
+    }
+
+    public function testFreeNightIsLockedAfterTheDeadline(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: 10, produced: 10, sold: 0, held: 0);
+        $this->posunCas('2099-01-01 00:00:00');
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        $this->assertTrue($cell->locked);
+        $this->assertFalse($cell->soldOut);
+    }
+
+    public function testOwnBookedNightStaysUnlockedAfterTheDeadline(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: 10, produced: 10, sold: 1, held: 1, koupeno: true);
+        $this->posunCas('2099-01-01 00:00:00');
+
+        $cell = $this->provider->provide(new Get())->types[0]->nights[self::DEN_CTVRTEK];
+
+        // Otherwise the customer could no longer cancel a night they already hold.
+        $this->assertTrue($cell->selected);
+        $this->assertFalse($cell->locked);
     }
 
     public function testMissingLegacySessionIsRefused(): void
@@ -177,6 +224,14 @@ class AccommodationProviderTest extends TestCase
         $this->assertSame([], $this->provider->provide(new Get())->types);
     }
 
+    private function posunCas(string $cas): void
+    {
+        $GLOBALS['systemoveNastaveni'] = SystemoveNastaveni::zGlobals(
+            \ROCNIK,
+            new DateTimeImmutableStrict($cas),
+        );
+    }
+
     private function prepareUser(): void
     {
         $this->security->method('getUser')->willReturn($this->createMock(User::class));
@@ -200,6 +255,7 @@ class AccommodationProviderTest extends TestCase
         int $sold,
         int $held,
         ?string $kodJinehoRadku = null,
+        bool $koupeno = false,
     ): ProductVariant {
         $product = $this->createProduct(1, 'Hotel');
 
@@ -225,7 +281,20 @@ class AccommodationProviderTest extends TestCase
             ->willReturn([
                 ($kodJinehoRadku ?? 'Hd-2L-ct') => $produced,
             ]);
-        $this->orderItemRepository->method('findByCustomerAndYear')->willReturn([]);
+        $koupeneItems = [];
+        if ($koupeno) {
+            // koupeneNoci() reads the tag off the product, because meals carry
+            // accommodation_day too and would otherwise count as booked nights.
+            $tag = new ProductTag();
+            $tag->setCode(ProductTagCode::UBYTOVANI->value);
+            $product->addTag($tag);
+
+            $item = new OrderItem();
+            $item->setVariant($variant);
+            $item->setProduct($product);
+            $koupeneItems[] = $item;
+        }
+        $this->orderItemRepository->method('findByCustomerAndYear')->willReturn($koupeneItems);
 
         return $variant;
     }

--- a/ui/src/api/symfony/endpoints.ts
+++ b/ui/src/api/symfony/endpoints.ts
@@ -1,5 +1,6 @@
 import { symfonyFetch } from "./fetch";
 import {
+  ApiAccommodation,
   ApiCart,
   ApiEntryFee,
   ApiHydraCollection,
@@ -18,6 +19,16 @@ export const fetchMeals = async (): Promise<ApiMealProduct[]> => {
   if (!res.ok) throw new Error(`Failed to fetch meals: ${res.status}`);
   const data = await res.json() as ApiHydraCollection<ApiMealProduct>;
   return data["hydra:member"] ?? data["member"] ?? [];
+};
+
+/**
+ * Fetch the accommodation section. One payload rather than a list: the nights of a
+ * booking must be consecutive, so they are chosen as a set.
+ */
+export const fetchAccommodation = async (): Promise<ApiAccommodation> => {
+  const res = await symfonyFetch("cart/accommodation");
+  if (!res.ok) throw new Error(`Failed to fetch accommodation: ${res.status}`);
+  return await res.json() as ApiAccommodation;
 };
 
 /**

--- a/ui/src/api/symfony/types.ts
+++ b/ui/src/api/symfony/types.ts
@@ -6,6 +6,43 @@ export type ApiMealProduct = {
   remainingQuantity: number | null;
 };
 
+export type ApiAccommodationCell = {
+  variantId: number;
+  selected: boolean;
+  /** Null = unlimited; dorm beds are effectively uncapped. */
+  remaining: number | null;
+  soldOut: boolean;
+  /** Cannot be ticked. An already-booked night is never locked, so it can be dropped. */
+  locked: boolean;
+};
+
+export type ApiAccommodationType = {
+  productId: number;
+  name: string;
+  description: string;
+  price: string;
+  discountedPrice: string;
+  /** Keyed by day index; a day this type is not offered on has no entry. */
+  nights: Record<number, ApiAccommodationCell>;
+};
+
+export type ApiAccommodationDay = {
+  /** 0 = Wednesday … 4 = Sunday. */
+  day: number;
+  name: string;
+};
+
+export type ApiAccommodation = {
+  days: ApiAccommodationDay[];
+  types: ApiAccommodationType[];
+  selectedVariantIds: number[];
+  /** Fewer nights than this is refused, unless the customer may book a single night. */
+  minimumNights: number;
+  saleClosed: boolean;
+  roommate: string | null;
+  declined: boolean;
+};
+
 export type ApiMerchProduct = {
   name: string;
   description: string;

--- a/ui/src/pages/ubytovani/UbytovaniMřížka.less
+++ b/ui/src/pages/ubytovani/UbytovaniMřížka.less
@@ -1,0 +1,99 @@
+.ubytovani-mrizka {
+  margin: 1em 0;
+
+  &--tabulka {
+    border-collapse: collapse;
+    width: 100%;
+
+    th,
+    td {
+      border: 1px solid #ddd;
+      padding: 8px 12px;
+      text-align: center;
+    }
+
+    th {
+      background-color: #f5f5f5;
+      font-weight: bold;
+    }
+  }
+
+  &--typ {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: left !important;
+  }
+
+  &--nazev {
+    font-weight: bold;
+  }
+
+  &--popis {
+    color: #777;
+    font-size: 0.85em;
+  }
+
+  &--cena {
+    font-weight: bold;
+  }
+
+  &--cena-puvodni {
+    margin-right: 6px;
+    color: #999;
+    font-weight: normal;
+    text-decoration: line-through;
+  }
+
+  &--bunka {
+    label,
+    input {
+      cursor: default;
+    }
+  }
+
+  &--zbyva {
+    display: block;
+    color: #777;
+    font-size: 0.75em;
+  }
+
+  &--vybrano {
+    background-color: #e8f5e9;
+  }
+
+  &--vyprodano,
+  &--zamceno {
+    background-color: #fafafa;
+    color: #aaa;
+  }
+
+  // A night this room type is not sold on at all — rendered blank, not disabled.
+  &--nenabizeno {
+    background-color: #f5f5f5;
+  }
+
+  &--uzavreno,
+  &--pravidlo {
+    color: #777;
+    font-size: 0.9em;
+  }
+
+  &--error {
+    margin-bottom: 1em;
+    padding: 8px 12px;
+    border-radius: 4px;
+    background-color: #fdecea;
+    color: #b3261e;
+  }
+
+  &--loading,
+  &--empty {
+    color: #777;
+  }
+
+  &--spolubydlici,
+  &--nechci {
+    margin-top: 0.5em;
+  }
+}

--- a/ui/src/pages/ubytovani/UbytovaniMřížka.tsx
+++ b/ui/src/pages/ubytovani/UbytovaniMřížka.tsx
@@ -1,0 +1,120 @@
+import { h } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import { fetchAccommodation } from "../../api/symfony/endpoints";
+import { ApiAccommodation, ApiAccommodationCell } from "../../api/symfony/types";
+import "./UbytovaniMřížka.less";
+
+/** Format price string for Czech locale: "1300.00" → "1300 Kč". */
+function formatCena(price: string): string {
+  const castka = parseFloat(price);
+  if (isNaN(castka)) return `${price}\u2009Kč`;
+  if (Number.isInteger(castka)) return `${castka}\u2009Kč`;
+  return `${castka.toFixed(2).replace(".", ",")}\u2009Kč`;
+}
+
+function stavBuňky(cell: ApiAccommodationCell): string {
+  if (cell.selected) return "ubytovani-mrizka--vybrano";
+  if (cell.soldOut) return "ubytovani-mrizka--vyprodano";
+  if (cell.locked) return "ubytovani-mrizka--zamceno";
+  return "";
+}
+
+/**
+ * Read-only for now: the write path saves the whole selection at once, because the nights
+ * of a booking must be consecutive and a per-click save cannot express that. Until then
+ * the legacy form below still does the saving.
+ */
+export function UbytovaniMřížka() {
+  const [ubytovani, setUbytovani] = useState<ApiAccommodation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAccommodation()
+      .then((data) => {
+        setUbytovani(data);
+        setLoading(false);
+      })
+      .catch((chyba: unknown) => {
+        setError(chyba instanceof Error ? chyba.message : "Nepodařilo se načíst ubytování");
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return <div class="ubytovani-mrizka--loading">Načítám ubytování…</div>;
+  if (error) return <div class="ubytovani-mrizka--error">{error}</div>;
+  if (!ubytovani || ubytovani.types.length === 0) {
+    return <div class="ubytovani-mrizka--empty">Žádné ubytování k dispozici.</div>;
+  }
+
+  const { days, types, minimumNights, saleClosed, roommate, declined } = ubytovani;
+
+  return (
+    <div class="ubytovani-mrizka">
+      {saleClosed && (
+        <p class="ubytovani-mrizka--uzavreno">Možnost objednání ubytování už skončila.</p>
+      )}
+
+      <table class="ubytovani-mrizka--tabulka">
+        <thead>
+          <tr>
+            <th></th>
+            {days.map((den) => (
+              <th key={den.day}>{den.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {types.map((typ) => (
+            <tr key={typ.productId}>
+              <td class="ubytovani-mrizka--typ">
+                <span class="ubytovani-mrizka--nazev">{typ.name}</span>
+                {typ.description && (
+                  <span class="ubytovani-mrizka--popis">{typ.description}</span>
+                )}
+                <span class="ubytovani-mrizka--cena">
+                  {typ.discountedPrice !== typ.price && (
+                    <span class="ubytovani-mrizka--cena-puvodni">{formatCena(typ.price)}</span>
+                  )}
+                  {formatCena(typ.discountedPrice)}
+                </span>
+              </td>
+              {days.map((den) => {
+                const cell = typ.nights[den.day];
+                if (!cell) {
+                  return <td key={den.day} class="ubytovani-mrizka--nenabizeno"></td>;
+                }
+
+                return (
+                  <td key={den.day} class={`ubytovani-mrizka--bunka ${stavBuňky(cell)}`}>
+                    <input type="checkbox" checked={cell.selected} disabled />
+                    {cell.remaining !== null && (
+                      <span class="ubytovani-mrizka--zbyva">
+                        {cell.soldOut ? "vyprodáno" : `zbývá ${cell.remaining}`}
+                      </span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p class="ubytovani-mrizka--pravidlo">
+        {minimumNights > 1
+          ? `Noci musí na sebe navazovat, nejméně ${minimumNights}.`
+          : "Noci musí na sebe navazovat."}
+      </p>
+
+      {roommate && (
+        <p class="ubytovani-mrizka--spolubydlici">
+          Na pokoji s: <strong>{roommate}</strong>
+        </p>
+      )}
+      {declined && (
+        <p class="ubytovani-mrizka--nechci">Ubytování nechceš.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Built on `1274-přepsat-e-shop` and targeting it — this is not a PR into `main`.

First part of accommodation: the data structure and the read endpoint. The write path comes in a following PR.

## Accommodation as product variants

Legacy sells every night as a separate product and recovers the room type from the name with a regex (`Shop::bezDne` strips "středa"). This makes it one product per type with a variant per night — the same shape t-shirt sizes already use.

The structure is in fact already in the data: `kod_predmetu` has the form `Hs-2L-ct` = type `Hs-2L`, night `ct`, and it agrees with `ubytovani_den` on all 40 rows of the current year. The migration therefore groups by code and never reads the name.

Result: **8 products × 5 nights**, with stock kept per night (`Hs-2L` has 3/11/12/12/3).

**Only the current year is converted.** Older years use a different convention (`Dvojlůžák středa`, no structured code) and each would need its own parsing; they are no longer on sale, so they keep a single default variant. There is a note about this in `MISSING_FEATURES.md`, where the status of the other items has also been checked and updated — the document started as a list of questions, so even finished items were marked with a cross.

**The day suffix stays in the name** of the 32 absorbed rows, because the legacy form still parses it. It is stripped only from the 8 owners, which would otherwise carry all five nights and be named "neděle" (the owner is the lowest id, which happens to be the Sunday row).

## Read endpoint

`GET /cart/accommodation` returns the whole section in one payload — the type × night grid, what the customer already bought, and the rules. One payload on purpose: the nights of a single order have to be consecutive, so they cannot be picked one at a time the way merch is, and the write path will be set-based too.

Rules included: the Sunday night is hidden without the permission (but shown when the customer already holds it — otherwise the write path would silently drop it and the rest would stop being consecutive), the minimum is 1 or 2 nights depending on the single-night permission, sale after the deadline is read-only, and an already booked night stays untickable even after the deadline.

## The component is not mounted yet

Without a write path, a second, unclickable grid would stand next to the legacy form — worse than nothing. The component and its stylesheet are in the bundle, ready; mounting comes together with the write path.

## What code review found

Two things that would have caused real damage in production:

- **Capacity was completely wrong.** `product_variant.remaining_quantity` is seeded from `kusu_vyrobeno` and only decremented by the new `CapacityManager` — but accommodation is still sold by the legacy form, which writes straight into `shop_nakupy`. On live data: `Hd-2L-ct` has capacity 10, **10 sold**, and `remaining_quantity` still 10. The grid would report "10 left" for a fully booked room. The remaining count is now derived as `kusu_vyrobeno − sold`, the way legacy does it.
- **A second run of the migration destroyed data.** The `UPDATE` joined on `product_variant.product_id`, but after the first run the variants sit on the owner whose own day is Sunday — a second run would rewrite all five nights of every type to Sunday, irreversibly. It now joins on the variant code (which does not change) and reads the day from the code. Verified by a second run: the days stayed `0,1,2,3,4`.

Also from the review: a product-state check (all 8 owners are `RESTRICTED`, because the owner is the Sunday row), subtracting places reserved for organizers, skipping codes without a separator, and a fix to `EshopImporter` — its variant sync assumes a variant mirrors its product, so on re-import it would have renamed the Sunday variant to the full type name and overwritten its stock with the total for the type.

## Second review round

Running the review again over the pushed commits found the capacity arithmetic was still wrong, in the opposite direction from the first round:

- **New-cart sales were subtracted twice.** `OrderItem` maps to `shop_nakupy` — the very table the legacy form writes — so `countSoldByVariant()` counts *both* sale paths, while `CapacityManager` has already decremented `remaining_quantity` for the new cart's share. Pairing the two double-counts every night the new cart sells, so a room reads sold out while beds are free. Now it uses legacy's own formula, `kusu_vyrobeno − sold + what this customer holds`, with the produced figure taken from the night's own `shop_predmety` row (matched by variant code — the migration reparents the variant but leaves that row alone, and nothing in the new stack mutates `kusu_vyrobeno`).
- **Your own booked night rendered as sold out.** Adding back the customer's own nights — which legacy also does — fixes the last bed showing "vyprodáno" next to its own ticked checkbox.
- **Organizer reservation dropped.** Legacy accommodation never consults `reserved_for_organizers`, and after the migration the parent product holds a single night's figure, which was being applied to all five — showing fewer beds than the legacy form for the same room while both are live.
- **Missing legacy session now fails with 403** instead of degrading to "no rights", which silently dropped an organizer's Sunday night and still returned 200.
- **Migration owner subquery** now applies the day filter too, so a row whose last code segment is not a day cannot win `MIN(id)` and become a type owner that is never renamed or given a day.

Verified by running the migration three times over 509 variants: zero day or code changes, and the nights stay spread across all five days instead of collapsing onto Sunday.

Dismissed: `formatCena` rendering a malformed price verbatim — the same helper exists in the merch and meal components, the value is `DECIMAL(6,2)` from PHP, and changing only this copy would leave the three inconsistent.

## Where to click through it

Nowhere yet — the component is not mounted. Verification:

```bash
./bin-docker/php ./vendor/bin/phpunit tests/Shop/
./bin-docker/php ./bin/console migrations:continue
./bin-docker/docker-bash bin/phpstan.sh
```
