### PR TITLE
Opravit týdenní GHCR prune (padal na SSH omezení)

### DIFF
--- a/.github/workflows/prune-ghcr-images.yml
+++ b/.github/workflows/prune-ghcr-images.yml
@@ -42,17 +42,6 @@ jobs:
                 # so one shared with another stream must be left alone. The
                 # rolling `preview-<slug>` / `archive-<year>` tag (no sha) is
                 # never a candidate: it is what the host pulls by default.
-            -   name: Set up SSH
-                env:
-                    SSH_KEY: ${{ secrets.GAMECON_DEPLOY_SSH_KEY }}
-                    SSH_KNOWN_HOSTS: ${{ secrets.GAMECON_KNOWN_HOSTS }}
-                run: |
-                    mkdir -p ~/.ssh
-                    echo "$SSH_KEY" > ~/.ssh/id_ed25519
-                    chmod 0600 ~/.ssh/id_ed25519
-                    echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-                    chmod 0644 ~/.ssh/known_hosts
-
             -   name: Prune superseded versions
                 env:
                     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,33 +60,21 @@ jobs:
                     total=$(jq 'length' all-versions.json)
                     echo "Total versions: $total"
 
-                    # Tags of everything currently deployed, from the host's
-                    # own records rather than inferred from tag shape: a slug
-                    # may end in something shaped like a sha (`sha-1a2b3c4d` is
-                    # a real fallback slug in deploy-preview.yml), so
-                    # `preview-slevy-abcdef1` reads equally as a stale build of
-                    # `slevy` and as a live preview's rolling tag. Fail closed —
-                    # without the records we cannot tell them apart.
-                    if ! ssh -o StrictHostKeyChecking=yes root@gamecon.cz \
-                        "cat /var/lib/gamecon/deployments/previews/*.json \
-                             /var/lib/gamecon/deployments/archives/*.json \
-                             2>/dev/null || true" > live-records.json; then
-                        echo "Could not read deployment records — aborting." >&2
-                        exit 1
-                    fi
-                    jq -rs '[.[] | .image | sub("^[^:]+:"; "")] | unique' \
-                        < live-records.json > live-tags.json
-                    echo "Live image tags: $(jq -r 'length' live-tags.json)"
-
-                    jq -r --argjson keep "$KEEP_PER_STREAM" \
-                          --slurpfile live live-tags.json '
-                        ($live[0]) as $liveTags
-                        | [ .[]
+                    # Deployments are protected two ways, because neither
+                    # alone is enough. A version carrying a bare rolling tag is
+                    # skipped outright (that is what a deploy pulls), and the
+                    # newest KEEP_PER_STREAM builds of every stream are kept.
+                    # Rolling out a stream makes its newest build, so the two
+                    # together cover the live image in normal operation.
+                    # KEEP_PER_STREAM is the margin for the case they do not:
+                    # a deliberate rollback to a build older than that, which
+                    # would have to be redeployed from CI afterwards. Asking
+                    # the host directly is not an option — the CI key is pinned
+                    # to a forced command permitting only the deploy scripts.
+                    jq -r --argjson keep "$KEEP_PER_STREAM" '
+                        [ .[]
                             | { id, created: .created_at,
                                 tags: (.metadata.container.tags // []) }
-                            # Never touch a version any deployment still points
-                            # at, whatever its tag looks like.
-                            | select([.tags[] | IN($liveTags[])] | any | not)
                             | . + { streams: [
                                   .tags[]
                                   | capture("^(?<stream>(preview|archive)-.+)-[0-9a-f]{7,40}$")


### PR DESCRIPTION
První ruční `dry_run` odhalil, že týdenní úklid GHCR **nefunguje** — a naplánovaný běh je v neděli 2026-09-13 05:30 UTC.

## Co padalo

```
Total versions: 2246
ci-preview-wrapper: command must invoke /usr/local/sbin/deploy-preview-branch.sh
                    or /usr/local/sbin/deploy-year-archive.sh
Could not read deployment records — aborting.
```

CI klíč je záměrně omezený `command="/usr/local/sbin/ci-preview-wrapper"` v `authorized_keys` a pouští jen ty dva deploy skripty. Můj `cat /var/lib/gamecon/deployments/*.json` tím pádem nikdy projít nemohl — což jsem si měl ověřit předem.

Job skončil chybou a **nic nesmazal** (fail-closed větev fungovala), ale v neděli by běžel neobsluhovaně a spadl stejně.

## Co ten běh zároveň ukázal

- **Token na org packages funguje** — `Total versions: 2246`. To byla jediná věc, kterou jsem lokálně ověřit nemohl (můj token nemá `read:packages`).
- **2246 verzí** v balíčku. První reálné číslo backlogu.

## Oprava

SSH není potřeba. Živý image poznáme z registru, který job stejně čte:

1. **Verze s rolling tagem** (`archive-2025` bez sha) se přeskakuje — přesně tu deploy pullne.
2. **N nejnovějších buildů každého streamu** se nechává.

Deploy streamu je zároveň to, co vytvoří jeho nejnovější build, takže se ty dvě podmínky v běžném provozu překrývají. `KEEP_PER_STREAM` je rezerva pro případ, kdy ne (vědomý rollback na starší build).

Odstraněn i mrtvý „Set up SSH" krok.

## Ověření

Spuštěno proti fixturám se **skutečnými živými tagy** (`archive-2022-c0611e2`, `2023-a9eed0d`, `2024-761a16f`, `2025-beca938`), stubnutý `gh`:

| scénář | výsledek |
|---|---|
| živá verze (rolling+sha) + 4 starší buildy | smaže 2 nejstarší, **živou nikdy** ✓ |
| jen 2 buildy na stream | nemaže nic ✓ |
| 20 verzí, vše by spadlo do výběru | **odmítne a skončí chybou** ✓ |

Ověřeno i na hostu: **0 z 32 deploymentů** běží na jiném než nejnovějším buildu svého streamu, takže se ty dvě ochrany dnes reálně překrývají.

`actionlint` čistý.

## Pozor při review

- **Po mergnutí je potřeba znovu spustit `dry_run: true`** a zkontrolovat výpis, než v neděli poprvé smaže doopravdy. Sám to potvrdit nemůžu — token nemám.
- Ve výpisu nesmí být žádný z těch čtyř živých archivních tagů.
- Když by výsledek vypadal divně, nejbezpečnější je zatím vypnout `schedule:` a nechat jen `workflow_dispatch`.