### PR TITLE
1488 Opravit 500 při odeslání login formuláře (2025)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,18 +49,22 @@ node_modules
 ui/node_modules
 
 # Dev-only vendor packages. vendor/ is committed, so COPY drags all of it
-# in; the Dockerfile regenerates the autoloader without them, which is
-# what makes dropping them safe — the committed autoloader eagerly
-# requires bootstrap.php from several of these and would fatal on every
-# request otherwise. Regenerate by diffing composer.lock's packages-dev
-# vendor dirs against packages.
+# in, and nothing here runs composer install to strip them.
+#
+# vendor/zenstruck is deliberately NOT listed: the archive boots the
+# kernel with an empty APP_ENV, which config/bundles.php reads as dev and
+# so registers ZenstruckFoundryBundle. Deleting the files makes every
+# kernel-booting page 500, and no autoloader dump can undo that. Before
+# adding a dir here, check that nothing in bundles.php comes from it.
+#
+# Regenerate by diffing composer.lock's packages-dev vendor dirs against
+# packages, minus anything bundles.php registers.
 vendor/symplify
 vendor/rector
 vendor/phpstan
 vendor/phpunit
 vendor/fakerphp
 vendor/nikic
-vendor/zenstruck
 vendor/sebastian
 vendor/phar-io
 vendor/myclabs


### PR DESCRIPTION
[Trello 1488](https://trello.com/c/zwJRjpTD) — druhý hotfix k [PR #1079](https://github.com/gamecon-cz/gamecon/pull/1079), navazuje na [#1080](https://github.com/gamecon-cz/gamecon/pull/1080).

## Co se rozbilo

`GET /prihlaseni` fungoval, ale **odeslání formuláře** skončilo prázdnou odpovědí — Firefox to hlásí jako `NS_ERROR_NET_ERROR_RESPONSE`, 0 B. V access logu je to `POST /prihlaseni → 500`.

Ze stderr kontejneru:

```
JWT deletion failed: Can not boot Symfony kernel. Current APP_ENV is dev.
Details: Class "Zenstruck\Foundry\ZenstruckFoundryBundle" not found
```

## Příčina

`symfony/config/bundles.php` registruje pro `dev` **dva** bundly:

```php
Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
```

Archiv bootuje kernel s prázdným `APP_ENV`, což se čte jako `dev`, takže se oba načítají.

[#1080](https://github.com/gamecon-cz/gamecon/pull/1080) opravil MakerBundle — ten přežil, protože bydlí pod `vendor/symfony`, sdíleným s produkcí, takže na disku zůstal a stačilo vrátit jeho záznam do autoloaderu.

**Foundry je jiný případ:** `vendor/zenstruck` je čistě dev, takže ho můj `.dockerignore` z image úplně smazal. Chybějící soubory žádný `dump-autoload` nevrátí.

## Oprava

Vyřadit `vendor/zenstruck` ze seznamu vylučovaných a zapsat pravidlo, které mi to mělo napovědět: **než přidáš adresář do seznamu, ověř, že z něj nic neregistruje `bundles.php`.**

Prošel jsem všech 5 registrovaných bundlů — `vendor/zenstruck` je jediný, který spadá do dev-only vendor adresáře. Ostatní (`symfony`, `doctrine`, `nextras`) jsou produkční.

## Ověření

- z nového buildu se načtou `MakerBundle`, `ZenstruckFoundryBundle` i `Doctrine\ORM\EntityManager`
- `phpstan`, `rector`, `symplify`, `phpunit` v image dál nejsou — úspora se nemění
- lokální 500 v samostatném kontejneru je `mysqli: Connection refused` (chybí DB), **žádná chyba bundlu ani kernelu**

## Pozor při review

- Merge = deploy živého webu.
- **Ověřoval jsem jen GET stránky, ne odeslání formuláře** — proto tohle uteklo jak mně, tak #1080. Po nasazení je potřeba reálně zkusit přihlášení, ne jen otevřít stránku.
- 2022/2023/2024 tenhle problém nemají — `bundles.php` tam Foundry neregistruje (ověřeno), ale i tak jim to zkontroluju, než se budou mergovat.