### PR TITLE
1488 Opravit fatal na /prihlaseni + hlídat závislosti kernelu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,11 +51,16 @@ ui/node_modules
 # Dev-only vendor packages. vendor/ is committed, so COPY drags all of it
 # in, and nothing here runs composer install to strip them.
 #
-# vendor/zenstruck is deliberately NOT listed: the archive boots the
-# kernel with an empty APP_ENV, which config/bundles.php reads as dev and
-# so registers ZenstruckFoundryBundle. Deleting the files makes every
-# kernel-booting page 500, and no autoloader dump can undo that. Before
-# adding a dir here, check that nothing in bundles.php comes from it.
+# The archive boots the kernel with an empty APP_ENV, which
+# config/bundles.php reads as dev, so it loads MakerBundle and
+# ZenstruckFoundryBundle. Anything those need — transitively — must stay:
+# zenstruck, fakerphp (Foundry uses Faker\Factory) and nikic. Deleting
+# any of them makes every kernel-booting page 500, and no autoloader dump
+# can undo a missing file.
+#
+# Do not hand-maintain this: bin/check-archive-dockerignore.php derives
+# the kernel's transitive closure from composer.lock and fails if the list
+# below overlaps it.
 #
 # Regenerate by diffing composer.lock's packages-dev vendor dirs against
 # packages, minus anything bundles.php registers.
@@ -63,8 +68,6 @@ vendor/symplify
 vendor/rector
 vendor/phpstan
 vendor/phpunit
-vendor/fakerphp
-vendor/nikic
 vendor/sebastian
 vendor/phar-io
 vendor/myclabs

--- a/bin/check-archive-dockerignore.php
+++ b/bin/check-archive-dockerignore.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The archive image ships a committed vendor/ and runs no composer install,
+ * so a vendor dir excluded in .dockerignore is simply gone at runtime. The
+ * kernel boots with an empty APP_ENV — read as dev — and loads the bundles
+ * config/bundles.php registers for it, so excluding anything they need
+ * transitively turns every kernel-booting page into a 500 that no
+ * autoloader dump can repair. Three such outages shipped before this check
+ * existed: MakerBundle, then ZenstruckFoundryBundle, then Faker\Factory.
+ */
+
+$root = dirname(__DIR__);
+$lock = json_decode((string) file_get_contents($root . '/composer.lock'), true, 512, JSON_THROW_ON_ERROR);
+
+$byName = [];
+foreach ([...$lock['packages'] ?? [], ...$lock['packages-dev'] ?? []] as $package) {
+    $byName[$package['name']] = $package;
+}
+
+$bundlesFile = $root . '/symfony/config/bundles.php';
+if (! is_file($bundlesFile)) {
+    echo "✓ no symfony/config/bundles.php — this year boots no kernel\n";
+
+    exit(0);
+}
+
+preg_match_all('~^\s*([A-Za-z\\\\]+)::class~m', (string) file_get_contents($bundlesFile), $matches);
+
+$queue = [];
+foreach ($matches[1] as $class) {
+    $vendorDir = strtolower(explode('\\', $class)[0]);
+    foreach (array_keys($byName) as $name) {
+        if (explode('/', $name)[0] === $vendorDir) {
+            $queue[] = $name;
+        }
+    }
+}
+
+$required = [];
+while ($queue !== []) {
+    $name = array_pop($queue);
+    if (isset($required[$name]) || ! isset($byName[$name])) {
+        continue;
+    }
+    $required[$name] = true;
+    foreach (array_keys($byName[$name]['require'] ?? []) as $dependency) {
+        $queue[] = $dependency;
+    }
+}
+
+$needed = [];
+foreach (array_keys($required) as $name) {
+    $needed[explode('/', $name)[0]] = true;
+}
+
+$excluded = [];
+foreach (file($root . '/.dockerignore', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+    $line = trim($line);
+    if (str_starts_with($line, 'vendor/')) {
+        $excluded[] = rtrim(substr($line, strlen('vendor/')), '/');
+    }
+}
+
+$broken = array_intersect($excluded, array_keys($needed));
+
+if ($broken !== []) {
+    fwrite(STDERR, ".dockerignore excludes vendor dirs the kernel needs — every kernel-booting page would 500:\n");
+    foreach ($broken as $dir) {
+        fwrite(STDERR, "  vendor/{$dir}\n");
+    }
+
+    exit(1);
+}
+
+echo '✓ .dockerignore leaves the kernel intact (' . count($needed) . " vendor dirs required)\n";
+
+exit(0);


### PR DESCRIPTION
[Trello 1488](https://trello.com/c/zwJRjpTD) — třetí hotfix k [PR #1079](https://github.com/gamecon-cz/gamecon/pull/1079). Navazuje na [#1080](https://github.com/gamecon-cz/gamecon/pull/1080) a [#1081](https://github.com/gamecon-cz/gamecon/pull/1081).

## Co se rozbilo

```
Uncaught Exception: Can not boot Symfony kernel. Current APP_ENV is dev.
Details: Class "Faker\Factory" not found
model/SystemoveNastaveni/SystemoveNastaveni.php:1144
```

## Příčina

Tohle je **potřetí ta samá chyba** a je to moje vina, že jsem ji opravoval po jedné.

Archiv bootuje kernel s prázdným `APP_ENV` (= `dev`), takže `config/bundles.php` načte `MakerBundle` i `ZenstruckFoundryBundle`. Foundry si vytváří `Faker\Factory` — a `vendor/fakerphp` jsem měl ve vylučovacím seznamu, takže v image fyzicky nebyl.

Postupně to padalo na:

1. `MakerBundle` → opraveno v #1080 (soubor byl na disku, chyběl jen záznam v autoloaderu)
2. `ZenstruckFoundryBundle` → opraveno v #1081 (`vendor/zenstruck` jsem mazal)
3. `Faker\Factory` → tenhle PR

A `nikic` byl v řadě jako čtvrtý.

## Oprava

Místo dalšího ručního doplňování jsem spočítal **tranzitivní uzávěr** závislostí bundlů z `composer.lock`:

```
vendor dirs, které kernel potřebuje: doctrine, egulias, fakerphp,
                                     nextras, nikic, psr, symfony, zenstruck
```

`fakerphp` i `nikic` z vylučovacího seznamu vypadly.

## Pojistka, aby se to nestalo počtvrté

`bin/check-archive-dockerignore.php` projde `bundles.php`, dohledá odpovídající balíčky v `composer.lock`, spočítá uzávěr jejich `require` a spadne, když `.dockerignore` cokoli z toho vylučuje.

Ověřeno proti všem třem reálným výpadkům:

| vyloučeno | výsledek |
|---|---|
| `vendor/zenstruck` | zachyceno ✓ |
| `vendor/fakerphp` | zachyceno ✓ |
| `vendor/nikic` | zachyceno ✓ |
| `vendor/symfony` | zachyceno ✓ |
| aktuální seznam | prochází ✓ |

## Ověření

- `MakerBundle`, `ZenstruckFoundryBundle` i `Faker\Factory` se v novém image načtou
- oba bundly jdou **instanciovat**, ne jen `class_exists`
- `phpstan`, `rector`, `symplify`, `phpunit`, `sebastian` v image dál nejsou
- `COPY` vrstva 99 MB (proti 241 MB původně) — úspora se zmenšila o vrácené balíčky, ale drží

## Pozor při review

- Merge = deploy živého webu.
- **Po nasazení prosím zkus reálně odeslat login formulář.** Moje ověřování třikrát po sobě kontrolovalo jen GET stránky, které kernel nebootují, takže jsem opakovaně hlásil „funguje" u rozbitého webu. Sám to bez databáze lokálně neodsimuluju.
- 2022/2023/2024 tímhle netrpí — `symfony/config/bundles.php` tam vůbec neexistuje (ověřeno), takže žádný kernel neběží. Check to pozná a vypíše, že není co hlídat.