### PR TITLE
Oprava rozpočtového reportu padajícího na chybějící SQL funkci

### DIFF
--- a/admin/scripts/zvlastni/reporty/finance-report-sirien.php
+++ b/admin/scripts/zvlastni/reporty/finance-report-sirien.php
@@ -49,6 +49,32 @@ $typRoleUcast = Role::TYP_UCAST;
 $idTaguUnikovka = Tag::UNIKOVKA;
 $idTaguMalovani = Tag::MALOVANI;
 
+$maPravoUzivatele = static fn (string $sloupecUzivatele, int $pravo): string => <<<SQL
+    EXISTS(SELECT 1
+           FROM platne_role_uzivatelu
+             JOIN prava_role ON prava_role.id_role = platne_role_uzivatelu.id_role
+           WHERE platne_role_uzivatelu.id_uzivatele = {$sloupecUzivatele}
+             AND prava_role.id_prava = {$pravo})
+    SQL;
+
+$delkaAktivityJakoNasobekStandardni = <<<SQL
+    CASE HOUR(TIMEDIFF(akce_seznam.konec, akce_seznam.zacatek))
+        WHEN 1 THEN 0.25
+        WHEN 2 THEN 0.5
+        WHEN 3 THEN 1
+        WHEN 4 THEN 1
+        WHEN 5 THEN 1
+        WHEN 6 THEN 1.5
+        WHEN 7 THEN 1.5
+        WHEN 8 THEN 2
+        WHEN 9 THEN 2
+        WHEN 10 THEN 2.5
+        WHEN 11 THEN 2.5
+        WHEN 12 THEN 3
+        WHEN 13 THEN 3
+    END
+    SQL;
+
 $report = Report::zSql(<<<SQL
 SELECT export_data.kod AS kod, export_data.popis AS popis, export_data.data AS data
 FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev) AS popis, MAX(data_rows.data) AS data
@@ -123,17 +149,17 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                        '3L_so',
                                        '3L_ne')
                AND (NOT (
-                 maPravo(shop_nakupy.id_uzivatele, $maUbytovaniZdarma) -- právo ubytování zdarma
+                 {$maPravoUzivatele('shop_nakupy.id_uzivatele', $maUbytovaniZdarma)} -- právo ubytování zdarma
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maStredecniNocZdarma) AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maStredecniNocZdarma)} AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maCtvrtecniNocZdarma) AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maCtvrtecniNocZdarma)} AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maPatecniNocZdarma) AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maPatecniNocZdarma)} AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maSobotniNocZdarma) AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maSobotniNocZdarma)} AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maNedelniNocZdarma) AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maNedelniNocZdarma)} AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
                  ))
 
              UNION
@@ -152,17 +178,17 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                        '2L_so',
                                        '2L_ne')
                AND (NOT (
-                 maPravo(shop_nakupy.id_uzivatele, $maUbytovaniZdarma) -- právo ubytování zdarma
+                 {$maPravoUzivatele('shop_nakupy.id_uzivatele', $maUbytovaniZdarma)} -- právo ubytování zdarma
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maStredecniNocZdarma) AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maStredecniNocZdarma)} AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maCtvrtecniNocZdarma) AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maCtvrtecniNocZdarma)} AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maPatecniNocZdarma) AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maPatecniNocZdarma)} AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maSobotniNocZdarma) AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maSobotniNocZdarma)} AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maNedelniNocZdarma) AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maNedelniNocZdarma)} AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
                  ))
 
              UNION
@@ -181,17 +207,17 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                        '1L_so',
                                        '1L_ne')
                AND (NOT (
-                 maPravo(shop_nakupy.id_uzivatele, $maUbytovaniZdarma) -- právo ubytování zdarma
+                 {$maPravoUzivatele('shop_nakupy.id_uzivatele', $maUbytovaniZdarma)} -- právo ubytování zdarma
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maStredecniNocZdarma) AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maStredecniNocZdarma)} AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maCtvrtecniNocZdarma) AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maCtvrtecniNocZdarma)} AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maPatecniNocZdarma) AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maPatecniNocZdarma)} AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maSobotniNocZdarma) AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maSobotniNocZdarma)} AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maNedelniNocZdarma) AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maNedelniNocZdarma)} AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
                  ))
 
              UNION
@@ -210,17 +236,17 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                        'spacak_so',
                                        'spacak_ne')
                AND (NOT (
-                 maPravo(shop_nakupy.id_uzivatele, $maUbytovaniZdarma) -- právo ubytování zdarma
+                 {$maPravoUzivatele('shop_nakupy.id_uzivatele', $maUbytovaniZdarma)} -- právo ubytování zdarma
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maStredecniNocZdarma) AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maStredecniNocZdarma)} AND shop_predmety.ubytovani_den = 0) -- ubytování zdarma středa
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maCtvrtecniNocZdarma) AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maCtvrtecniNocZdarma)} AND shop_predmety.ubytovani_den = 1) -- ubytování zdarma čtvrtek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maPatecniNocZdarma) AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maPatecniNocZdarma)} AND shop_predmety.ubytovani_den = 2) -- ubytování zdarma pátek
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maSobotniNocZdarma) AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maSobotniNocZdarma)} AND shop_predmety.ubytovani_den = 3) -- ubytování zdarma sobota
                      OR
-                 (maPravo(shop_nakupy.id_uzivatele, $maNedelniNocZdarma) AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
+                 ({$maPravoUzivatele('shop_nakupy.id_uzivatele', $maNedelniNocZdarma)} AND shop_predmety.ubytovani_den = 4) -- ubytování zdarma neděle
                  ))
 
              UNION
@@ -244,7 +270,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
                      AND akce_seznam.bez_slevy = 0
-                     AND (maPravo(ap.id_uzivatele, $maAktivityZdarma)) -- právo Plná sleva na aktivity
+                     AND ({$maPravoUzivatele('ap.id_uzivatele', $maAktivityZdarma)}) -- právo Plná sleva na aktivity
                      AND akce_typy.kod_typu IS NOT NULL) activity_data
              GROUP BY activity_data.kod
 
@@ -268,7 +294,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                             JOIN akce_prihlaseni_spec ap ON akce_seznam.id_akce = ap.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
-                     AND (akce_seznam.bez_slevy = 1 OR (NOT maPravo(ap.id_uzivatele, $maAktivityZdarma))) -- není zdarma
+                     AND (akce_seznam.bez_slevy = 1 OR (NOT {$maPravoUzivatele('ap.id_uzivatele', $maAktivityZdarma)})) -- není zdarma
                      AND ap.id_stavu_prihlaseni = 4                                               -- storno
                      AND akce_typy.kod_typu IS NOT NULL) activity_data
              GROUP BY activity_data.kod
@@ -288,7 +314,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                              AND ast.id_tagu = $idTaguUnikovka), 'AHEsc', 'AHry'),
                                                  akce_typy.kod_typu)))             AS kod,
                           'Počet aktivit přepočtený na standardní aktivitu' AS nazev,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) AS data
+                          {$delkaAktivityJakoNasobekStandardni} AS data
                    FROM akce_seznam
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
@@ -316,7 +342,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                       akce_typy.kod_typu)))                                        AS kod,
                           'Průměrná kapacita aktivity, vážený průměr podle přepočtu na standardní aktivitu' AS nazev,
                           IF(akce_seznam.teamova = 0, akce_seznam.kapacita + akce_seznam.kapacita_f + akce_seznam.kapacita_m, akce_seznam.team_max) AS kapacita,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) AS dajns
+                          {$delkaAktivityJakoNasobekStandardni} AS dajns
                    FROM akce_seznam
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
@@ -347,7 +373,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                           (SELECT COUNT(*)
                            FROM akce_organizatori
                            WHERE akce_organizatori.id_akce = akce_seznam.id_akce)                                                        AS vypraveci,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) AS dajns
+                          {$delkaAktivityJakoNasobekStandardni} AS dajns
                    FROM akce_seznam
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
@@ -373,7 +399,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                               'AHry'),
                                                            akce_typy.kod_typu)))                                                AS kod,
                           'Vypravěčobloky (přepočtené standardní aktivity * počet lidí) vedené Vypravěči nebo Half-orgy' AS nazev,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) AS data
+                          {$delkaAktivityJakoNasobekStandardni} AS data
                    FROM akce_organizatori
                             JOIN akce_seznam ON akce_seznam.id_akce = akce_organizatori.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
@@ -404,7 +430,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                               'AHry'),
                                                            akce_typy.kod_typu)))                            AS kod,
                           'Vypravěčobloky (přepočtené standardní aktivity * počet lidí) vedené Orgy' AS nazev,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce)                                                                    AS data
+                          {$delkaAktivityJakoNasobekStandardni}                                                                    AS data
                    FROM akce_organizatori
                             JOIN akce_seznam ON akce_seznam.id_akce = akce_organizatori.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
@@ -433,12 +459,12 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                                 AND ast.id_tagu = $idTaguUnikovka), 'AHEsc', 'AHry'),
                                                     akce_typy.kod_typu)))                                        AS kod,
                           'Suma bonusů za vedení aktivit u lidí bez práva "bez bonusu za vedení aktivit"' AS nazev,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) * $bonusZa3hAz5hAktivitu AS data
+                          {$delkaAktivityJakoNasobekStandardni} * $bonusZa3hAz5hAktivitu AS data
                    FROM akce_organizatori
                             JOIN akce_seznam ON akce_seznam.id_akce = akce_organizatori.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
-                     AND NOT maPravo(akce_organizatori.id_uzivatele, $bezBonusuZaVedeniAktivit)
+                     AND NOT {$maPravoUzivatele('akce_organizatori.id_uzivatele', $bezBonusuZaVedeniAktivit)}
                      AND akce_typy.kod_typu IS NOT NULL) activity_data
              GROUP BY activity_data.kod
 
@@ -457,7 +483,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                                                                AND ast.id_tagu = $idTaguUnikovka), 'AHEsc', 'AHry'),
                                                    akce_typy.kod_typu)))                                                               AS kod,
                           'Počet herních bloků zabraný hráči přepočtený na standardní aktivitu (bez ohledu na kategorii hráče)' AS nazev,
-                          delkaAktivityJakoNasobekStandardni(akce_seznam.id_akce) AS data
+                          {$delkaAktivityJakoNasobekStandardni} AS data
                    FROM akce_prihlaseni
                             JOIN akce_seznam ON akce_prihlaseni.id_akce = akce_seznam.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
@@ -487,7 +513,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                             JOIN akce_seznam ON ap.id_akce = akce_seznam.id_akce
                             JOIN akce_typy ON akce_seznam.typ = akce_typy.id_typu
                    WHERE akce_seznam.rok = $rocnik
-                     AND NOT maPravo(ap.id_uzivatele, $maAktivityZdarma) -- plná sleva na aktivity
+                     AND NOT {$maPravoUzivatele('ap.id_uzivatele', $maAktivityZdarma)} -- plná sleva na aktivity
                      AND akce_typy.kod_typu IS NOT NULL) activity_data
              GROUP BY activity_data.kod
 
@@ -517,7 +543,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                             JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
                    WHERE shop_nakupy.rok = $rocnik
                      AND shop_predmety.kod_predmetu LIKE '%kostk%'
-                     AND maPravo(shop_nakupy.id_uzivatele, $maKostkuZdarma) -- kostka zdarma
+                     AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $maKostkuZdarma)} -- kostka zdarma
                    GROUP BY shop_nakupy.id_uzivatele) activity_data
 
              UNION
@@ -539,7 +565,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                             JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
                    WHERE shop_nakupy.rok = $rocnik
                      AND shop_predmety.kod_predmetu LIKE '%plack%'
-                     AND maPravo(shop_nakupy.id_uzivatele, $plackaZdarma) -- placka zdarma
+                     AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $plackaZdarma)} -- placka zdarma
                    GROUP BY shop_nakupy.id_uzivatele) activity_data
 
              UNION
@@ -581,7 +607,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND shop_predmety.kod_predmetu LIKE '%snidane%'
-               AND NOT maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
+               AND NOT {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
 
              UNION
 
@@ -590,7 +616,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND (shop_predmety.kod_predmetu LIKE '%obed%' OR shop_predmety.kod_predmetu LIKE '%vecere%')
-               AND NOT maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
+               AND NOT {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
 
              UNION
 
@@ -602,7 +628,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND shop_predmety.kod_predmetu LIKE '%snidane%'
-               AND maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
+               AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
 
              UNION
 
@@ -614,7 +640,7 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND (shop_predmety.kod_predmetu LIKE '%obed%' OR shop_predmety.kod_predmetu LIKE '%vecere%')
-               AND maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
+               AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
 
              UNION
 
@@ -626,8 +652,8 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND shop_predmety.kod_predmetu LIKE '%snidane%'
-               AND NOT maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
-               AND maPravo(shop_nakupy.id_uzivatele, $jidloSeSlevou)   -- jidlo se slevou
+               AND NOT {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
+               AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloSeSlevou)}   -- jidlo se slevou
 
              UNION
 
@@ -639,8 +665,8 @@ FROM (SELECT MAX(data_rows.poradi) AS poradi, data_rows.kod, MAX(data_rows.nazev
                       JOIN shop_predmety ON shop_nakupy.id_predmetu = shop_predmety.id_predmetu
              WHERE shop_nakupy.rok = $rocnik
                AND (shop_predmety.kod_predmetu LIKE '%obed%' OR shop_predmety.kod_predmetu LIKE '%vecere%')
-               AND NOT maPravo(shop_nakupy.id_uzivatele, $jidloZdarma) -- jidlo zdarma
-               AND maPravo(shop_nakupy.id_uzivatele, $jidloSeSlevou) -- jidlo se slevou
+               AND NOT {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloZdarma)} -- jidlo zdarma
+               AND {$maPravoUzivatele('shop_nakupy.id_uzivatele', $jidloSeSlevou)} -- jidlo se slevou
             )
             UNION ALL
             (SELECT 1 AS poradi, 'Ir-Timestamp' AS kod, NULL AS nazev, NULL AS data

--- a/tests/Model/Report/FinanceReportSirienTest.php
+++ b/tests/Model/Report/FinanceReportSirienTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Report;
+
+use Gamecon\Tests\Db\AbstractTestDb;
+
+class FinanceReportSirienTest extends AbstractTestDb
+{
+    private const SKRIPT_REPORTU = __DIR__ . '/../../../admin/scripts/zvlastni/reporty/finance-report-sirien.php';
+
+    /**
+     * Zálohy se obnovují bez uložených rutin, takže volání kterékoli z nich
+     * na ostré i v preview spadne.
+     *
+     * @test
+     */
+    public function reportNevolaZadnouUlozenouSqlFunkci(): void
+    {
+        $zdrojReportu = $this->zdrojReportu();
+
+        foreach (['maPravo', 'delkaAktivityJakoNasobekStandardni'] as $nazevFunkce) {
+            self::assertDoesNotMatchRegularExpression(
+                '~(?<![>$\w])' . preg_quote($nazevFunkce, '~') . '\s*\(~',
+                $zdrojReportu,
+                "Report volá SQL funkci {$nazevFunkce}, kterou databáze nemá – zálohy se obnovují bez rutin",
+            );
+        }
+    }
+
+    /**
+     * Test výše dává smysl jen nad databází bez rutin.
+     *
+     * @test
+     */
+    public function testovaciDatabazeNemaUlozeneRutiny(): void
+    {
+        self::assertSame(
+            '0',
+            (string) dbOneCol(<<<SQL
+                SELECT COUNT(*)
+                FROM information_schema.routines
+                WHERE routine_schema = DATABASE()
+                SQL,
+            ),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function vyrazyNahrazujiciSqlFunkceJsouPlatneSql(): void
+    {
+        $zdrojReportu = $this->zdrojReportu();
+
+        $maPravo = $this->vyrazZeSkriptu(
+            '~\$maPravoUzivatele\s*=\s*static fn[^=]*=>\s*<<<SQL\n(.*?)\n\s*SQL;~s',
+            $zdrojReportu,
+            'maPravoUzivatele',
+        );
+        $maPravo = strtr($maPravo, [
+            '{$sloupecUzivatele}' => 'uzivatele_hodnoty.id_uzivatele',
+            '{$pravo}'            => '1008',
+        ]);
+
+        $delkaAktivity = $this->vyrazZeSkriptu(
+            '~\$delkaAktivityJakoNasobekStandardni\s*=\s*<<<SQL\n(.*?)\n\s*SQL;~s',
+            $zdrojReportu,
+            'delkaAktivityJakoNasobekStandardni',
+        );
+
+        self::assertContains(
+            (int) dbOneCol(<<<SQL
+                SELECT {$maPravo}
+                FROM uzivatele_hodnoty
+                LIMIT 1
+                SQL,
+            ),
+            [0, 1],
+            'Výraz nahrazující maPravo nevrací pravdivostní hodnotu',
+        );
+
+        self::assertIsNumeric(
+            dbOneCol(<<<SQL
+                SELECT COUNT(*)
+                FROM akce_seznam
+                WHERE {$delkaAktivity} IS NOT NULL
+                SQL,
+            ),
+            'Výraz nahrazující delkaAktivityJakoNasobekStandardni neprojde v dotazu',
+        );
+    }
+
+    private function zdrojReportu(): string
+    {
+        $zdrojReportu = file_get_contents(self::SKRIPT_REPORTU);
+        self::assertNotFalse($zdrojReportu, 'Skript reportu nejde přečíst');
+
+        return $zdrojReportu;
+    }
+
+    private function vyrazZeSkriptu(
+        string $vzor,
+        string $zdrojReportu,
+        string $nazevVyrazu,
+    ): string {
+        self::assertSame(
+            1,
+            preg_match($vzor, $zdrojReportu, $shody),
+            "Ve skriptu reportu nejde najít výraz {$nazevVyrazu}",
+        );
+
+        return $shody[1];
+    }
+}


### PR DESCRIPTION
[Trello 1466 — Rozpočtový report 2026](https://trello.com/c/gy0EIX3D/1466-rozpo%C4%8Dtov%C3%BD-report-2026)

## Problém

Sirienův rozpočtový report nejde vygenerovat — ani v HTML, ani v XLSX. Místo tabulky vypadne Tracy s hláškou:

```
mysqli_sql_exception: FUNCTION gamecon.maPravo does not exist  #1305
```

Report je přitom podklad pro zpracování účetnictví, takže bez něj se po GC nedá uzavřít ročník.

## Příčina

Report si historicky sám vytvářel dvě SQL funkce při každém spuštění (`DROP FUNCTION` + `CREATE FUNCTION` nad dočasným spojením) a pak je volal ve svém dotazu.

Commit fa4a8ad9e *„Do not use SQL function drop on runtime"* (18. 11. 2025) to DDL za běhu správně odstranil — ale **nechal v dotazu všech 45 volání**:

* `maPravo(...)` — 38×
* `delkaAktivityJakoNasobekStandardni(...)` — 7×

Od té chvíle report spadne na prvním volání. Funkce neexistuje nikde jinde v repu — `git grep` na `CREATE FUNCTION` nevrací mimo `vendor/` nic.

**Proč to neopravit migrací.** Nabízí se funkce prostě vytvořit migrací, ale nevydrželo by to: zálohy se dělají **bez uložených rutin**. `ifsnop/mysqldump-php` má `'routines' => false` (`vendor/ifsnop/mysqldump-php/.../Mysqldump.php:144`) a projekt to nikde nepřepisuje — `NastrojeDatabaze` posílá jen `skip-definer`. Produkční dump `export_latest.sql` proto obsahuje **0** definic rutin. Funkce vytvořená migrací by tedy zmizela při každém importu zálohy do lokálu i preview a report by tam padal dál.

## Řešení

Oba výrazy jsou nově přímo v dotazu, interpolované do už existujícího heredocu (`admin/scripts/zvlastni/reporty/finance-report-sirien.php:52`):

* `$maPravoUzivatele(sloupec, pravo)` — closure vracející `EXISTS(...)` nad `platne_role_uzivatelu JOIN prava_role`
* `$delkaAktivityJakoNasobekStandardni` — `CASE HOUR(TIMEDIFF(...))` čtený přímo z `akce_seznam` v okolním scope

Report tím nezávisí na ničem v databázi — funguje na ostré, v preview, v archivech i po každém importu zálohy. Žádné DDL za běhu.

## Ověření

Ověřeno nad **produkčními daty** (import `export_latest.sql`), v DB s **nula uloženými rutinami** — tedy přesně ve stavu, v jakém je ostrá.

| | před | po |
|---|---|---|
| HTML | Tracy chyba, 206 kB | **HTTP 200**, tabulka, 19 853 B |
| XLSX | Tracy chyba | **HTTP 200**, validní `Microsoft Excel 2007+` |
| rutin v DB | 0 | 0 |

**Shoda čísel — hlavní důkaz.** Vygeneroval jsem report jednou s ručně vytvořenými původními funkcemi (baseline) a podruhé po opravě s nulou rutin. Porovnání `kod → data` po řádcích:

```
✅ všech 178 hodnot identických, diff prázdný
```

(179. řádek je `Ir-Timestamp`, ten se mezi běhy liší z definice.) Kontrolní vzorek hodnot, které musí sedět a sedí: `Vr-Vstupne 60973.00`, `Ir-Ucast-Ucastnici 842`, `Nr-BonusyRPG 97740.00`, `Vr-Ubytovani-3L 453`, `Xr-Jidla-Hlavni 1617`.

**Precedence.** Riziko bylo, že bare `EXISTS(...)` se v `AND`/`OR`/`NOT` naváže jinak než volání funkce. Ověřeno přímo v MariaDB — `EXISTS(...)` je samostatný primární výraz, `NOT` se na něj váže stejně těsně jako na funkci:

```
NOT EXISTS(SELECT 1 WHERE 1=0) = 1     (1=1 AND NOT EXISTS(SELECT 1)) = 0
NOT EXISTS(SELECT 1)           = 0     (1=0 OR NOT EXISTS(SELECT 1 WHERE 1=0)) = 1
```

**Injection.** Do interpolace nevstupuje nic uživatelského: všech 12 předávaných hodnot jsou konstanty `Pravo::` (parametr je navíc `int`), tři názvy sloupců jsou literály v kódu.

**Testy.** `tests/Model/Report/FinanceReportSirienTest.php` — celá sada **893 testů, 3295 asercí, 0 failures**. Oba nové testy jsem nechal prokazatelně spadnout, než jsem jim uvěřil:

* strážce zdrojáku hlásí na předchozí verzi 38 + 7 shod, na opravené 0 + 0
* test spouštějící výrazy odhalí i překlep uvnitř inlinovaného SQL (podstrčil jsem `prava_rolee` → `Table ... doesn't exist`)

## Pozor při review

* **Čísla se nemění.** Je to čistě oprava rozbitého reportu, ne změna metodiky výpočtu — proto ten diff všech 178 hodnot výše. Jediný teoretický rozdíl: původní funkce měla `RETURNS DECIMAL(4,2)`, inline `CASE` vrací literály. Všechny (`0.25, 0.5, 1, 1.5, 2, 2.5, 3`) se do `DECIMAL(4,2)` vejdou přesně, takže je to no-op.
* **Diff je velký (45 míst), ale mechanický.** Volání mají jen tři tvary; nahrazení proběhlo skriptem, ne ručně po jednom.
* **`delkaAktivity...` už nedělá vlastní poddotaz** — místo `(SELECT ... FROM akce_seznam WHERE id_akce = id_akce LIMIT 1)` čte `akce_seznam.konec/zacatek` z okolního dotazu. Ověřil jsem u všech 7 míst, že `akce_seznam` je ve scope a jde o tentýž řádek, včetně těch, kde se joinuje přes `akce_organizatori` / `akce_prihlaseni`.
* **Test je částečně strážce zdrojového textu.** Spouští sice oba výrazy proti DB (to chytí syntaktickou chybu), ale neprovádí celý report — ten potřebuje naplněnou DB a `$u`/`$podstranka` z `index.php`. Shodu 178 hodnot jsem ověřoval ručně, automatizovaná není.
* **Co NENÍ v tomhle PR:** `BfgrReportTest::bfgrReportOdpovidaOcekavani()` má uprostřed `return;`, takže jeho asserty na obsah nikdy neběží. Je to předchozí stav, nesouvisí s touhle kartou, nechal jsem to být — můžu založit zvlášť.

## Kde to naklikat

Lokálně (`docker compose up`, admin login):

* `http://localhost/admin/reporty/finance-report-sirien?format=html` → **otevři** → tabulka `kod / popis / data` s daty ročníku 2026; dřív tu byla Tracy chyba `FUNCTION gamecon.maPravo does not exist`
* `http://localhost/admin/reporty/finance-report-sirien?format=xlsx` → **otevři** → stáhne se validní `.xlsx` (tohle sirien potřebuje na účetnictví)
* `http://localhost/admin/reporty` → **otevři** → v seznamu „Sirienův rozpočtový report" s odkazy `html` / `xlsx`

Report vyžaduje právo 104 (`ADMINISTRACE_REPORTY`) — na čerstvě naimportované DB může být potřeba přidat účtu roli, která ho nese (např. `ORGANIZATOR_ZDARMA`), jinak vypadne „Nemáš právo 104".
