### PR TITLE
1488 Zmenšit archivní image 2025 (−dev vendor, −.git z COPY vrstvy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,71 @@
+# Dockerfile.archive COPYs the entire context into the image. Exclude
+# things that bloat the layer, contain secrets, or come from local dev
+# state that shouldn't end up in a published image.
+#
+# The Dockerfile used to delete several of these again, but a later RUN
+# cannot shrink an earlier layer — they stay paid for unless they never
+# enter the context at all.
+
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# CI / GitHub
+.github
+
+# Editor / IDE
+.idea
+.vscode
+.envrc
+.mcp.json
+
+# PHP test/static-analysis artefacts
+phpunit_log
+phpunit.xml
+phpstan.neon
+.phpunit.result.cache
+.phpunit.cache
+test-results
+
+# Local dev only — bind-mounted in dev compose, never needed in image
+.docker
+
+# Tests and the deployment ledger: an archived year never runs its tests
+# from the image and is not re-deployed through that mechanism.
+tests
+.htdeployment
+
+# Runtime state — must NOT bake stale logs / cache / uploads into image
+cache/private/*
+!cache/private/.htaccess
+cache/public/*
+!cache/public/.htaccess
+logy/*
+!logy/.htaccess
+
+# UI build state
+node_modules
+ui/node_modules
+
+# Dev-only vendor packages. vendor/ is committed, so COPY drags all of it
+# in; the Dockerfile regenerates the autoloader without them, which is
+# what makes dropping them safe — the committed autoloader eagerly
+# requires bootstrap.php from several of these and would fatal on every
+# request otherwise. Regenerate by diffing composer.lock's packages-dev
+# vendor dirs against packages.
+vendor/symplify
+vendor/rector
+vendor/phpstan
+vendor/phpunit
+vendor/fakerphp
+vendor/nikic
+vendor/zenstruck
+vendor/sebastian
+vendor/phar-io
+vendor/myclabs
+vendor/cweagans
+vendor/theseer
+
+# Symfony runtime artefacts (rebuilt on first request)
+symfony/var

--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -11,7 +11,9 @@
 #      already (see .htdeployment artifacts in the 2024 on-disk
 #      snapshot). Skipping these saves ~3 min of build time per year
 #      and avoids depending on whichever Composer/Node version happened
-#      to be installed in the archived branch's base image.
+#      to be installed in the archived branch's base image. The one
+#      exception is `composer dump-autoload`, which resolves nothing and
+#      fetches nothing — see the note further down for why it is needed.
 #   2. NO migration / cache-refresh hooks at deploy time. Archives are
 #      read-only-ish — the DB is a frozen point in time, code is frozen
 #      at the branch tip. Nothing to migrate.
@@ -34,22 +36,24 @@ COPY --chown=www-data:www-data . /var/www/html/gamecon
 
 WORKDIR /var/www/html/gamecon
 
-# Strip dev / runtime junk that snuck in via COPY .. cache/private gets
-# rebuilt on demand, no point baking historical entries into the image.
-# .git is ~tens of MB and never read at runtime. .htdeployment is the
-# deployment ledger; archived branches won't be re-deployed via that
-# mechanism so its presence is just dead weight (~120 KB but pointless).
+# .dockerignore keeps .git, tests, node_modules and the dev vendor dirs
+# out of the context. Deleting them here instead did remove them from the
+# image, but they stayed paid for in the COPY layer above — a later layer
+# cannot shrink an earlier one. What is left needs a glob, or has to be
+# recreated empty right below.
 RUN rm -rf \
-    /var/www/html/gamecon/.git \
-    /var/www/html/gamecon/.github \
-    /var/www/html/gamecon/.docker \
-    /var/www/html/gamecon/.htdeployment \
-    /var/www/html/gamecon/node_modules \
-    /var/www/html/gamecon/ui/node_modules \
-    /var/www/html/gamecon/tests \
     /var/www/html/gamecon/phpunit*.* \
     /var/www/html/gamecon/phpstan*.* \
     /var/www/html/gamecon/cache/private
+
+# The committed autoloader's `files` list eagerly requires bootstrap.php
+# from phpstan, rector, symplify and friends, so an image without those
+# fatals on every request until the autoloader is rebuilt without them.
+# `dump-autoload` needs no network and no package resolution — this is
+# still not the `composer install` the header rules out.
+USER www-data
+RUN composer dump-autoload --no-dev --optimize --no-interaction
+USER root
 
 # Make cache/ and logy/ writable by Apache. cache/public stays (assets
 # committed at archive time); only cache/private was stripped above


### PR DESCRIPTION
[Trello 1488 — Archivní image 2022+: stejná optimalizace jako preview](https://trello.com/c/zwJRjpTD)

Jeden ze čtyř PR (2022, 2023, 2024, 2025) — každý ročník má vlastní větev a vlastní `composer.lock`, takže se to nedá udělat jedním.

## Problém

`Dockerfile.archive` dělá `COPY . ` a teprve v **další** vrstvě maže `.git`, `.github`, `tests` a `node_modules`.

**`.git` v hotovém image opravdu není** — `RUN rm -rf` ho smaže, takže se nikomu neservíruje. Jenže se maže **až v pozdější vrstvě**, takže jeho bajty pořád leží v `COPY` vrstvě pod ním a počítají se do velikosti i do stahování image. Jediný způsob, jak za to přestat platit, je nepustit ho do build kontextu vůbec.

Důkaz z reálného CI image `archive-2025-4ceba0b`: `COPY` vrstva **241 MB**, ale `RUN rm -rf` vrstva jen **3,58 kB** — maže ~150 MB a zpětně nezíská nic.

Archivní větve **nemají `.dockerignore` vůbec**.

## Řešení

1. `.dockerignore` — `.git`, `.github`, `tests`, `node_modules`, runtime stav a dev balíčky `vendor/`.
2. Zkrácení `RUN rm -rf` na to, co `.dockerignore` neumí (globy `phpunit*.*` / `phpstan*.*`) a na `cache/private`, který se hned pod tím vytváří prázdný znovu.
3. `composer dump-autoload --no-dev --optimize` — **nutné**, viz níže.

## Proč ten dump-autoload

Bez něj image fatáluje na každém requestu:

```
Failed opening required '.../vendor/composer/../phpstan/phpstan/bootstrap.php'
```

Archiv nespouští `composer install`, takže ho bootuje commitnutý autoloader, jehož seznam `files` natvrdo requiruje bootstrap z několika dev balíčků. `dump-autoload` **nic neresolvuje ani nestahuje** — běží offline, takže neporušuje důvod, proč se tu `composer install` nedělá (build time + nezávislost na verzi Composeru). Vrstva stojí ~1,25 MB.

## Seznam dev balíčků je z lockfile TOHOTO ročníku

Seznamy se mezi ročníky liší; zkopírovat je z `main` nebo z jiného roku by rozbilo produkci. Na 2022 je `vendor/doctrine` dev-only (jen `doctrine/instantiator` pro PHPUnit), na 2025 je Doctrine ORM produkční závislost.

Pro 2025: `cweagans, fakerphp, myclabs, nikic, phar-io, phpstan, phpunit, rector, roave, sebastian, symplify, theseer, zenstruck`

## Ověření

| | před | po |
|---|---|---|
| `COPY` vrstva | 157 MB | **87,3 MB** |

- image se postaví, autoloader nabootuje, produkční knihovny se načtou
- dev balíčky v image opravdu nejsou
- **HTTP odpověď identická s původním buildem**: 500 / 152844 B před i po — je to `mysqli: Connection refused`, protože testovací kontejner nedostává `DB_*` env; živý web s databází vrací 200

## Pozor při review

- **Merge tohohle PR = deploy živého webu.** Push do `archive/**` spouští `deploy-year-archive.yml`; není tam branch protection ani PR gate.
- **CI na tomhle PR nic nespustí.** `run-tests.yml` běží jen na PR do `main`, takže tu nebude žádný check — jediné ověření je to ruční výše.
- Změna nesahá na data. Archivní deploy nespouští migrace; `provision_db` dělá `CREATE ... IF NOT EXISTS` a `ALTER USER` na už používané odvozené heslo, což je no-op.
- Revert = `git revert` + push, který přestaví předchozí image; staré image navíc zůstávají v GHCR.

## Kde to naklikat

- **https://2025.gamecon.cz/** (basic auth gate) → po merge a doběhnutí deploye se má chovat úplně stejně jako teď.
- Velikost na hostu: `docker images | grep archive-2025` → čekej menší image než dosud.
