### PR TITLE
1274 Ubytování: omezení jen na spacáky přes tag

### DIFF
--- a/symfony/migrations/structures/2026-09-10-100019_spacak-product-tag.php
+++ b/symfony/migrations/structures/2026-09-10-100019_spacak-product-tag.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var Godric\DbMigrations\Migration $this */
+
+// When rooms are short the festival can restrict accommodation to sleeping bags. Legacy
+// picks the surviving type by the literal name "Spacák"; a tag says the same thing without
+// tying the rule to a product's wording.
+
+$this->q(<<<SQL
+INSERT IGNORE INTO product_tag (code, name, created_at)
+VALUES ('spacak', 'Spacák', NOW())
+SQL);
+
+// Existing sleeping-bag products are archived years, but tagging them keeps the data honest
+// and means a revived product is tagged by copying an old one.
+$this->q(<<<SQL
+INSERT IGNORE INTO product_product_tag (product_id, tag_id)
+SELECT shop_predmety.id_predmetu, product_tag.id
+FROM shop_predmety
+JOIN product_tag ON product_tag.code = 'spacak'
+WHERE shop_predmety.nazev LIKE 'Spacák%'
+SQL);

--- a/symfony/src/Enum/ProductTagCode.php
+++ b/symfony/src/Enum/ProductTagCode.php
@@ -12,9 +12,8 @@ namespace App\Enum;
  * — 'tricka' for 'tricko', or a Czech diacritic — matches nothing and fails silently:
  * no error, no failing test, the feature simply never applies.
  *
- * Seven of them are categories, one per product, mirroring the old typ 1–7. MIKINA is
- * different: it is a sub-tag carried in addition to PREDMET, replacing the old
- * podtyp='mikina'.
+ * Seven of them are categories, one per product, mirroring the old typ 1–7. MIKINA and
+ * SPACAK are different: they are sub-tags carried in addition to a category.
  */
 enum ProductTagCode: string
 {
@@ -27,6 +26,8 @@ enum ProductTagCode: string
     case PROPLACENI_BONUSU = 'proplaceni-bonusu';
 
     case MIKINA = 'mikina';
+
+    case SPACAK = 'spacak';
 
     /**
      * The category tags — exactly one of these per product, the successor of typ 1–7.
@@ -62,6 +63,7 @@ enum ProductTagCode: string
     {
         return [
             self::MIKINA->value => self::PREDMET,
+            self::SPACAK->value => self::UBYTOVANI,
         ];
     }
 
@@ -100,6 +102,7 @@ enum ProductTagCode: string
             self::PARCON            => 'ParCon mini-akce',
             self::PROPLACENI_BONUSU => 'Výplata bonusu (interní)',
             self::MIKINA            => 'Mikina',
+            self::SPACAK            => 'Spacák',
         };
     }
 }

--- a/symfony/src/Service/AccommodationRules.php
+++ b/symfony/src/Service/AccommodationRules.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+
+class AccommodationRules
+{
+    /**
+     * When rooms are short the festival can restrict accommodation to sleeping bags, and a
+     * handful of roles keep a real bed anyway. Read by both the grid and the write path, so
+     * a hand-made request cannot book what the grid hides.
+     */
+    public function jenSpacaky(\Uzivatel $legacyUzivatel): bool
+    {
+        return SystemoveNastaveni::zGlobals()->jeOmezeniUbytovaniPouzeNaSpacaky()
+            && ! $this->maPravoNaPostel($legacyUzivatel);
+    }
+
+    private function maPravoNaPostel(\Uzivatel $legacyUzivatel): bool
+    {
+        return $legacyUzivatel->jeVypravec()
+            || $legacyUzivatel->jeOrganizator()
+            || $legacyUzivatel->jeHerman()
+            || $legacyUzivatel->jePartner()
+            || $legacyUzivatel->jeInfopultak()
+            || $legacyUzivatel->jeZazemi();
+    }
+}

--- a/symfony/src/Service/AccommodationWriter.php
+++ b/symfony/src/Service/AccommodationWriter.php
@@ -43,8 +43,9 @@ readonly class AccommodationWriter
         bool $muzeJednuNoc,
         ?string $spolubydlici = null,
         bool $nechceUbytovani = false,
+        bool $jenSpacaky = false,
     ): void {
-        $varianty = $this->nactiVarianty($variantIds);
+        $varianty = $this->nactiVarianty($variantIds, $jenSpacaky);
 
         // Only judge the nights when they actually change. The legacy admin screens can book a
         // set these rules would reject, and re-validating an untouched booking would leave
@@ -145,7 +146,7 @@ readonly class AccommodationWriter
      *
      * @return array<int, ProductVariant> keyed by variant id
      */
-    private function nactiVarianty(array $variantIds): array
+    private function nactiVarianty(array $variantIds, bool $jenSpacaky): array
     {
         if ($variantIds === []) {
             return [];
@@ -153,6 +154,11 @@ readonly class AccommodationWriter
 
         $varianty = [];
         foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
+            // The grid hides room types under this restriction, so accepting one here would
+            // let a hand-made request book what the customer cannot see.
+            if ($jenSpacaky && ! $product->hasTag(ProductTagCode::SPACAK->value)) {
+                continue;
+            }
             foreach ($product->getVariants() as $variant) {
                 $id = $variant->getId();
                 if ($id !== null && in_array($id, $variantIds, true) && $variant->getAccommodationDay() !== null) {

--- a/symfony/src/State/Cart/AccommodationProvider.php
+++ b/symfony/src/State/Cart/AccommodationProvider.php
@@ -15,6 +15,7 @@ use App\Entity\User;
 use App\Enum\ProductTagCode;
 use App\Repository\OrderItemRepository;
 use App\Repository\ProductRepository;
+use App\Service\AccommodationRules;
 use App\Service\BreakfastCanceller;
 use App\Service\CartService;
 use App\Service\CurrentYearProviderInterface;
@@ -47,6 +48,7 @@ readonly class AccommodationProvider implements ProviderInterface
         private LegacySessionService $legacySession,
         private CartService $cartService,
         private BreakfastCanceller $breakfastCanceller,
+        private AccommodationRules $accommodationRules,
         private Security $security,
     ) {
     }
@@ -112,7 +114,20 @@ readonly class AccommodationProvider implements ProviderInterface
         $viditelneDny = array_column($dto->days, 'day');
         [$prodano, $drzeno, $kapacity] = $this->obsazenostVariant($user, $year);
 
-        foreach ($this->productRepository->findByTag(ProductTagCode::UBYTOVANI) as $product) {
+        $jenSpacaky = $this->accommodationRules->jenSpacaky($legacyUzivatel);
+        $ubytovani = $this->productRepository->findByTag(ProductTagCode::UBYTOVANI);
+
+        // Turning the restriction on with nothing tagged would hide accommodation entirely
+        // instead of narrowing it, and it would look like the section is simply broken.
+        if ($jenSpacaky && ! $this->existujeSpacak($ubytovani)) {
+            throw new \RuntimeException('Ubytování je omezené na spacáky, ale žádný spacák není v nabídce (produkt se značkou "' . ProductTagCode::SPACAK->value . '").');
+        }
+
+        foreach ($ubytovani as $product) {
+            if ($jenSpacaky && ! $product->hasTag(ProductTagCode::SPACAK->value)) {
+                continue;
+            }
+
             $typDto = $this->toTypeDto(
                 $product, $user, $year, $viditelneDny, $prodejUkoncen, $koupeneVarianty, $prodano, $drzeno, $kapacity,
             );
@@ -194,6 +209,20 @@ readonly class AccommodationProvider implements ProviderInterface
         }
 
         return $typDto->nights === [] ? null : $typDto;
+    }
+
+    /**
+     * @param Product[] $ubytovani
+     */
+    private function existujeSpacak(array $ubytovani): bool
+    {
+        foreach ($ubytovani as $product) {
+            if ($product->hasTag(ProductTagCode::SPACAK->value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/symfony/src/State/Cart/SetAccommodationProcessor.php
+++ b/symfony/src/State/Cart/SetAccommodationProcessor.php
@@ -9,6 +9,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Dto\Cart\AccommodationOutputDto;
 use App\Dto\Cart\SetAccommodationInputDto;
 use App\Entity\User;
+use App\Service\AccommodationRules;
 use App\Service\AccommodationWriter;
 use App\Service\BreakfastCanceller;
 use App\Service\CurrentYearProviderInterface;
@@ -27,6 +28,7 @@ readonly class SetAccommodationProcessor implements ProcessorInterface
     public function __construct(
         private AccommodationWriter $accommodationWriter,
         private BreakfastCanceller $breakfastCanceller,
+        private AccommodationRules $accommodationRules,
         private AccommodationProvider $accommodationProvider,
         private CurrentYearProviderInterface $currentYearProvider,
         private LegacySessionService $legacySession,
@@ -63,6 +65,7 @@ readonly class SetAccommodationProcessor implements ProcessorInterface
                 $legacyUzivatel->maPravo(Pravo::UBYTOVANI_MUZE_OBJEDNAT_JEDNU_NOC),
                 $data->roommate,
                 $data->declined,
+                $this->accommodationRules->jenSpacaky($legacyUzivatel),
             );
         } catch (\RuntimeException $chyba) {
             throw new BadRequestHttpException($chyba->getMessage(), $chyba);

--- a/symfony/tests/State/Cart/AccommodationProviderTest.php
+++ b/symfony/tests/State/Cart/AccommodationProviderTest.php
@@ -14,6 +14,7 @@ use App\Enum\ProductStateEnum;
 use App\Enum\ProductTagCode;
 use App\Repository\OrderItemRepository;
 use App\Repository\ProductRepository;
+use App\Service\AccommodationRules;
 use App\Service\BreakfastCanceller;
 use App\Service\CartService;
 use App\Service\CurrentYearProviderInterface;
@@ -47,6 +48,10 @@ class AccommodationProviderTest extends TestCase
 
     private MockObject $breakfastCanceller;
 
+    private MockObject $accommodationRules;
+
+    private bool $jenSpacaky = false;
+
     private AccommodationProvider $provider;
 
     private ?SystemoveNastaveni $puvodniNastaveni = null;
@@ -74,6 +79,9 @@ class AccommodationProviderTest extends TestCase
         $this->cartService = $this->createMock(CartService::class);
         $this->breakfastCanceller = $this->createMock(BreakfastCanceller::class);
         $this->breakfastCanceller->method('restorable')->willReturn([]);
+        $this->accommodationRules = $this->createMock(AccommodationRules::class);
+        $this->accommodationRules->method('jenSpacaky')
+            ->willReturnCallback(fn (): bool => $this->jenSpacaky);
 
         $this->provider = new AccommodationProvider(
             $this->productRepository,
@@ -83,6 +91,7 @@ class AccommodationProviderTest extends TestCase
             $this->legacySession,
             $this->cartService,
             $this->breakfastCanceller,
+            $this->accommodationRules,
             $this->security,
         );
     }
@@ -268,6 +277,7 @@ class AccommodationProviderTest extends TestCase
         int $held,
         ?string $kodJinehoRadku = null,
         bool $koupeno = false,
+        ?Product $dalsiProdukt = null,
     ): ProductVariant {
         $product = $this->createProduct(1, 'Hotel');
 
@@ -282,7 +292,7 @@ class AccommodationProviderTest extends TestCase
 
         $this->productRepository->method('findByTag')
             ->with(ProductTagCode::UBYTOVANI)
-            ->willReturn([$product]);
+            ->willReturn($dalsiProdukt === null ? [$product] : [$product, $dalsiProdukt]);
         $this->orderItemRepository->method('countSoldByVariant')->willReturn([
             50 => $sold,
         ]);
@@ -293,6 +303,10 @@ class AccommodationProviderTest extends TestCase
             ->willReturn([
                 ($kodJinehoRadku ?? 'Hd-2L-ct') => [
                     'vyrobeno' => $produced,
+                    'nabizeno' => true,
+                ],
+                'spacak-ct' => [
+                    'vyrobeno' => 10,
                     'nabizeno' => true,
                 ],
             ]);
@@ -312,6 +326,57 @@ class AccommodationProviderTest extends TestCase
         $this->orderItemRepository->method('findByCustomerAndYear')->willReturn($koupeneItems);
 
         return $variant;
+    }
+
+    public function testSleepingBagRestrictionWithNothingTaggedIsRefused(): void
+    {
+        $this->prepareUser();
+        $this->prepareGrid(remainingQuantity: 10, produced: 10, sold: 0, held: 0);
+        $this->jenSpacaky = true;
+
+        // Hiding everything would read as a broken section rather than a restriction.
+        $this->expectExceptionMessage('žádný spacák není v nabídce');
+
+        $this->provider->provide(new Get());
+    }
+
+    public function testSleepingBagRestrictionHidesRoomTypes(): void
+    {
+        $this->prepareUser();
+        $spacak = $this->vytvorSpacak();
+        $pokoj = $this->prepareGrid(
+            remainingQuantity: 10, produced: 10, sold: 0, held: 0, dalsiProdukt: $spacak,
+        );
+        $this->jenSpacaky = true;
+
+        $typy = $this->provider->provide(new Get())->types;
+
+        // Legacy skips a non-sleeping-bag type entirely rather than showing it disabled.
+        self::assertCount(1, $typy);
+        self::assertSame((int) $spacak->getId(), $typy[0]->productId);
+        self::assertNotSame((int) $pokoj->getProduct()->getId(), $typy[0]->productId);
+    }
+
+    /**
+     * A sleeping-bag product to pass into prepareGrid() as an extra offered type.
+     */
+    private function vytvorSpacak(): Product
+    {
+        $spacak = $this->createProduct(2, 'Spacák');
+        $tag = new ProductTag();
+        $tag->setCode(ProductTagCode::SPACAK->value);
+        $spacak->addTag($tag);
+
+        $variant = new ProductVariant();
+        $variant->setProduct($spacak);
+        $variant->setCode('spacak-ct');
+        $variant->setName('čtvrtek');
+        $variant->setAccommodationDay(self::DEN_CTVRTEK);
+        $variant->setRemainingQuantity(10);
+        $this->setId($variant, 60);
+        $spacak->addVariant($variant);
+
+        return $spacak;
     }
 
     private function createProduct(int $id, string $name): Product


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Postaveno na `1274-ubytovani-zapis` ([PR #1074](https://github.com/gamecon-cz/gamecon/pull/1074)) a míří tam, takže je potřeba mergnout nejdřív ten.

## Problém

Legacy umí omezit ubytování jen na spacáky — zavedeno v roce 2024, když vypadla budova C. Nová mřížka to pravidlo neznala, takže kdyby se zaplo, legacy formulář by pokoje schoval a nová mřížka by je dál nabízela.

## Řešení

Nový podřízený tag `spacak` místo legacy shody na doslovném názvu produktu „Spacák" — stejný krok, jako když se z `podtyp='mikina'` stal tag. Pravidlo je pak na produktu, ne v jeho pojmenování.

Predikát („omezení je zapnuté **a** uživatel nemá právo na postel") je v jedné službě `AccommodationRules`, kterou se ptá **jak mřížka, tak zápis**. Bez toho by ručně sestavený požadavek objednal typ, který mřížka schovává — legacy tuhle kontrolu v zápisu vůbec nemá.

Šest rolí s právem na postel je převzato beze změny: vypravěč, organizátor, herman, partner, infopultak, zázemí.

## Zapnutí bez spacáku teď skončí chybou

Bez toho by se stalo něco horšího než neomezené nabízení: `findByTag()` filtruje `archived_at IS NULL`, takže by se skryly **všechny** typy ubytování, ne jen pokoje. Zákazník by viděl prázdnou sekci a vypadalo by to jako rozbitá stránka, ne jako omezení.

Je to reálné riziko, ne teorie — viz ověření níže.

## Ověření

| kontrola | výsledek |
|---|---|
| produktů s tagem `spacak` | 71 |
| z toho nearchivovaných | **0** |
| spacák v letošním ročníku | žádný, poslední jsou z 2025 |
| `UBYTOVANI_POUZE_SPACAKY` | natvrdo `false`, nikde se nepřepisuje |

Takže dnes se nemění nic. Pravidlo je připravené a správné pro chvíli, kdy spacák jako produkt zase vznikne.

Testy: 296 testů v `symfony/tests`, 77 v `tests/Shop`, PHPStan bez chyb, ECS čistý. Oba nové testy ověřeny mutací — bez filtru typů projdou 2 typy místo 1, bez kontroly prázdné nabídky se nevyhodí výjimka.

Existující test `ProductTagCodeTest::testEveryCaseExistsInTheDatabase` si vynutil migraci: enum case bez řádku v `product_tag` by tiše filtroval na prázdno.

## Pozor při review

- **Nový spacák se musí otagovat ručně.** Migrace otaguje jen archivní produkty podle názvu; nový produkt tag nedostane sám. Proto ta hlasitá chyba výše — jinak by se na to přišlo až tím, že sekce zmizí.
- **Pravidlo je dnes neaktivní.** Konstanta je natvrdo `false`, takže tenhle PR nic nemění na chování; jen zavírá rozdíl mezi oběma formuláři.
- **Legacy rozlišuje ubytovaného a objednatele**, tady je to vždy přihlášený uživatel. Pro samoobslužnou přihlášku to vychází stejně; infopult objednávající za někoho jiného zůstává neřešený, stejně jako v [PR #1074](https://github.com/gamecon-cz/gamecon/pull/1074).

## Kde to naklikat

Bez zapnutého omezení není co vidět — pravidlo je neaktivní a chování se nemění. Zapnout ho jde jen změnou konstanty `UBYTOVANI_POUZE_SPACAKY` v `nastaveni/nastaveni.php`, což není součástí tohoto PR.

Po zapnutí na lokále (a se stejným posunem termínových bran jako v [PR #1074](https://github.com/gamecon-cz/gamecon/pull/1074)):

- <http://localhost:18020/web/prihlaska> → sekce Ubytování jako uživatel bez role z výčtu výše → čekej chybu o chybějícím spacáku, dokud nějaký produkt tag `spacak` nedostane
- tamtéž jako organizátor → mřížka vypadá stejně jako bez omezení
