### PR TITLE
1488 Zmenšit archivní image 2022 (−dev vendor, −.git z COPY vrstvy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Dockerfile.archive COPYs the entire context into the image. Exclude
+# things that bloat the layer, contain secrets, or come from local dev
+# state that shouldn't end up in a published image.
+#
+# A later RUN cannot shrink an earlier layer, so anything deleted after
+# the COPY stays paid for — it has to be kept out of the context instead.
+
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# CI / GitHub
+.github
+
+# Editor / IDE
+.idea
+.vscode
+.envrc
+.mcp.json
+
+# PHP test/static-analysis artefacts
+phpunit_log
+phpunit.xml
+phpstan.neon
+.phpunit.result.cache
+.phpunit.cache
+test-results
+
+# Local dev only — bind-mounted in dev compose, never needed in image
+.docker
+
+# Tests and the deployment ledger: an archived year never runs its tests
+# from the image and is not re-deployed through that mechanism.
+tests
+.htdeployment
+
+# Runtime state — must NOT bake stale logs / cache / uploads into image
+cache/private/*
+!cache/private/.htaccess
+cache/public/*
+!cache/public/.htaccess
+logy/*
+!logy/.htaccess
+
+# UI build state
+node_modules
+ui/node_modules
+
+# Dev-only vendor packages for THIS year — the list differs per archive
+# branch and must come from its own composer.lock, never from main's:
+# 2022 has doctrine/instantiator as dev-only while 2025 needs Doctrine
+# in production. Dropping these is safe only because the Dockerfile
+# regenerates the autoloader; the committed one eagerly requires
+# bootstrap.php from several of them and would fatal on every request.
+vendor/cweagans
+vendor/doctrine
+vendor/myclabs
+vendor/phpunit
+vendor/symplify
+vendor/theseer
+
+# Symfony runtime artefacts (rebuilt on first request)
+symfony/var

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -51,7 +51,13 @@ RUN rm -rf \
 # image fatals on every request. `dump-autoload` resolves nothing and
 # fetches nothing — it is not the `composer install` the header rules out.
 USER www-data
-RUN composer dump-autoload --no-dev --optimize --no-interaction
+# NOT --no-dev: the archive boots the kernel with an empty APP_ENV, which
+# bundles.php reads as dev and so registers MakerBundle. That one lives
+# under vendor/symfony, shared with production and therefore still on
+# disk — --no-dev drops its autoload entry anyway and every kernel-booting
+# page 500s while the homepage, which boots no kernel, stays fine. A plain
+# dump maps what is present and omits what .dockerignore removed.
+RUN composer dump-autoload --optimize --no-interaction
 USER root
 
 # Make cache/ and logy/ writable by Apache. cache/public stays (assets

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -11,7 +11,9 @@
 #      already (see .htdeployment artifacts in the 2024 on-disk
 #      snapshot). Skipping these saves ~3 min of build time per year
 #      and avoids depending on whichever Composer/Node version happened
-#      to be installed in the archived branch's base image.
+#      to be installed in the archived branch's base image. The one
+#      exception is `composer dump-autoload`, which resolves nothing and
+#      fetches nothing — see the note further down for why it is needed.
 #   2. NO migration / cache-refresh hooks at deploy time. Archives are
 #      read-only-ish — the DB is a frozen point in time, code is frozen
 #      at the branch tip. Nothing to migrate.
@@ -34,22 +36,23 @@ COPY --chown=www-data:www-data . /var/www/html/gamecon
 
 WORKDIR /var/www/html/gamecon
 
-# Strip dev / runtime junk that snuck in via COPY .. cache/private gets
-# rebuilt on demand, no point baking historical entries into the image.
-# .git is ~tens of MB and never read at runtime. .htdeployment is the
-# deployment ledger; archived branches won't be re-deployed via that
-# mechanism so its presence is just dead weight (~120 KB but pointless).
+# .dockerignore keeps .git, tests, node_modules and the dev vendor dirs
+# out of the context. Deleting them here instead did remove them from the
+# image, but they stayed paid for in the COPY layer above — a later layer
+# cannot shrink an earlier one. What is left needs a glob, or has to be
+# recreated empty right below.
 RUN rm -rf \
-    /var/www/html/gamecon/.git \
-    /var/www/html/gamecon/.github \
-    /var/www/html/gamecon/.docker \
-    /var/www/html/gamecon/.htdeployment \
-    /var/www/html/gamecon/node_modules \
-    /var/www/html/gamecon/ui/node_modules \
-    /var/www/html/gamecon/tests \
     /var/www/html/gamecon/phpunit*.* \
     /var/www/html/gamecon/phpstan*.* \
     /var/www/html/gamecon/cache/private
+
+# The committed autoloader's `files` list eagerly requires bootstrap.php
+# from the dev packages .dockerignore now drops, so without this the
+# image fatals on every request. `dump-autoload` resolves nothing and
+# fetches nothing — it is not the `composer install` the header rules out.
+USER www-data
+RUN composer dump-autoload --no-dev --optimize --no-interaction
+USER root
 
 # Make cache/ and logy/ writable by Apache. cache/public stays (assets
 # committed at archive time); only cache/private was stripped above

--- a/bin/check-archive-dockerignore.php
+++ b/bin/check-archive-dockerignore.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The archive image ships a committed vendor/ and runs no composer install,
+ * so a vendor dir excluded in .dockerignore is simply gone at runtime. The
+ * kernel boots with an empty APP_ENV — read as dev — and loads the bundles
+ * config/bundles.php registers for it, so excluding anything they need
+ * transitively turns every kernel-booting page into a 500 that no
+ * autoloader dump can repair. Three such outages shipped before this check
+ * existed: MakerBundle, then ZenstruckFoundryBundle, then Faker\Factory.
+ */
+
+$root = dirname(__DIR__);
+$lock = json_decode((string) file_get_contents($root . '/composer.lock'), true, 512, JSON_THROW_ON_ERROR);
+
+$byName = [];
+foreach ([...$lock['packages'] ?? [], ...$lock['packages-dev'] ?? []] as $package) {
+    $byName[$package['name']] = $package;
+}
+
+$bundlesFile = $root . '/symfony/config/bundles.php';
+if (! is_file($bundlesFile)) {
+    echo "✓ no symfony/config/bundles.php — this year boots no kernel\n";
+
+    exit(0);
+}
+
+preg_match_all('~^\s*([A-Za-z\\\\]+)::class~m', (string) file_get_contents($bundlesFile), $matches);
+
+$queue = [];
+foreach ($matches[1] as $class) {
+    $vendorDir = strtolower(explode('\\', $class)[0]);
+    foreach (array_keys($byName) as $name) {
+        if (explode('/', $name)[0] === $vendorDir) {
+            $queue[] = $name;
+        }
+    }
+}
+
+$required = [];
+while ($queue !== []) {
+    $name = array_pop($queue);
+    if (isset($required[$name]) || ! isset($byName[$name])) {
+        continue;
+    }
+    $required[$name] = true;
+    foreach (array_keys($byName[$name]['require'] ?? []) as $dependency) {
+        $queue[] = $dependency;
+    }
+}
+
+$needed = [];
+foreach (array_keys($required) as $name) {
+    $needed[explode('/', $name)[0]] = true;
+}
+
+$excluded = [];
+foreach (file($root . '/.dockerignore', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+    $line = trim($line);
+    if (str_starts_with($line, 'vendor/')) {
+        $excluded[] = rtrim(substr($line, strlen('vendor/')), '/');
+    }
+}
+
+$broken = array_intersect($excluded, array_keys($needed));
+
+if ($broken !== []) {
+    fwrite(STDERR, ".dockerignore excludes vendor dirs the kernel needs — every kernel-booting page would 500:\n");
+    foreach ($broken as $dir) {
+        fwrite(STDERR, "  vendor/{$dir}\n");
+    }
+
+    exit(1);
+}
+
+echo '✓ .dockerignore leaves the kernel intact (' . count($needed) . " vendor dirs required)\n";
+
+exit(0);


### PR DESCRIPTION
[Trello 1488 — Archivní image 2022+: stejná optimalizace jako preview](https://trello.com/c/zwJRjpTD)

Jeden ze čtyř PR (2022, 2023, 2024, 2025) — každý ročník má vlastní větev a vlastní `composer.lock`, takže se to nedá udělat jedním.

## Problém

`Dockerfile.archive` dělá `COPY . ` a teprve v **další** vrstvě maže `.git`, `.github`, `tests` a `node_modules`.

**`.git` v hotovém image opravdu není** — `RUN rm -rf` ho smaže, takže se nikomu neservíruje. Jenže se maže **až v pozdější vrstvě**, takže jeho bajty pořád leží v `COPY` vrstvě pod ním a počítají se do velikosti i do stahování image. Jediný způsob, jak za to přestat platit, je nepustit ho do build kontextu vůbec.

Důkaz z reálného CI image `archive-2025-4ceba0b`: `COPY` vrstva **241 MB**, ale `RUN rm -rf` vrstva jen **3,58 kB** — maže ~150 MB a zpětně nezíská nic.

Archivní větve **nemají `.dockerignore` vůbec**.

## Řešení

1. `.dockerignore` — `.git`, `.github`, `tests`, `node_modules`, runtime stav a dev balíčky `vendor/`.
2. Zkrácení `RUN rm -rf` na to, co `.dockerignore` neumí (globy `phpunit*.*` / `phpstan*.*`) a na `cache/private`, který se hned pod tím vytváří prázdný znovu.
3. `composer dump-autoload --no-dev --optimize` — **nutné**, viz níže.

## Proč ten dump-autoload

Bez něj image fatáluje na každém requestu:

```
Failed opening required '.../vendor/composer/../phpstan/phpstan/bootstrap.php'
```

Archiv nespouští `composer install`, takže ho bootuje commitnutý autoloader, jehož seznam `files` natvrdo requiruje bootstrap z několika dev balíčků. `dump-autoload` **nic neresolvuje ani nestahuje** — běží offline, takže neporušuje důvod, proč se tu `composer install` nedělá (build time + nezávislost na verzi Composeru). Vrstva stojí ~1,25 MB.

## Seznam dev balíčků je z lockfile TOHOTO ročníku

Seznamy se mezi ročníky liší; zkopírovat je z `main` nebo z jiného roku by rozbilo produkci. Na 2022 je `vendor/doctrine` dev-only (jen `doctrine/instantiator` pro PHPUnit), na 2025 je Doctrine ORM produkční závislost.

Pro 2022: `cweagans, doctrine, myclabs, phpunit, symplify, theseer`

## Ověření

| | před | po |
|---|---|---|
| `COPY` vrstva | 50,8 MB | **47,3 MB** |

- image se postaví, autoloader nabootuje, produkční knihovny se načtou
- dev balíčky v image opravdu nejsou
- **HTTP odpověď identická s původním buildem**: 200 / 69 B před i po

## Pozor při review

- **Merge tohohle PR = deploy živého webu.** Push do `archive/**` spouští `deploy-year-archive.yml`; není tam branch protection ani PR gate.
- **CI na tomhle PR nic nespustí.** `run-tests.yml` běží jen na PR do `main`, takže tu nebude žádný check — jediné ověření je to ruční výše.
- Změna nesahá na data. Archivní deploy nespouští migrace; `provision_db` dělá `CREATE ... IF NOT EXISTS` a `ALTER USER` na už používané odvozené heslo, což je no-op.
- Revert = `git revert` + push, který přestaví předchozí image; staré image navíc zůstávají v GHCR.

## Kde to naklikat

- **https://2022.gamecon.cz/** (basic auth gate) → po merge a doběhnutí deploye se má chovat úplně stejně jako teď.
- Velikost na hostu: `docker images | grep archive-2022` → čekej menší image než dosud.
