### PR TITLE
Rozpočtový report (BFSR) jde vygenerovat i se sortimentem 2026

### DIFF
--- a/model/Report/BfsrReport.php
+++ b/model/Report/BfsrReport.php
@@ -15,6 +15,7 @@ use Gamecon\Shop\TypPredmetu;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveni;
 use Gamecon\SystemoveNastaveni\SystemoveNastaveniKlice;
 use Gamecon\Uzivatel\Dto\PolozkaProBfgr;
+use Gamecon\Uzivatel\Finance;
 use Report;
 use Uzivatel;
 use Webmozart\Assert\Assert;
@@ -22,6 +23,36 @@ use Webmozart\Assert\Assert;
 // takzvaný BFSR (Big f**king Sirien report)
 class BfsrReport
 {
+    /**
+     * Druh ubytování -> [předpona kódu předmětu, popis do reportu].
+     * `Hdb-` musí zůstat před `Hd-`, jinak se dvojbuňky schovají do deluxe.
+     */
+    private const DRUHY_UBYTOVANI = [
+        'spac'            => ['spacak_', 'spacáky'],
+        'vlastni-stan'    => ['vlastni_stan_', 'vlastní stany'],
+        'chata-richor'    => ['4L_chataRichor_', 'chata Richor'],
+        'penzion-witch'   => ['2_4L_penzionWitch_', 'penzion Witch'],
+        'hotel-deluxe-2b' => ['Hdb-', 'hotel deluxe dvojbuňka'],
+        'hotel-deluxe'    => ['Hd-', 'hotel deluxe'],
+        'hotel-snidane'   => ['Hs-', 'hotel se snídaní'],
+        '3L'              => ['3L_', '3L'],
+        '2L'              => ['2L_', '2L'],
+        '1L'              => ['1L_', '1L'],
+    ];
+
+    /**
+     * Účetní řádky Infopultu, které Finance vydává společně s nákupy v shopu.
+     * Nejsou to předměty, mají prázdný kód a report je nevykazuje.
+     */
+    private const UCETNI_TYPY_MIMO_SHOP = [
+        Finance::AKTIVITY,
+        Finance::PRIPSANE_SLEVY,
+        Finance::ZUSTATEK_Z_PREDCHOZICH_LET,
+        Finance::ORGSLEVA,
+        Finance::BRIGADNICKA_ODMENA,
+        Finance::PLATBA,
+    ];
+
     private ?float $missedPriceCoefficient          = null;
     private ?float $tooLateCanceledPriceCoefficient = null;
 
@@ -56,14 +87,8 @@ SQL,
 
         // Inicializace počítadel
         $vstupneSum                  = 0.0;
-        $placeneUbytovani3L          = 0;
-        $placeneUbytovani2L          = 0;
-        $placeneUbytovani1L          = 0;
-        $placeneUbytovaniSpacak      = 0;
-        $zdarmaUbytovani3L           = 0;
-        $zdarmaUbytovani2L           = 0;
-        $zdarmaUbytovani1L           = 0;
-        $zdarmaUbytovaniSpacak       = 0;
+        $placeneNoci                 = array_fill_keys(array_keys(self::DRUHY_UBYTOVANI), 0);
+        $zdarmaNoci                  = array_fill_keys(array_keys(self::DRUHY_UBYTOVANI), 0);
         $trickaOrgovskaZdarma        = 0;
         $trickaVypravecskaZdarma     = 0;
         $trickaUcastnickaZdarma      = 0;
@@ -98,6 +123,9 @@ SQL,
         $taskyCelkem                 = [];
         $taskyZdarma                 = 0;
         $taskyPlacene                = 0;
+        $mikinyCelkem                = [];
+        $mikinyZdarma                = 0;
+        $mikinyPlacene               = 0;
         $jidlaSnidaneCelkem          = [];
         $jidlaSnidaneZdarma          = 0;
         $jidlaSnidaneSeSlevou        = 0;
@@ -162,35 +190,16 @@ SQL,
             $polozky = $navstevnik->finance()->dejPolozkyProBfgr();
 
             foreach ($polozky as $polozka) {
+                if (self::jeUcetniRadekMimoShop($polozka)) {
+                    continue;
+                }
+
                 // Ubytování - placené i zdarma
                 if ($polozka->typ === TypPredmetu::UBYTOVANI) {
                     $isPaid = $polozka->castka > 0.0;
 
-                    if (str_starts_with($polozka->kodPredmetu, 'spacak_')) {
-                        if ($isPaid) {
-                            $placeneUbytovaniSpacak++;
-                        } else {
-                            $zdarmaUbytovaniSpacak++;
-                        }
-                    } elseif (str_starts_with($polozka->kodPredmetu, '3L_')) {
-                        if ($isPaid) {
-                            $placeneUbytovani3L++;
-                        } else {
-                            $zdarmaUbytovani3L++;
-                        }
-                    } elseif (str_starts_with($polozka->kodPredmetu, '2L_')) {
-                        if ($isPaid) {
-                            $placeneUbytovani2L++;
-                        } else {
-                            $zdarmaUbytovani2L++;
-                        }
-                    } elseif (str_starts_with($polozka->kodPredmetu, '1L_')) {
-                        if ($isPaid) {
-                            $placeneUbytovani1L++;
-                        } else {
-                            $zdarmaUbytovani1L++;
-                        }
-                    } else {
+                    $druhUbytovani = self::druhUbytovaniPodleKodu($polozka->kodPredmetu);
+                    if ($druhUbytovani === null) {
                         throw new \Chyba(
                             sprintf(
                                 "Neznámý kód předmětu typu ubytování %s (název '%s')",
@@ -198,6 +207,12 @@ SQL,
                                 $polozka->nazev,
                             ),
                         );
+                    }
+
+                    if ($isPaid) {
+                        $placeneNoci[$druhUbytovani]++;
+                    } else {
+                        $zdarmaNoci[$druhUbytovani]++;
                     }
                     continue;
                 }
@@ -350,6 +365,20 @@ SQL,
                     continue;
                 }
 
+                // Mikiny
+                if (Predmet::jeToMikina($polozka->kodPredmetu)) {
+                    $mikinyCelkemKod                = 'Vr-Mikiny-' . $polozka->kodPredmetu;
+                    $mikinyCelkem[$mikinyCelkemKod] ??= 0;
+                    $mikinyCelkem[$mikinyCelkemKod]++;
+
+                    if ($polozka->castka === 0.0) {
+                        $mikinyZdarma++;
+                    } else {
+                        $mikinyPlacene++;
+                    }
+                    continue;
+                }
+
                 // Jídla - snídaně
                 if (Predmet::jeToSnidane($polozka->kodPredmetu)) {
                     $jidlaSnidaneCelkemKod                      = 'Xr-Jidla-Snidane';
@@ -443,14 +472,7 @@ SQL,
         $data = [
             ['Ir-Timestamp', 'Timestamp reportu', $this->systemoveNastaveni->ted()->format('Y-m-d H:i:s')],
             ['Vr-Vstupne', 'Dobrovolné vstupné (sum CZK)', $vstupneSum],
-            ['Vr-Ubytovani-3L', 'Prodané noci 3L (počet)', $placeneUbytovani3L],
-            ['Vr-Ubytovani-2L', 'Prodané noci 2L (počet)', $placeneUbytovani2L],
-            ['Vr-Ubytovani-1L', 'Prodané noci 1L (počet)', $placeneUbytovani1L],
-            ['Vr-Ubytovani-spac', 'Prodané noci spacáky (počet)', $placeneUbytovaniSpacak],
-            ['Nr-UbytovaniZdarma-3L', 'Noci 3L zdarma (počet)', $zdarmaUbytovani3L],
-            ['Nr-UbytovaniZdarma-2L', 'Noci 2L zdarma (počet)', $zdarmaUbytovani2L],
-            ['Nr-UbytovaniZdarma-1L', 'Noci 1L zdarma (počet)', $zdarmaUbytovani1L],
-            ['Nr-UbytovaniZdarma-spac', 'Noci spacáky zdarma (počet)', $zdarmaUbytovaniSpacak],
+            ...self::radkyUbytovani($placeneNoci, $zdarmaNoci),
             ['Ir-Ucast-Ucastnici', 'Počet letos přihlášených normálních účastníků (nespadajících do žádného z dalších Ir-Ucast-)', $participantStats['Ir-Ucast-Ucastnici'] ?? 0],
             ['Ir-Ucast-Org0', 'Počet letos přihlášených úplných orgů', $participantStats['Ir-Ucast-Org0'] ?? 0],
             ['Ir-Ucast-OrgU', 'Počet letos přihlášených orgů s ubytováním', $participantStats['Ir-Ucast-OrgU'] ?? 0],
@@ -610,6 +632,14 @@ SQL,
         }
 
         Assert::same(
+            array_sum($mikinyCelkem), $mikinyZdarma + $mikinyPlacene,
+            'Součet mikin zdarma a placených musí odpovídat celkovému počtu mikin',
+        );
+        foreach ($mikinyCelkem as $code => $value) {
+            $data[] = [$code, 'mikiny prodeje - včetně zdarma - kusy', $value];
+        }
+
+        Assert::same(
             array_sum($jidlaSnidaneCelkem), $jidlaSnidaneZdarma + $jidlaSnidaneSeSlevou + $jidlaSnidanePlnePlacene,
             'Součet snídaní zdarma, se slevou a placených musí odpovídat celkovému počtu snídaní',
         );
@@ -657,6 +687,42 @@ SQL,
         $data[] = ['Nr-Slevy-Manualni', 'Manuální slevy (Připsaná sleva přes admin) (sum CZK)', $manualniSlevyCelkem];
 
         Report::zPoli(['kod', 'popis', 'data'], $data)->tFormat($format);
+    }
+
+    public static function jeUcetniRadekMimoShop(PolozkaProBfgr $polozka): bool
+    {
+        return in_array($polozka->typ, self::UCETNI_TYPY_MIMO_SHOP, true);
+    }
+
+    private static function druhUbytovaniPodleKodu(string $kodPredmetu): ?string
+    {
+        foreach (self::DRUHY_UBYTOVANI as $druh => [$predpona]) {
+            if (str_starts_with($kodPredmetu, $predpona)) {
+                return $druh;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, int> $placeneNoci
+     * @param array<string, int> $zdarmaNoci
+     * @return list<array{string, string, int}>
+     */
+    private static function radkyUbytovani(
+        array $placeneNoci,
+        array $zdarmaNoci,
+    ): array {
+        $radky = [];
+        foreach (self::DRUHY_UBYTOVANI as $druh => [, $popis]) {
+            $radky[] = ["Vr-Ubytovani-{$druh}", "Prodané noci {$popis} (počet)", $placeneNoci[$druh]];
+        }
+        foreach (self::DRUHY_UBYTOVANI as $druh => [, $popis]) {
+            $radky[] = ["Nr-UbytovaniZdarma-{$druh}", "Noci {$popis} zdarma (počet)", $zdarmaNoci[$druh]];
+        }
+
+        return $radky;
     }
 
     /**

--- a/model/Shop/Predmet.php
+++ b/model/Shop/Predmet.php
@@ -57,6 +57,11 @@ class Predmet extends \DbObject
         return self::jeToDleCasti($kodPredmetu, 'taska');
     }
 
+    public static function jeToMikina(string $kodPredmetu): bool
+    {
+        return self::jeToDleCasti($kodPredmetu, 'mikina');
+    }
+
     public static function jeToSnidane(string $kodPredmetu): bool
     {
         return self::jeToDleCasti($kodPredmetu, 'snidane');

--- a/tests/Model/Report/BfsrReportUbytovaniTest.php
+++ b/tests/Model/Report/BfsrReportUbytovaniTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gamecon\Tests\Model\Report;
+
+use Gamecon\Report\BfsrReport;
+use Gamecon\Shop\Predmet;
+use Gamecon\Shop\SqlStruktura\PredmetSqlStruktura as PredmetSql;
+use Gamecon\Shop\TypPredmetu;
+use Gamecon\Tests\Db\AbstractTestDb;
+use Gamecon\Uzivatel\Dto\PolozkaProBfgr;
+use Gamecon\Uzivatel\Finance;
+
+class BfsrReportUbytovaniTest extends AbstractTestDb
+{
+    /**
+     * Sortiment roku 2026, na kterém report spadl.
+     */
+    private const PREDMETY = [
+        ['Hs-1L-st', TypPredmetu::UBYTOVANI],
+        ['Hs-2L-st', TypPredmetu::UBYTOVANI],
+        ['Hd-1L-st', TypPredmetu::UBYTOVANI],
+        ['Hd-2L-st', TypPredmetu::UBYTOVANI],
+        ['Hdb-1L-st', TypPredmetu::UBYTOVANI],
+        ['4L_chataRichor_st', TypPredmetu::UBYTOVANI],
+        ['2_4L_penzionWitch_st', TypPredmetu::UBYTOVANI],
+        ['vlastni_stan_st', TypPredmetu::UBYTOVANI],
+        ['spacak_st', TypPredmetu::UBYTOVANI],
+        ['3L_st', TypPredmetu::UBYTOVANI],
+        ['2L_st', TypPredmetu::UBYTOVANI],
+        ['1L_st', TypPredmetu::UBYTOVANI],
+        ['mikina_2026_verne_l', TypPredmetu::PREDMET],
+        ['taska_2022', TypPredmetu::PREDMET],
+        ['nicknack_2019', TypPredmetu::PREDMET],
+        ['blok_2023', TypPredmetu::PREDMET],
+        ['ponozky_2021_vel_38_39', TypPredmetu::PREDMET],
+        ['kostka_2026_verne', TypPredmetu::PREDMET],
+        ['placka_2026_verne', TypPredmetu::PREDMET],
+    ];
+
+    protected static function getBeforeClassInitCallbacks(): array
+    {
+        return [
+            static function () {
+                foreach (self::PREDMETY as [$kodPredmetu, $typ]) {
+                    dbInsert(PredmetSql::SHOP_PREDMETY_TABULKA, [
+                        PredmetSql::NAZEV         => $kodPredmetu,
+                        PredmetSql::KOD_PREDMETU  => $kodPredmetu,
+                        PredmetSql::MODEL_ROK     => 2026,
+                        PredmetSql::CENA_AKTUALNI => 100,
+                        PredmetSql::STAV          => 1,
+                        PredmetSql::TYP           => $typ,
+                        PredmetSql::POPIS         => '',
+                    ]);
+                }
+            },
+        ];
+    }
+
+    /**
+     * Report pro každý kód ubytování zvyšuje jeden čítač; kód, který nezná,
+     * shodí celý report výjimkou.
+     *
+     * @test
+     */
+    public function kazdyKodUbytovaniVDatabaziSpadaDoNejakehoDruhu(): void
+    {
+        $kodyUbytovani = dbOneArray(<<<SQL
+            SELECT DISTINCT kod_predmetu
+            FROM shop_predmety
+            WHERE typ = $0
+            SQL,
+            [
+                0 => TypPredmetu::UBYTOVANI,
+            ],
+        );
+        self::assertNotEmpty($kodyUbytovani, 'V databázi není žádné ubytování, test by nic neověřil');
+
+        $predpony = array_column(
+            (new \ReflectionClass(BfsrReport::class))->getConstant('DRUHY_UBYTOVANI'),
+            0,
+        );
+
+        foreach ($kodyUbytovani as $kodPredmetu) {
+            $zname = false;
+            foreach ($predpony as $predpona) {
+                if (str_starts_with((string) $kodPredmetu, $predpona)) {
+                    $zname = true;
+                    break;
+                }
+            }
+            self::assertTrue(
+                $zname,
+                "Kód ubytování '{$kodPredmetu}' nespadá do žádného druhu, report na něm spadne",
+            );
+        }
+    }
+
+    /**
+     * Finance vydávají tyhle řádky společně s nákupy, ale nejsou to předměty –
+     * mají prázdný kód, takže je report bez přeskočení nedokáže zařadit a spadne.
+     *
+     * @test
+     *
+     * @dataProvider ucetniRadkyMimoShop
+     */
+    public function ucetniRadkyInfopultuReportPreskoci(
+        int $typ,
+        string $nazev,
+    ): void {
+        $polozka = new PolozkaProBfgr(
+            nazev: $nazev,
+            pocet: '1',
+            castka: -100.0,
+            sleva: 0.0,
+            typ: $typ,
+            kodPredmetu: '',
+            idPredmetu: '',
+        );
+
+        self::assertTrue(
+            BfsrReport::jeUcetniRadekMimoShop($polozka),
+            "Účetní řádek '{$nazev}' (typ {$typ}) report nepřeskočí a spadne na něm",
+        );
+    }
+
+    /**
+     * @return array<string, array{int, string}>
+     */
+    public static function ucetniRadkyMimoShop(): array
+    {
+        return [
+            'zůstatek z minulých let' => [Finance::ZUSTATEK_Z_PREDCHOZICH_LET, 'Zůstatek z minulých let'],
+            'aktivity'                => [Finance::AKTIVITY, 'Aktivita'],
+            'připsané slevy'          => [Finance::PRIPSANE_SLEVY, 'Sleva'],
+            'bonus za aktivity'       => [Finance::ORGSLEVA, 'Bonus za aktivity'],
+            'brigádnická odměna'      => [Finance::BRIGADNICKA_ODMENA, 'Brigádnická odměna'],
+            'platba'                  => [Finance::PLATBA, 'Platba'],
+        ];
+    }
+
+    /**
+     * Skutečný nákup v shopu se přeskočit nesmí, jinak by report přestal počítat.
+     *
+     * @test
+     */
+    public function nakupVShopuSeNepreskoci(): void
+    {
+        $polozka = new PolozkaProBfgr(
+            nazev: 'Mikina L',
+            pocet: '1',
+            castka: 800.0,
+            sleva: 0.0,
+            typ: TypPredmetu::PREDMET,
+            kodPredmetu: 'mikina_2026_verne_l',
+            idPredmetu: '1',
+        );
+
+        self::assertFalse(BfsrReport::jeUcetniRadekMimoShop($polozka));
+    }
+
+    /**
+     * @test
+     */
+    public function mikinaJeRozpoznanaPodleKodu(): void
+    {
+        self::assertTrue(Predmet::jeToMikina('mikina_2026_verne_l'));
+        self::assertFalse(Predmet::jeToMikina('tricko_2026_verne_l'));
+    }
+
+    /**
+     * Prodávaný předmět, který report nezná, shodí generování pro všechny.
+     *
+     * @test
+     */
+    public function kazdyLetosProdavanyPredmetJeReportuZnamy(): void
+    {
+        $predmety = dbFetchAll(<<<SQL
+            SELECT kod_predmetu, typ
+            FROM shop_predmety
+            WHERE typ = $0
+            SQL,
+            [
+                0 => TypPredmetu::PREDMET,
+            ],
+        );
+        self::assertNotEmpty($predmety, 'V databázi nejsou žádné předměty, test by nic neověřil');
+
+        foreach ($predmety as $predmet) {
+            $kodPredmetu = (string) $predmet[PredmetSql::KOD_PREDMETU];
+            $typ = (int) $predmet[PredmetSql::TYP];
+
+            $zname = Predmet::jeToTricko($kodPredmetu, $typ)
+                || Predmet::jeToTilko($kodPredmetu, $typ)
+                || Predmet::jeToPlacka($kodPredmetu)
+                || Predmet::jeToKostka($kodPredmetu)
+                || Predmet::jeToNicknack($kodPredmetu)
+                || Predmet::jeToBlok($kodPredmetu)
+                || Predmet::jeToPonozka($kodPredmetu)
+                || Predmet::jeToTaska($kodPredmetu)
+                || Predmet::jeToMikina($kodPredmetu);
+
+            self::assertTrue(
+                $zname,
+                "Předmět '{$kodPredmetu}' report nezná, spadne na něm",
+            );
+        }
+    }
+}


### PR DESCRIPTION
[Trello 1466 — Rozpočtový report 2026](https://trello.com/c/gy0EIX3D/1466-rozpo%C4%8Dtov%C3%BD-report-2026)

Navazuje na [PR #1086](https://github.com/gamecon-cz/gamecon/pull/1086) — ten opravil *Sirienův rozpočtový report* (`finance-report-sirien`). Tohle je ale **jiný report se skoro stejným názvem**: `bfsr-report`, registrovaný jako **„Finance: Rozpočtový report"** (BFSR), a padal z úplně jiných důvodů.

## Problém

Report nešel vygenerovat vůbec — skončil hláškou a nevypsal ani řádek:

```
Neznámý kód předmětu '' s typem 13 (název 'Zůstatek z minulých let')
```

Po odstranění téhle příčiny vylezly další dvě ze stejné rodiny:

```
Neznámý kód předmětu typu ubytování 'Hs-1L-st' (název 'Postel na 1L hotelu se snídaní středa')
Neznámý kód předmětu 'mikina_2026_verne_l' s typem 1 (název 'Mikina L')
```

## Příčina

Report iteruje položky z `Finance::dejPolozkyProBfgr()` a na konci má catch-all `throw` pro cokoli, co nepoznal. Do něj padaly tři různé věci:

**1. Účetní řádky Infopultu, které nejsou předměty.** `Finance` vydává společně s nákupy i vlastní řádky s pseudo-typy, které nejsou typy předmětů (`TypPredmetu` končí u 7) — mají prázdný `kodPredmetu` a slouží k řazení v Infopultu. Report je nezná. `Accounting.php:60` přitom `ZUSTATEK_Z_PREDCHOZICH_LET` explicitně ošetřuje, takže tady šlo o opomenutí, ne o záměr.

Ověřeno nad produkčními daty — v datech jsou **všechny** a *každá z nich* by report shodila (tj. nešlo o tiché špatné počítání, jen o to, že typ 13 přišel u prvního uživatele první):

| pseudo-typ | položek | kam spadl |
|---|---|---|
| `AKTIVITY` (-1) | 3672 | throw |
| `PRIPSANE_SLEVY` (11) | 9 | throw |
| `ZUSTATEK_Z_PREDCHOZICH_LET` (13) | 304 | throw |
| `ORGSLEVA` (14) | 248 | throw |
| `BRIGADNICKA_ODMENA` (15) | 11 | throw |
| `PLATBA` (17) | 1248 | throw |

**2. Nové typy ubytování 2026.** Report uměl jen `3L_`/`2L_`/`1L_`/`spacak_`. Letos přibyly hotelové varianty a další ubytování.

**3. Nový sortiment 2026 — mikiny.** `Predmet` na ně neměl predikát a report neměl větev.

## Řešení

- `UCETNI_TYPY_MIMO_SHOP` — účetní řádky se přeskočí (report je nevykazuje, žádný jeho řádek je nepočítá).
- `DRUHY_UBYTOVANI` — mapa `předpona → čítač` místo čtyřnásobného `if/elseif`; pokrývá i `Hs-`, `Hd-`, `Hdb-`, `4L_chataRichor_`, `2_4L_penzionWitch_`, `vlastni_stan_`. Hotelové noci dostaly **vlastní řádky**, neslučují se do 1L/2L.
- `Predmet::jeToMikina()` + větev `Vr-Mikiny-<kod>`, stejným vzorem jako tašky/bloky/ponožky.

## Ověření

Nad **produkčními daty** (import `export_latest.sql`). Report se vygeneruje a čísla sedí proti DB:

| řádek | report | DB (placené+zdarma) |
|---|---|---|
| `Vr-Ubytovani-hotel-snidane` | 45 + 15 zdarma | 60 ✅ |
| `Vr-Ubytovani-hotel-deluxe` | 37 + 12 zdarma | 49 ✅ |
| `Vr-Ubytovani-hotel-deluxe-2b` | 6 + 0 zdarma | 6 ✅ |
| `Vr-Mikiny-*` (7 velikostí) | 53 kusů | 53 ✅ |

**Pořadí předpon** — hlavní riziko mapy. Ověřeno na všech 115 kódech ubytování v DB: každý spadne právě do jednoho druhu, **žádný nezůstal nezařazený**, `Hdb-` se nenechá spolknout `Hd-` a `4L_chataRichor_`/`2_4L_penzionWitch_` nespadnou pod `2L_`/`1L_`.

**Kódy stávajících řádků se nezměnily** — `Vr-Ubytovani-{3L,2L,1L,spac}` a `Nr-UbytovaniZdarma-{3L,2L,1L,spac}` jsou proti `origin/main` znak po znaku shodné (sirienův Excel na nich závisí). Nové řádky jsou čistě přírůstek.

**Testy:** celá sada **903 testů / 3325 asercí / 0 failures**, ECS čistý. Testy jsem nechal prokazatelně spadnout: po vypnutí přeskakování účetních řádků padne **6 testů** (jeden na každý pseudo-typ, včetně typu 13 z hlášky výše), po odebrání hotelových předpon a `jeToMikina()` padnou zbylé tři.

## Pozor při review

- **Ta `zdarma` čísla nejsou z ceny nákupu.** Report klasifikuje „zdarma" podle `$polozka->castka`, tj. ceny *po* orgovských slevách — ne podle `shop_nakupy.cena_nakupni`. V DB má hotel-deluxe 49 placených / 0 zdarma, report hlásí 37 + 12. Stejný rozpor má i stávající 3L (DB 534/0, report 453 + 81), takže **jde o dosavadní záměrné chování**, které jsem jen převzal — ne o něco, co zavádí tenhle PR. Součty sedí.
- **Nové řádky v reportu = změna struktury výstupu.** Přibylo 12 řádků ubytování (6 druhů × placené/zdarma) a 7 řádků mikin. Pokud sirienův Excel čte řádky pozičně a ne podle kódu, bude to chtít zkontrolovat.
- **Prázdné druhy se vypisují s nulou** (vlastní stany, chata Richor, penzion Witch — letos 0 nákupů). Držel jsem konzistenci se stávajícím `Vr-Ubytovani-spac`, které se taky vypisuje jako 0.
- **Mapování hotelů na vlastní řádky bylo produktové rozhodnutí,** ne technická nutnost — šlo je i přičíst k 1L/2L podle počtu lůžek. Pokud to sirien chce jinak, je to změna jedné konstanty.
- **Code review našla díru v mých testech a měla pravdu.** První verze testů ověřovala jen ubytování a mikiny — když jsem *odstranil vlastní opravu* přeskakování účetních řádků (tu na chybu ze zadání), všechny testy dál prošly. Doplnil jsem proto `jeUcetniRadekMimoShop()` jako testovatelný bod a data-provider přes všech šest pseudo-typů; teď vypnutí opravy shodí 6 testů.
- **Neověřeno:** report jsem spouštěl přes `BfsrReport::exportuj()` nad produkční kopií, ne proklikáním v adminu s přihlášením (na ostrou se přihlásit neumím). XLSX variantu jsem netestoval, jen HTML.

## Kde to naklikat

Lokálně (`docker compose up`, admin login):

* `http://localhost/admin/reporty/bfsr-report?format=html` → **otevři** → tabulka; dřív tu byla červená hláška „Neznámý kód předmětu". Zkontroluj řádky `Vr-Ubytovani-hotel-*` a `Vr-Mikiny-*`.
* `http://localhost/admin/reporty/bfsr-report?format=xlsx` → **otevři** → stáhne se xlsx.
* `http://localhost/admin/reporty` → **otevři** → „Finance: Rozpočtový report" (tenhle) vs. „Sirienův rozpočtový report" (ten z [PR #1086](https://github.com/gamecon-cz/gamecon/pull/1086)) — pozor, jsou to dva různé reporty.
