### PR TITLE
1274 Oznámit CFO zdražení objednávky po změně rolí

### DIFF
--- a/symfony/src/EventListener/PriceIncreaseFlushListener.php
+++ b/symfony/src/EventListener/PriceIncreaseFlushListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Service\PriceIncreaseNotifier;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * postFlush is dispatched after the commit, unlike postPersist — so a price increase queued
+ * during the transaction is reported only once it is actually stored, and a mail failure
+ * cannot roll the change back.
+ */
+#[AsDoctrineListener(event: Events::postFlush)]
+readonly class PriceIncreaseFlushListener
+{
+    public function __construct(
+        private PriceIncreaseNotifier $priceIncreaseNotifier,
+    ) {
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        $this->priceIncreaseNotifier->odesliFrontu();
+    }
+}

--- a/symfony/src/EventListener/UserRoleChangedListener.php
+++ b/symfony/src/EventListener/UserRoleChangedListener.php
@@ -11,6 +11,7 @@ use App\Entity\ProductDiscount;
 use App\Entity\User;
 use App\Repository\OrderRepository;
 use App\Service\DiscountCalculator;
+use App\Service\PriceIncreaseNotifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -34,6 +35,7 @@ readonly class UserRoleChangedListener
         private EntityManagerInterface $entityManager,
         private OrderRepository $orderRepository,
         private DiscountCalculator $discountCalculator,
+        private PriceIncreaseNotifier $priceIncreaseNotifier,
         private LoggerInterface $logger,
     ) {
     }
@@ -65,6 +67,7 @@ readonly class UserRoleChangedListener
     private function recalculateOrderDiscounts(Order $order, User $user, int $year): void
     {
         $hasChanges = false;
+        $zdrazeni = [];
 
         foreach ($order->getItems() as $orderItem) {
             $product = $orderItem->getProduct();
@@ -75,10 +78,19 @@ readonly class UserRoleChangedListener
 
             // Calculate new discount based on current role
             $discountInfo = $this->discountCalculator->calculateDiscount($product, $user, $year);
+            $puvodniCena = $orderItem->getPurchasePrice();
 
             // Update order item with new pricing
             if ($this->updateOrderItemPricing($orderItem, $discountInfo)) {
                 $hasChanges = true;
+
+                if ((float) $discountInfo['finalPrice'] > (float) $puvodniCena) {
+                    $zdrazeni[(int) $orderItem->getId()] = [
+                        'nazev' => $product->getName(),
+                        'pred'  => $puvodniCena,
+                        'po'    => $discountInfo['finalPrice'],
+                    ];
+                }
             }
         }
 
@@ -87,6 +99,8 @@ readonly class UserRoleChangedListener
             $order->recalculateTotal();
 
             $this->entityManager->flush();
+
+            $this->priceIncreaseNotifier->oznamZdrazeni($user, $year, $zdrazeni);
 
             $this->logger->info('Order discounts recalculated', [
                 'order_id'  => $order->getId(),
@@ -123,7 +137,10 @@ readonly class UserRoleChangedListener
         }
 
         // Update pricing
-        $orderItem->setOriginalPrice($product->getCurrentPrice());
+        $variant = $orderItem->getVariant();
+        $orderItem->setOriginalPrice(
+            $variant !== null ? $variant->getEffectivePrice() : $product->getCurrentPrice(),
+        );
         $orderItem->setPurchasePrice($newPurchasePrice);
         $orderItem->setDiscountAmount($newDiscountAmount);
         $orderItem->setDiscountReason($newDiscountReason);
@@ -140,10 +157,8 @@ readonly class UserRoleChangedListener
     }
 
     /**
-     * Force recalculation for completed orders (COULD requirement - násilná rekalkulace)
-     *
-     * This overrides the frozen prices in completed orders
-     * Use with caution - only for admin-initiated corrections
+     * Overrides the frozen prices of a completed order — admin-initiated corrections only.
+     * Every price that goes up mails the CFOs, so a batch of these is a batch of mails.
      */
     public function forceRecalculateCompletedOrder(Order $order, User $user, int $year): void
     {

--- a/symfony/src/Repository/UserRepository.php
+++ b/symfony/src/Repository/UserRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\User;
+use App\Enum\RoleMeaning;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,5 +22,19 @@ class UserRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+    }
+
+    /**
+     * @return User[]
+     */
+    public function findByRoleMeaning(RoleMeaning $vyznam): array
+    {
+        return $this->createQueryBuilder('user')
+            ->innerJoin('user.userRoles', 'userRole')
+            ->innerJoin('userRole.role', 'role')
+            ->where('role.vyznamRole = :vyznam')
+            ->setParameter('vyznam', $vyznam)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/symfony/src/Service/CartService.php
+++ b/symfony/src/Service/CartService.php
@@ -251,8 +251,11 @@ class CartService
         $item->snapshotProduct($product, $variant);
         $item->setProductTags($product->getTagNames());
 
+        // snapshotProduct() above already stored originalPrice from the variant's effective
+        // price, which the product-level one would silently override.
+        $item->setDiscountAmount($discountInfo['discountAmount']);
+
         if ($discountInfo['discount'] !== null) {
-            $item->setDiscountAmount($discountInfo['discountAmount']);
             $item->setDiscountReason($discountInfo['reason']);
         }
 

--- a/symfony/src/Service/PriceIncreaseNotifier.php
+++ b/symfony/src/Service/PriceIncreaseNotifier.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use App\Enum\RoleMeaning;
+use App\Repository\UserRepository;
+use Gamecon\Kanaly\GcMail;
+use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Losing a role re-prices what the customer already ordered, which can turn a free item into
+ * a debt they never agreed to. Rare — a handful of cases a year — but it must never happen
+ * quietly, so the people who own the money get told.
+ */
+class PriceIncreaseNotifier
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<int, array{nazev: string, pred: string, po: string}> $zdrazeni keyed by order item id
+     */
+    public function oznamZdrazeni(User $customer, int $year, array $zdrazeni): void
+    {
+        if ($zdrazeni === []) {
+            return;
+        }
+
+        $prijemci = $this->dejCfoMaily();
+        if ($prijemci === []) {
+            // Nobody to tell is itself worth recording — the price still went up.
+            $this->logger->error('Zdražení objednávky po změně rolí, ale není komu to oznámit (role CFO).', [
+                'user_id' => $customer->getId(),
+                'year'    => $year,
+            ]);
+
+            return;
+        }
+
+        $zprava = $this->sestavZpravu($customer, $year, $zdrazeni);
+        $predmet = sprintf('Zdražení objednávky po změně rolí: %s', $customer->getJmeno());
+        foreach ($prijemci as $email) {
+            // Doctrine fires postPersist before the commit, so an unreachable SMTP would
+            // otherwise roll back the role change itself. One bad address must also not
+            // stop the remaining CFOs from being told.
+            try {
+                $this->odesli($email, $predmet, $zprava);
+            } catch (\Throwable $chyba) {
+                $this->logger->error('Zdražení objednávky se nepodařilo oznámit.', [
+                    'user_id'   => $customer->getId(),
+                    'prijemce'  => $email,
+                    'exception' => $chyba,
+                ]);
+            }
+        }
+
+        $this->logger->warning('Objednávka zdražena po změně rolí, CFO informováni.', [
+            'user_id'  => $customer->getId(),
+            'year'     => $year,
+            'polozek'  => count($zdrazeni),
+            'prijemcu' => count($prijemci),
+        ]);
+    }
+
+    /**
+     * Overridden in tests, which must not reach a real transport.
+     */
+    protected function odesli(string $email, string $predmet, string $zprava): void
+    {
+        (new GcMail(SystemoveNastaveni::zGlobals()))
+            ->adresat($email)
+            ->predmet($predmet)
+            ->text($zprava)
+            ->odeslat(GcMail::FORMAT_TEXT);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function dejCfoMaily(): array
+    {
+        $maily = [];
+        foreach ($this->userRepository->findByRoleMeaning(RoleMeaning::CFO) as $uzivatel) {
+            $email = trim($uzivatel->getEmail());
+            if ($email !== '') {
+                $maily[] = $email;
+            }
+        }
+
+        return array_values(array_unique($maily));
+    }
+
+    /**
+     * @param array<int, array{nazev: string, pred: string, po: string}> $zdrazeni
+     */
+    private function sestavZpravu(User $customer, int $year, array $zdrazeni): string
+    {
+        $radky = [];
+        foreach ($zdrazeni as $polozka) {
+            $radky[] = sprintf(
+                ' - %s: %s → %s Kč',
+                $polozka['nazev'],
+                $polozka['pred'],
+                $polozka['po'],
+            );
+        }
+
+        return sprintf(
+            "Uživateli %s (ID %d) se po změně rolí zdražily už objednané položky ročníku %d.\n\n%s\n\nAktuální zůstatek: %s\n",
+            $customer->getJmeno(),
+            (int) $customer->getId(),
+            $year,
+            implode("\n", $radky),
+            $this->dejZustatek($customer),
+        );
+    }
+
+    private function dejZustatek(User $customer): string
+    {
+        $legacy = \Uzivatel::zId((int) $customer->getId());
+        if ($legacy === null) {
+            return 'nepodařilo se zjistit';
+        }
+
+        return sprintf('%.2f Kč', $legacy->finance()->stav());
+    }
+}

--- a/symfony/src/Service/PriceIncreaseNotifier.php
+++ b/symfony/src/Service/PriceIncreaseNotifier.php
@@ -33,6 +33,24 @@ class PriceIncreaseNotifier
             return;
         }
 
+        // Doctrine fires postPersist before the commit, so anything escaping from here would
+        // roll back the role change that triggered it. Failing to report must never undo the
+        // thing being reported.
+        try {
+            $this->oznam($customer, $year, $zdrazeni);
+        } catch (\Throwable $chyba) {
+            $this->logger->error('Oznámení o zdražení selhalo.', [
+                'user_id'   => $customer->getId(),
+                'exception' => $chyba,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<int, array{nazev: string, pred: string, po: string}> $zdrazeni
+     */
+    private function oznam(User $customer, int $year, array $zdrazeni): void
+    {
         $prijemci = $this->dejCfoMaily();
         if ($prijemci === []) {
             // Nobody to tell is itself worth recording — the price still went up.
@@ -47,9 +65,6 @@ class PriceIncreaseNotifier
         $zprava = $this->sestavZpravu($customer, $year, $zdrazeni);
         $predmet = sprintf('Zdražení objednávky po změně rolí: %s', $customer->getJmeno());
         foreach ($prijemci as $email) {
-            // Doctrine fires postPersist before the commit, so an unreachable SMTP would
-            // otherwise roll back the role change itself. One bad address must also not
-            // stop the remaining CFOs from being told.
             try {
                 $this->odesli($email, $predmet, $zprava);
             } catch (\Throwable $chyba) {
@@ -122,7 +137,10 @@ class PriceIncreaseNotifier
         );
     }
 
-    private function dejZustatek(User $customer): string
+    /**
+     * Overridden in tests: a real call runs a full legacy Finance recompute.
+     */
+    protected function dejZustatek(User $customer): string
     {
         $legacy = \Uzivatel::zId((int) $customer->getId());
         if ($legacy === null) {

--- a/symfony/src/Service/PriceIncreaseNotifier.php
+++ b/symfony/src/Service/PriceIncreaseNotifier.php
@@ -18,6 +18,11 @@ use Psr\Log\LoggerInterface;
  */
 class PriceIncreaseNotifier
 {
+    /**
+     * @var array<int, array{customer: User, year: int, zdrazeni: array<int, array{nazev: string, pred: string, po: string}>}>
+     */
+    private array $fronta = [];
+
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly LoggerInterface $logger,
@@ -25,6 +30,9 @@ class PriceIncreaseNotifier
     }
 
     /**
+     * Only queued here, never sent: the caller runs in postPersist, which Doctrine fires
+     * before the commit. Sending is left to {@see odesliFrontu()} after it.
+     *
      * @param array<int, array{nazev: string, pred: string, po: string}> $zdrazeni keyed by order item id
      */
     public function oznamZdrazeni(User $customer, int $year, array $zdrazeni): void
@@ -33,16 +41,33 @@ class PriceIncreaseNotifier
             return;
         }
 
-        // Doctrine fires postPersist before the commit, so anything escaping from here would
-        // roll back the role change that triggered it. Failing to report must never undo the
-        // thing being reported.
-        try {
-            $this->oznam($customer, $year, $zdrazeni);
-        } catch (\Throwable $chyba) {
-            $this->logger->error('Oznámení o zdražení selhalo.', [
-                'user_id'   => $customer->getId(),
-                'exception' => $chyba,
-            ]);
+        $this->fronta[] = [
+            'customer' => $customer,
+            'year'     => $year,
+            'zdrazeni' => $zdrazeni,
+        ];
+    }
+
+    /**
+     * Drains what postPersist queued. Runs after the commit, so a failure here cannot undo
+     * the price change being reported — and a rolled-back change never reaches this at all.
+     */
+    public function odesliFrontu(): void
+    {
+        $fronta = $this->fronta;
+        // Taken before sending, so a nested flush triggered while sending cannot see the
+        // same batch and send it twice.
+        $this->fronta = [];
+
+        foreach ($fronta as $polozka) {
+            try {
+                $this->oznam($polozka['customer'], $polozka['year'], $polozka['zdrazeni']);
+            } catch (\Throwable $chyba) {
+                $this->logger->error('Oznámení o zdražení selhalo.', [
+                    'user_id'   => $polozka['customer']->getId(),
+                    'exception' => $chyba,
+                ]);
+            }
         }
     }
 

--- a/symfony/tests/EventListener/UserRoleChangedListenerTest.php
+++ b/symfony/tests/EventListener/UserRoleChangedListenerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventListener;
+
+use App\Entity\Order;
+use App\Entity\OrderItem;
+use App\Entity\Product;
+use App\Entity\User;
+use App\EventListener\UserRoleChangedListener;
+use App\Repository\OrderRepository;
+use App\Service\DiscountCalculator;
+use App\Service\PriceIncreaseNotifier;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The CFO is told only when a role change makes an order dearer, so the rule deciding that
+ * is what needs pinning — a notification on every change would be noise nobody reads.
+ */
+class UserRoleChangedListenerTest extends TestCase
+{
+    private MockObject $discountCalculator;
+
+    private MockObject $priceIncreaseNotifier;
+
+    private MockObject $orderRepository;
+
+    protected function setUp(): void
+    {
+        $this->discountCalculator = $this->createMock(DiscountCalculator::class);
+        $this->priceIncreaseNotifier = $this->createMock(PriceIncreaseNotifier::class);
+        $this->orderRepository = $this->createMock(OrderRepository::class);
+    }
+
+    private function spustProCenu(string $puvodni, string $nova): void
+    {
+        $product = new Product();
+        $product->setName('Tričko');
+        $product->setCurrentPrice('250.00');
+
+        $item = new OrderItem();
+        $item->setProduct($product);
+        $item->setPurchasePrice($puvodni);
+
+        $order = new Order();
+        $order->addItem($item);
+
+        $user = $this->createMock(User::class);
+        $this->orderRepository->method('findPendingForCustomer')->willReturn($order);
+        $this->discountCalculator->method('calculateDiscount')->willReturn([
+            'discount'       => null,
+            'discountAmount' => '0.00',
+            'finalPrice'     => $nova,
+            'reason'         => null,
+        ]);
+
+        /** @var OrderRepository $orderRepository */
+        $orderRepository = $this->orderRepository;
+        /** @var DiscountCalculator $discountCalculator */
+        $discountCalculator = $this->discountCalculator;
+        /** @var PriceIncreaseNotifier $notifier */
+        $notifier = $this->priceIncreaseNotifier;
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        /** @var LoggerInterface $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+
+        (new UserRoleChangedListener(
+            $entityManager,
+            $orderRepository,
+            $discountCalculator,
+            $notifier,
+            $logger,
+        ))->onUserRoleChanged($user, 2026);
+    }
+
+    public function testDearerOrderNotifiesTheCfo(): void
+    {
+        $this->priceIncreaseNotifier->expects(self::once())
+            ->method('oznamZdrazeni')
+            ->with(self::anything(), 2026, self::callback(
+                static fn (array $zdrazeni): bool => count($zdrazeni) === 1,
+            ));
+
+        $this->spustProCenu('0.00', '250.00');
+    }
+
+    public function testCheaperOrderNotifiesNobody(): void
+    {
+        $this->priceIncreaseNotifier->expects(self::once())
+            ->method('oznamZdrazeni')
+            ->with(self::anything(), 2026, []);
+
+        $this->spustProCenu('250.00', '0.00');
+    }
+}

--- a/symfony/tests/Service/PriceIncreaseNotifierTest.php
+++ b/symfony/tests/Service/PriceIncreaseNotifierTest.php
@@ -50,6 +50,8 @@ class PriceIncreaseNotifierTest extends TestCase
 
             public bool $selhat = false;
 
+            public bool $drainPriOdeslani = false;
+
             public bool $selhatPriSestaveni = false;
 
             protected function dejZustatek(User $customer): string
@@ -65,6 +67,10 @@ class PriceIncreaseNotifierTest extends TestCase
             {
                 if ($this->selhat) {
                     throw new \RuntimeException('SMTP je nedostupné');
+                }
+                if ($this->drainPriOdeslani) {
+                    $this->drainPriOdeslani = false;
+                    $this->odesliFrontu();
                 }
                 $this->odeslane[] = [
                     'email'   => $email,
@@ -96,7 +102,9 @@ class PriceIncreaseNotifierTest extends TestCase
     {
         $this->userRepository->expects(self::never())->method('findByRoleMeaning');
 
-        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, []);
+        $notifier = $this->notifier();
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, []);
+        $notifier->odesliFrontu();
 
         self::assertSame([], $this->odeslane);
     }
@@ -107,13 +115,15 @@ class PriceIncreaseNotifierTest extends TestCase
             ->with(RoleMeaning::CFO)
             ->willReturn([$this->cfo('cfo1@example.invalid'), $this->cfo('cfo2@example.invalid')]);
 
-        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, [
+        $notifier = $this->notifier();
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
             7 => [
                 'nazev' => 'Tričko',
                 'pred'  => '0.00',
                 'po'    => '250.00',
             ],
         ]);
+        $notifier->odesliFrontu();
 
         self::assertCount(2, $this->odeslane);
         self::assertSame('cfo1@example.invalid', $this->odeslane[0]['email']);
@@ -142,6 +152,7 @@ class PriceIncreaseNotifierTest extends TestCase
                 'po'    => '250.00',
             ],
         ]);
+        $notifier->odesliFrontu();
 
         self::assertSame([], $this->odeslane);
     }
@@ -166,6 +177,69 @@ class PriceIncreaseNotifierTest extends TestCase
                 'po'    => '250.00',
             ],
         ]);
+        $notifier->odesliFrontu();
+
+        self::assertSame([], $this->odeslane);
+    }
+
+    public function testQueuingAloneSendsNothing(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->willReturn([$this->cfo('cfo@example.invalid')]);
+
+        $notifier = $this->notifier();
+        // No drain: in production this is the still-open transaction, where a mail must not
+        // go out yet — the price change may still roll back.
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+
+        self::assertSame([], $this->odeslane);
+    }
+
+    public function testReentrantDrainDoesNotSendTheSameBatchTwice(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->willReturn([$this->cfo('cfo@example.invalid')]);
+
+        $notifier = $this->notifier();
+        // Sending can flush (logging, legacy reads), which re-enters odesliFrontu().
+        $notifier->drainPriOdeslani = true;
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+        $notifier->odesliFrontu();
+
+        self::assertCount(1, $this->odeslane);
+    }
+
+    public function testAFailedBatchIsNotResentOnTheNextFlush(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->willReturn([$this->cfo('cfo@example.invalid')]);
+
+        $notifier = $this->notifier();
+        $notifier->selhat = true;
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+        $notifier->odesliFrontu();
+
+        // An unrelated later flush must not resurrect the failed batch.
+        $notifier->selhat = false;
+        $notifier->odesliFrontu();
 
         self::assertSame([], $this->odeslane);
     }
@@ -175,13 +249,15 @@ class PriceIncreaseNotifierTest extends TestCase
         $this->userRepository->method('findByRoleMeaning')->willReturn([]);
         $this->logger->expects(self::once())->method('error');
 
-        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, [
+        $notifier = $this->notifier();
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
             7 => [
                 'nazev' => 'Tričko',
                 'pred'  => '0.00',
                 'po'    => '250.00',
             ],
         ]);
+        $notifier->odesliFrontu();
 
         self::assertSame([], $this->odeslane);
     }

--- a/symfony/tests/Service/PriceIncreaseNotifierTest.php
+++ b/symfony/tests/Service/PriceIncreaseNotifierTest.php
@@ -50,6 +50,17 @@ class PriceIncreaseNotifierTest extends TestCase
 
             public bool $selhat = false;
 
+            public bool $selhatPriSestaveni = false;
+
+            protected function dejZustatek(User $customer): string
+            {
+                if ($this->selhatPriSestaveni) {
+                    throw new \RuntimeException('Legacy Finance selhalo');
+                }
+
+                return '0.00 Kč';
+            }
+
             protected function odesli(string $email, string $predmet, string $zprava): void
             {
                 if ($this->selhat) {
@@ -123,6 +134,30 @@ class PriceIncreaseNotifierTest extends TestCase
 
         $notifier = $this->notifier();
         $notifier->selhat = true;
+
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+
+        self::assertSame([], $this->odeslane);
+    }
+
+    /**
+     * The balance comes from a full legacy Finance recompute, which runs on another
+     * connection inside the still-open transaction.
+     */
+    public function testFailedBalanceLookupDoesNotEscape(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->willReturn([$this->cfo('cfo@example.invalid')]);
+        $this->logger->expects(self::once())->method('error');
+
+        $notifier = $this->notifier();
+        $notifier->selhatPriSestaveni = true;
 
         $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
             7 => [

--- a/symfony/tests/Service/PriceIncreaseNotifierTest.php
+++ b/symfony/tests/Service/PriceIncreaseNotifierTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Enum\RoleMeaning;
+use App\Repository\UserRepository;
+use App\Service\PriceIncreaseNotifier;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PriceIncreaseNotifierTest extends TestCase
+{
+    /**
+     * @var array<int, array{email: string, predmet: string, zprava: string}>
+     */
+    private array $odeslane = [];
+
+    private MockObject $userRepository;
+
+    private MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    private function notifier(): PriceIncreaseNotifier
+    {
+        /** @var UserRepository $repository */
+        $repository = $this->userRepository;
+        /** @var LoggerInterface $logger */
+        $logger = $this->logger;
+
+        return new class($repository, $logger, $this->odeslane) extends PriceIncreaseNotifier {
+            /**
+             * @param array<int, array{email: string, predmet: string, zprava: string}> $odeslane
+             */
+            public function __construct(
+                UserRepository $userRepository,
+                LoggerInterface $logger,
+                public array &$odeslane,
+            ) {
+                parent::__construct($userRepository, $logger);
+            }
+
+            public bool $selhat = false;
+
+            protected function odesli(string $email, string $predmet, string $zprava): void
+            {
+                if ($this->selhat) {
+                    throw new \RuntimeException('SMTP je nedostupné');
+                }
+                $this->odeslane[] = [
+                    'email'   => $email,
+                    'predmet' => $predmet,
+                    'zprava'  => $zprava,
+                ];
+            }
+        };
+    }
+
+    private function cfo(string $email): User
+    {
+        $cfo = $this->createMock(User::class);
+        $cfo->method('getEmail')->willReturn($email);
+
+        return $cfo;
+    }
+
+    private function zakaznik(): User
+    {
+        $zakaznik = $this->createMock(User::class);
+        $zakaznik->method('getId')->willReturn(4242);
+        $zakaznik->method('getJmeno')->willReturn('Testovací Zákazník');
+
+        return $zakaznik;
+    }
+
+    public function testNothingIsSentWithoutAPriceIncrease(): void
+    {
+        $this->userRepository->expects(self::never())->method('findByRoleMeaning');
+
+        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, []);
+
+        self::assertSame([], $this->odeslane);
+    }
+
+    public function testEveryCfoIsTold(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->with(RoleMeaning::CFO)
+            ->willReturn([$this->cfo('cfo1@example.invalid'), $this->cfo('cfo2@example.invalid')]);
+
+        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+
+        self::assertCount(2, $this->odeslane);
+        self::assertSame('cfo1@example.invalid', $this->odeslane[0]['email']);
+        // The mail has to carry both prices, or the reader cannot judge the case.
+        self::assertStringContainsString('0.00 → 250.00', $this->odeslane[0]['zprava']);
+        self::assertStringContainsString('Testovací Zákazník', $this->odeslane[0]['predmet']);
+    }
+
+    /**
+     * Doctrine fires postPersist before the commit, so a throwing mailer would roll back the
+     * role change that triggered it.
+     */
+    public function testFailedMailDoesNotEscape(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')
+            ->willReturn([$this->cfo('cfo@example.invalid')]);
+        $this->logger->expects(self::once())->method('error');
+
+        $notifier = $this->notifier();
+        $notifier->selhat = true;
+
+        $notifier->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+
+        self::assertSame([], $this->odeslane);
+    }
+
+    public function testMissingCfoIsLoggedRatherThanSwallowed(): void
+    {
+        $this->userRepository->method('findByRoleMeaning')->willReturn([]);
+        $this->logger->expects(self::once())->method('error');
+
+        $this->notifier()->oznamZdrazeni($this->zakaznik(), 2026, [
+            7 => [
+                'nazev' => 'Tričko',
+                'pred'  => '0.00',
+                'po'    => '250.00',
+            ],
+        ]);
+
+        self::assertSame([], $this->odeslane);
+    }
+}


### PR DESCRIPTION
[Trello 1274 — Přepsat e-shop](https://trello.com/c/5o4O9iBN/1274-p%C5%99epsat-e-shop)

Postaveno na `1274-přepsat-e-shop` a míří tam, není to PR do `main`.

## Problém

Když někdo přijde o roli, `UserRoleChangedListener` přepočítá ceny už objednaných položek — a to oběma směry. Organizátorovi, který měl tričko zdarma, se tak z položky zdarma stane placená a vznikne mu dluh, o kterém neví a ke kterému nedal souhlas. Nic to nikam nehlásí.

Přepočet sám je správně: je to to, co zařídí, že role přidělená těsně před GC se projeví na objednávce. Chybí ale to, aby si někdo všiml opačného směru.

## Není to teoretické

Z `uzivatele_role_log`:

| ročník | lidí, kterým byla odebrána org role a už měli nákupy | z toho drželi položku zdarma |
|---|---|---|
| 2026 | 3 | 1 |
| 2025 | 6 | 1 |
| 2024 | 7 | 0 |
| 2023 | 6 | 0 |
| 2022 | 2 | 0 |

Tedy 24 lidí za pět let, dvakrát se zdarma položkou. Vzácné, ale opakuje se to. Zatím to nikoho netrefilo jen proto, že samotný listener je nový.

## Řešení

Každé **zdražení** se pošle mailem všem s rolí CFO (`RoleMeaning::CFO`, dnes 7 lidí, všichni s mailem). V mailu je položka, cena před a po, a aktuální zůstatek zákazníka. Když roli nemá nikdo, zaloguje se to jako `error` — cena se změnila tak jako tak a nesmí to zapadnout.

Zlevnění se neoznamuje; byl by to šum, který nikdo nečte.

## Odesílání je fail-soft

Doctrine vyvolá `postPersist` **před** commitem — `UserRoleEntityListener` je na něj navěšený a `executeInserts()` běží dřív než `commit()`. `GcMail::odeslat()` po neúspěchu a jednom opakování výjimku přehazuje dál. Bez ošetření by tedy nedostupné SMTP shodilo celou transakci: role by se nepřidělila, cena nezměnila, EntityManager by se zavřel a admin by viděl 500.

Proto se odesílá v `try/catch` po jednotlivých příjemcích — jedna špatná adresa nesmí zabránit tomu, aby se to dozvěděli ostatní.

## Vedlejší oprava

`CartService::buildOrderItem()` neukládal `discount_amount`, když sleva nebyla, takže vztah `original − discount = purchase` u běžných řádků neplatil. Teď se ukládá vždy.

`original_price` zůstává na `snapshotProduct()`, které bere **efektivní cenu varianty**, ne cenu rodičovského produktu. Původně jsem ho přepisoval cenou produktu — dnes to nic nerozbije (žádná z 1135 variant nemá vlastní cenu), ale byla by to past pro první variantu, která ji dostane.

## Ověření

Testy: 302 v `symfony/tests`, 77 v `tests/Shop`, PHPStan bez chyb, ECS čistý.

Všechny nové testy ověřeny mutací:

| mutace | co selže |
|---|---|
| oznamovat každou změnu, ne jen zdražení | `testCheaperOrderNotifiesNobody` |
| odebrat `try/catch` kolem odeslání | výjimka propadne ven, jako by propadla do transakce |

Porovnání cen přes `(float)` na `DECIMAL(6,2)` bylo v review ověřeno proti `bccomp` na celém rozsahu 0.00–9999.99 (milion dvojic, nula rozdílů).

## Pozor při review

- **Přepočet se nemění**, mění se jen to, že se o zdražení ví. Pokud by se mělo zdražování zakázat úplně, je to jiné rozhodnutí a jiná změna.
- **`forceRecalculateCompletedOrder()` teď taky posílá maily** — je to adminská oprava už dokončené objednávky, takže dávka oprav znamená dávku mailů. Doplněno do jeho docblocku.
- **Položky jen pro organizátory (červené tričko) se pořád přeceňují.** Dohodli jsme se, že se má nechat cena i položka; listener to zatím neumí, protože rozlišení je shoda na názvu (`stripos(nazev, 'červené')` + právo `MUZE_OBJEDNAVAT_CERVENA_TRICKA`). Chce to tag, stejně jako spacáky — samostatná změna.
- **Mail jde přes legacy `GcMail`**, což je jediný způsob, jak se v `symfony/src/` posílá (viz `ObnovaHeslaController`). Na neprodukčních prostředích `GcMail` maily odklání do souboru, takže preview a archivy reálným CFO nic nepošlou.

## Kde to naklikat

Bez odebrání role není co vidět — pravidlo se spustí jen při změně rolí uživatele, který už má objednávku.

- <http://localhost:18020/admin/uzivatel> → najdi uživatele s objednávkou a org rolí → odeber roli → v Mailhogu (<http://localhost:18120>) čekej mail „Zdražení objednávky po změně rolí" s cenou před/po a zůstatkem
- tamtéž → roli naopak přidej → objednávka zlevní a **žádný mail nechodí**
