### PR TITLE
1488 Opravit 500 na /prihlaseni v archivu 2025

### DIFF
--- a/Dockerfile.archive
+++ b/Dockerfile.archive
@@ -48,11 +48,18 @@ RUN rm -rf \
 
 # The committed autoloader's `files` list eagerly requires bootstrap.php
 # from phpstan, rector, symplify and friends, so an image without those
-# fatals on every request until the autoloader is rebuilt without them.
-# `dump-autoload` needs no network and no package resolution — this is
-# still not the `composer install` the header rules out.
+# fatals on every request until the autoloader is rebuilt. `dump-autoload`
+# needs no network and no package resolution — this is still not the
+# `composer install` the header rules out.
+#
+# NOT --no-dev: the archive boots the kernel with an empty APP_ENV, which
+# bundles.php reads as dev and so registers MakerBundle. That one lives
+# under vendor/symfony, shared with production and therefore still on
+# disk — --no-dev drops its autoload entry anyway and every kernel-booting
+# page 500s while the homepage, which boots no kernel, stays fine. A plain
+# dump maps what is present and omits what .dockerignore removed.
 USER www-data
-RUN composer dump-autoload --no-dev --optimize --no-interaction
+RUN composer dump-autoload --optimize --no-interaction
 USER root
 
 # Make cache/ and logy/ writable by Apache. cache/public stays (assets


### PR DESCRIPTION
[Trello 1488](https://trello.com/c/zwJRjpTD) — hotfix k [PR #1079](https://github.com/gamecon-cz/gamecon/pull/1079).

## Co se rozbilo

Po nasazení #1079 vracelo **https://2025.gamecon.cz/prihlaseni chybu 500**. Homepage fungovala dál, takže se to při ověřování neprojevilo.

Z `logy/chyby.sqlite` v kontejneru:

```
RuntimeException: Can not boot Symfony kernel. Current APP_ENV is dev.
Details: Class "Symfony\Bundle\MakerBundle\MakerBundle" not found
model/SystemoveNastaveni/SystemoveNastaveni.php:1144
```

## Příčina

Archiv bootuje Symfony kernel s **prázdným `APP_ENV`**, což `symfony/config/bundles.php` bere jako `dev` — a registruje `MakerBundle` (`'dev' => true`).

`symfony/maker-bundle` je dev závislost, ale bydlí pod `vendor/symfony`, které je sdílené s produkcí, takže ho `.dockerignore` **nechává na disku**. Přesto `dump-autoload --no-dev` zahodil jeho PSR-4 záznam, takže třída nešla načíst. Ověřeno v běžícím kontejneru: `grep -c MakerBundle vendor/composer/autoload_psr4.php` → `0`.

Proč to prošlo ověřením: homepage kernel vůbec nebootuje, takže vracela 200 a bajtově identickou odpověď. Rozbité byly jen stránky, které kernel potřebují.

## Oprava

Vypustit `--no-dev`. Dev balíčky odstraňuje `.dockerignore`, ne ten flag — a `dump-autoload` mapuje jen to, co reálně na disku je, takže smazané balíčky do autoloaderu stejně nepřidá.

## Ověření

- v běžícím kontejneru: po plném dumpu `MakerBundle` **loads OK**, autoloader nabootuje i s chybějícím phpstanem
- **https://2025.gamecon.cz/prihlaseni → 200**, `<title>Přihlášení</title>` (živý web už je takhle opravený ručně, tenhle PR to dělá trvalým)
- z nového buildu: `MakerBundle` i `Endroid\QrCode` se načtou, `phpstan`/`rector`/`symplify`/`phpunit` v image nejsou
- `COPY` vrstva zůstává **87,3 MB** — úspora se nemění

## Pozor při review

- Merge = deploy živého webu (push do `archive/**`).
- **Stejná oprava bude potřeba i pro 2022/2023/2024** — jejich PR ([#1076](https://github.com/gamecon-cz/gamecon/pull/1076), [#1077](https://github.com/gamecon-cz/gamecon/pull/1077), [#1078](https://github.com/gamecon-cz/gamecon/pull/1078)) mají `--no-dev` taky. Nemergovat je, dokud je neopravím.