### PR TITLE
Mazat staré preview a archive images z GHCR

### DIFF
--- a/.github/workflows/prune-ghcr-images.yml
+++ b/.github/workflows/prune-ghcr-images.yml
@@ -1,0 +1,157 @@
+name: Prune old GHCR images
+
+# Safety net for whatever the per-teardown cleanup in teardown-preview.yml
+# misses: images from previews torn down before that existed, and superseded
+# archive builds (a year archive is never torn down, so nothing else ever
+# removes its old sha-tagged versions).
+#
+# yamllint disable-line rule:truthy
+on:
+    schedule:
+        # Sundays 05:30 UTC — after the host's own weekly image prune, and
+        # well clear of the working week so a bug here is noticed on a
+        # deploy, not in the middle of one.
+        -   cron: '30 5 * * 0'
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                description: 'List what would be deleted without deleting'
+                type: boolean
+                default: true
+
+permissions:
+    contents: read
+    packages: write
+
+concurrency:
+    group: prune-ghcr-images
+    cancel-in-progress: false
+
+jobs:
+    prune:
+        runs-on: ubuntu-24.04
+        steps:
+                # Keeps, for every distinct preview slug / archive year, the
+                # KEEP_PER_STREAM newest versions and deletes older ones. Age
+                # alone is the wrong axis: an archive year that has not been
+                # rebuilt since June is still live on the host, and deleting
+                # its only image would break a redeploy.
+                #
+                # A version is a candidate only when ALL its tags belong to
+                # one stream — deleting a version drops every tag it carries,
+                # so one shared with another stream must be left alone. The
+                # rolling `preview-<slug>` / `archive-<year>` tag (no sha) is
+                # never a candidate: it is what the host pulls by default.
+            -   name: Set up SSH
+                env:
+                    SSH_KEY: ${{ secrets.GAMECON_DEPLOY_SSH_KEY }}
+                    SSH_KNOWN_HOSTS: ${{ secrets.GAMECON_KNOWN_HOSTS }}
+                run: |
+                    mkdir -p ~/.ssh
+                    echo "$SSH_KEY" > ~/.ssh/id_ed25519
+                    chmod 0600 ~/.ssh/id_ed25519
+                    echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+                    chmod 0644 ~/.ssh/known_hosts
+
+            -   name: Prune superseded versions
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    OWNER: ${{ github.repository_owner }}
+                    KEEP_PER_STREAM: '2'
+                    DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+                run: |
+                    # `jq -s add` merges the pages: --paginate emits one JSON
+                    # array per page on some gh versions and a single merged
+                    # array on others, and the runner's version is not ours to
+                    # pin. Slurping is correct either way; without it the
+                    # keep-N-per-stream below would silently apply per page.
+                    gh api --paginate \
+                        "/orgs/$OWNER/packages/container/gamecon/versions?per_page=100" \
+                        | jq -s 'add // []' > all-versions.json
+                    total=$(jq 'length' all-versions.json)
+                    echo "Total versions: $total"
+
+                    # Tags of everything currently deployed, from the host's
+                    # own records rather than inferred from tag shape: a slug
+                    # may end in something shaped like a sha (`sha-1a2b3c4d` is
+                    # a real fallback slug in deploy-preview.yml), so
+                    # `preview-slevy-abcdef1` reads equally as a stale build of
+                    # `slevy` and as a live preview's rolling tag. Fail closed —
+                    # without the records we cannot tell them apart.
+                    if ! ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
+                        "cat /var/lib/gamecon/deployments/previews/*.json \
+                             /var/lib/gamecon/deployments/archives/*.json \
+                             2>/dev/null || true" > live-records.json; then
+                        echo "Could not read deployment records — aborting." >&2
+                        exit 1
+                    fi
+                    jq -rs '[.[] | .image | sub("^[^:]+:"; "")] | unique' \
+                        < live-records.json > live-tags.json
+                    echo "Live image tags: $(jq -r 'length' live-tags.json)"
+
+                    jq -r --argjson keep "$KEEP_PER_STREAM" \
+                          --slurpfile live live-tags.json '
+                        ($live[0]) as $liveTags
+                        | [ .[]
+                            | { id, created: .created_at,
+                                tags: (.metadata.container.tags // []) }
+                            # Never touch a version any deployment still points
+                            # at, whatever its tag looks like.
+                            | select([.tags[] | IN($liveTags[])] | any | not)
+                            | . + { streams: [
+                                  .tags[]
+                                  | capture("^(?<stream>(preview|archive)-.+)-[0-9a-f]{7,40}$")
+                                  | .stream
+                              ] }
+                            # Every tag must resolve to one stream: deleting a
+                            # version drops all of its tags at once. A version
+                            # carrying a bare rolling tag resolves to none and
+                            # is skipped, so what the host pulls is never a
+                            # candidate.
+                            | select((.tags | length) > 0
+                                     and (.streams | length) == (.tags | length)
+                                     and (.streams | unique | length) == 1)
+                            | . + { stream: .streams[0] }
+                          ]
+                        | group_by(.stream)
+                        | map(sort_by(.created) | reverse | .[$keep:])
+                        | flatten
+                        | .[]
+                        | "\(.id)\t\(.stream)\t\(.created)"
+                    ' all-versions.json > prunable.tsv
+
+                    # Untagged versions are the manifests orphaned when a
+                    # rebuild moves a rolling tag off them, and they are the
+                    # bulk of the storage. Nothing references them by name, so
+                    # age is the only safe axis — a very recent one may belong
+                    # to a build still being tagged.
+                    jq -r --arg cutoff "$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)" '
+                        .[]
+                        | select((.metadata.container.tags // []) | length == 0)
+                        | select(.created_at < $cutoff)
+                        | "\(.id)\tuntagged\t\(.created_at)"
+                    ' all-versions.json >> prunable.tsv
+
+                    count=$(grep -c . prunable.tsv || true)
+                    echo "Prunable (keeping $KEEP_PER_STREAM newest per stream): $count"
+                    cat prunable.tsv
+
+                    # A filter bug that marks everything prunable must not be
+                    # able to empty the package on an unattended run.
+                    if [ "$total" -gt 0 ] && [ "$count" -gt $((total * 3 / 4)) ]; then
+                        echo "Refusing: $count of $total versions marked prunable." >&2
+                        echo "That is more than expected — check the filter." >&2
+                        exit 1
+                    fi
+
+                    if [ "$DRY_RUN" = "true" ]; then
+                        echo "Dry run — nothing deleted."
+                        exit 0
+                    fi
+
+                    cut -f1 prunable.tsv | while read -r version_id; do
+                        gh api -X DELETE \
+                            "/orgs/$OWNER/packages/container/gamecon/versions/$version_id" \
+                            && echo "deleted $version_id" \
+                            || echo "failed $version_id (continuing)"
+                    done

--- a/.github/workflows/teardown-preview.yml
+++ b/.github/workflows/teardown-preview.yml
@@ -26,6 +26,8 @@ on:
 
 permissions:
     contents: read
+    # Delete this branch's images from GHCR when its preview is torn down.
+    packages: write
 
 # MUST stay byte-identical to the group in deploy-preview.yml — concurrency
 # groups are repo-global, so the deploy and the teardown of one branch only
@@ -127,3 +129,87 @@ jobs:
                 run: |
                     ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
                         "/usr/local/sbin/deploy-preview-branch.sh --remove '$SLUG'"
+
+            -   name: Delete this preview's images from GHCR
+                # The host container is gone, so its images are dead weight in
+                # the registry — nothing else ever removes them, and each build
+                # is ~2 GB against the org's packages quota. Deletes the two
+                # tags deploy-preview.yml pushes: the rolling `preview-<slug>`
+                # and every immutable `preview-<slug>-<sha>`.
+                #
+                # A version is deleted only when EVERY one of its tags belongs
+                # to this slug — deleting a version drops all its tags at once,
+                # so a shared one would take an unrelated tag with it.
+                #
+                # `preview-<slug>-<sha>` is matched only when the tag is not
+                # itself another preview's rolling tag: a slug may end in
+                # something shaped like a sha (`sha-1a2b3c4d` is a real
+                # fallback slug above), so tearing down `slevy` must not delete
+                # the live rolling tag of a separate preview `slevy-abcdef1`.
+                #
+                # Best-effort: a registry hiccup must not fail a teardown whose
+                # real work (removing the running preview) already succeeded.
+                if: steps.slug.outputs.slug != ''
+                continue-on-error: true
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    SLUG: ${{ steps.slug.outputs.slug }}
+                    OWNER: ${{ github.repository_owner }}
+                run: |
+                    # `jq -s add` merges the pages: --paginate emits one array
+                    # per page on some gh versions and a single merged array on
+                    # others, and the runner's version is not ours to pin.
+                    gh api --paginate \
+                        "/orgs/$OWNER/packages/container/gamecon/versions?per_page=100" \
+                        | jq -s 'add // []' > all-versions.json
+
+                    # Tags belonging to previews that are still deployed. A tag
+                    # cannot be classified by shape alone: `preview-slevy-abcdef1`
+                    # reads equally as a stale build of `slevy` and as the live
+                    # rolling tag of a separate preview `slevy-abcdef1` (a slug
+                    # ending in hex is legal, and `sha-1a2b3c4d` is a real
+                    # fallback slug above). The host's deployment records say
+                    # which slugs actually exist, so ask it rather than guess.
+                    # Fail closed: if the host cannot be read we cannot tell a
+                    # stale build from a live preview's rolling tag, so delete
+                    # nothing rather than guess. The teardown itself already
+                    # succeeded; the weekly prune will catch these later.
+                    if ! ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
+                        "cat /var/lib/gamecon/deployments/previews/*.json 2>/dev/null || true" \
+                        > live-records.json; then
+                        echo "Could not read deployment records — skipping GHCR cleanup." >&2
+                        exit 0
+                    fi
+                    jq -rs '[.[] | "preview-" + .slug] | unique' \
+                        < live-records.json > live-tags.json
+                    echo "Live preview tags: $(jq -r 'length' live-tags.json)"
+
+                    jq -r --slurpfile live live-tags.json "
+                        (\$live[0]) as \$liveTags
+                        | (\"preview-\" + \$ENV.SLUG) as \$mine
+                        | .[]
+                        | select(
+                            (.metadata.container.tags | length) > 0
+                            and (
+                                [.metadata.container.tags[]
+                                 | . as \$tag
+                                 | \$tag == \$mine
+                                   or (
+                                       (\$tag | startswith(\$mine + \"-\"))
+                                       and (\$tag[(\$mine | length) + 1:]
+                                            | test(\"^[0-9a-f]{7,40}\$\"))
+                                       # not a still-deployed preview's own tag
+                                       and ([\$liveTags[] | select(. == \$tag)]
+                                            | length) == 0
+                                   )]
+                                | all
+                            )
+                          )
+                        | .id
+                    " all-versions.json \
+                    | while read -r version_id; do
+                        echo "Deleting version $version_id"
+                        gh api -X DELETE \
+                            "/orgs/$OWNER/packages/container/gamecon/versions/$version_id" \
+                            || echo "  (delete failed, continuing)"
+                      done


### PR DESCRIPTION
Poslední kus úklidu po diskovém incidentu na hostu — tentokrát v registru.

## Co se hromadí a proč

Oba deploy workflow pushují **dva tagy na build**:

```
ghcr.io/gamecon-cz/gamecon:preview-<slug>            ← rolling, přepisuje se
ghcr.io/gamecon-cz/gamecon:preview-<slug>-<sha7>     ← immutable, nový pokaždé
```

Rolling tag se přesune, takže předchozí image osiří, a sha tag drží každý build navěky. A hlavně:

- **v `.github/` není žádná retention workflow** — nic to nemaže
- **`teardown-preview.yml` sundá kontejner na hostu, ale registru se nedotkne**, takže po mergnutí a smazání větve její images v GHCR zůstanou napořád

Změřeno: **185 úspěšných preview buildů od 21. 7.** (~3,7/den) plus 182 archivních, á zhruba 2 GB.

## Poznámka k účtování

Balíček je **privátní**, i když repo je veřejné (anonymní pull → 403). Veřejné balíčky mají GHCR storage zdarma, privátní se počítají do kvóty organizace — a `gamecon-cz` je na **free** plánu.

Skutečné využití jsem změřit nedokázal (můj token nemá `read:packages`, billing endpointy vyžadují `admin:org`), takže žádné číslo neuvádím. **Stojí za kontrolu v Settings → Billing → Packages.** A nabízí se otázka: nemá být ten balíček veřejný? Repo už veřejné je a problém s kvótou by tím zmizel. Images ale zapékají basic-auth k preview/archive bráně, takže to chce rozhodnutí, ne reflex.

## Řešení — dvě vrstvy

1. **Při teardownu** (`teardown-preview.yml`) — když preview mizí, smažou se i jeho images. To je přesný okamžik, kdy víme, že jsou mrtvé.
2. **Týdenní úklid** (nový `prune-ghcr-images.yml`, neděle 05:30 UTC) — nechá 2 nejnovější buildy na stream plus smaže untagged manifesty starší 30 dnů. Pokrývá, co první vrstva nemůže: existující backlog a archivy (ročník se nikdy „netrhá", takže jeho staré buildy by jinak nikdo neuklidil).

## Klíčová věc: podle jména tagu to rozhodnout NELZE

`preview-slevy-abcdef1` se dá číst dvěma způsoby:

- starý build slugu `slevy` se sha `abcdef1` → **smazat**
- živý rolling tag samostatného preview `slevy-abcdef1` → **nesahat**

A slug končící hexem je legální — `deploy-preview.yml` sám používá fallback `sha-<8 hex>`. První verze téhle změny tenhle případ mazala; ověřeno reprodukcí, že by smazala jediný image živého preview.

Oba joby se proto **ptají hostu**, co je reálně nasazené (`/var/lib/gamecon/deployments/`), a když se tam nedostanou, **radši nesmažou nic**, než aby hádaly.

## Ověření

Testováno spuštěním skutečného kódu z workflow (vytaženého z YAML) proti fixturám se stubnutým `gh` a `ssh`:

- teardown `slevy` smaže jen jeho buildy — nesáhne na `slevy-admin` ani na živý `slevy-abcdef1`
- verze sdílející tag s jiným streamem se nemaže (smazání verze zahodí všechny její tagy)
- rolling tag, který host pulluje, není nikdy kandidát
- ročník s jediným imagem si ho nechá — ověřeno i proti reálným 31 streamům na hostu, kde prune správně nemaže **nic**
- untagged: starý se smaže, nedávný (< 30 dnů) ne
- nedostupný host → teardown krok se přeskočí, prune skončí chybou; v obou případech se nemaže nic
- **pojistka proti rozjetí:** když by filtr označil >75 % verzí, job skončí chybou a nemaže — otestováno, 18 z 20 zastaveno
- `--paginate` sjednoceno přes `jq -s add` (některé verze `gh` vrací pole na stránku, jiné jedno sloučené — verzi na runneru neřídíme)
- `actionlint` čistý na obou souborech

## Doporučení k prvnímu spuštění

Týdenní workflow má `workflow_dispatch` s **`dry_run` defaultně `true`**. Vzhledem k velikosti backlogu bych ho poprvé pustil takhle a podíval se, co by smazal, než ho necháš mazat doopravdy.
